### PR TITLE
Fixed an issue when compiling no_std and no_optimize on a target with no alloc::sync

### DIFF
--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -11,7 +11,9 @@ mod inner {
     #[cfg(not(target_arch = "wasm32"))]
     pub use core::{i128, u128};
 
-    pub use alloc::{borrow, boxed, format, rc, string, sync, vec};
+    #[cfg(feature = "sync")]
+    pub use alloc::sync;
+    pub use alloc::{borrow, boxed, format, rc, string, vec};
 
     pub use core_error as error;
 


### PR DESCRIPTION
I'm trying to run rhai on a microcontroller called [atsamd21g18](https://docs.rs/atsamd21g/0.9.0/atsamd21g/). This is a thumbv6m microcontroller. This target does not have the `alloc::sync` namespace: https://doc.rust-lang.org/stable/src/alloc/lib.rs.html#179-180

![image](https://user-images.githubusercontent.com/2743142/103903729-8f3c3380-50fc-11eb-96be-d67bd448c686.png)

I import rhai without the `sync` feature, and the `stdlib::sync` import doesn't seem to be used, so I put it behind the `sync` feature flag.

