### PR TITLE
Fix some rustdoc warnings and a typo in FLOAT's docs

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -184,7 +184,7 @@ pub fn export_module(
     proc_macro::TokenStream::from(tokens)
 }
 
-/// Macro to generate a Rhai `Module` from a _plugin module_ defined via [`#[export_module]`][export_module].
+/// Macro to generate a Rhai `Module` from a _plugin module_ defined via [`#[export_module]`][macro@export_module].
 ///
 /// # Usage
 ///
@@ -265,7 +265,7 @@ pub fn combine_with_exported_module(args: proc_macro::TokenStream) -> proc_macro
     }
 }
 
-/// Macro to register a _plugin function_ (defined via [`#[export_fn]`][export_fn]) into an `Engine`.
+/// Macro to register a _plugin function_ (defined via [`#[export_fn]`][macro@export_fn]) into an `Engine`.
 ///
 /// # Usage
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ pub type INT = i32;
 /// The system floating-point type. It is defined as [`f64`].
 /// Not available under `no_float`.
 ///
-/// If the `f32_float` feature is enabled, this will be [`i32`] instead.
+/// If the `f32_float` feature is enabled, this will be [`f32`] instead.
 #[cfg(not(feature = "no_float"))]
 #[cfg(not(feature = "f32_float"))]
 pub type FLOAT = f64;


### PR DESCRIPTION
This fixes the warnings about ambiguous links and a small typo in `FLOAT`'s docs.