### PR TITLE
poc: adds rustyline to rhai-repl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 benches/results
 before*
 after*
+.rhai-repl-history.txt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,22 @@ include = ["**/*.rs", "scripts/*.rhai", "**/*.md", "Cargo.toml"]
 keywords = ["scripting", "scripting-engine", "scripting-language", "embedded"]
 categories = ["no-std", "embedded", "wasm", "parser-implementations"]
 
+[lib]
+name = "rhai"
+path = "src/lib.rs"
+
+[[bin]]
+name = "rhai-repl"
+path = "src/bin/rhai-repl.rs"
+required-features = ["rustyline"]
+
 [dependencies]
 smallvec = { version = "1.7", default-features = false, features = ["union", "const_new" ] }
 ahash = { version = "0.7", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 smartstring = { version = "0.2.8", default-features = false }
 rhai_codegen = { version = "1.2", path = "codegen", default-features = false }
+rustyline = { versoin = "9", optional = true }
 
 [dev-dependencies]
 serde_bytes = "0.11"

--- a/src/bin/rhai-repl.rs
+++ b/src/bin/rhai-repl.rs
@@ -1,3 +1,5 @@
+use rustyline::error::ReadlineError;
+use rustyline::Editor;
 use rhai::{Dynamic, Engine, EvalAltResult, Module, Scope, AST, INT};
 
 use std::{
@@ -194,6 +196,12 @@ fn main() {
     // Create scope
     let mut scope = Scope::new();
 
+    // REPL line editor setup
+    let mut rl = Editor::<()>::new();
+    if rl.load_history(".rhai-repl-history.txt").is_err() {
+        println!("No previous history.");
+    }
+
     // REPL loop
     let mut input = String::new();
     let mut main_ast = AST::empty();
@@ -203,32 +211,47 @@ fn main() {
     print_help();
 
     'main_loop: loop {
-        print!("rhai-repl> ");
-        stdout().flush().expect("couldn't flush stdout");
-
         input.clear();
 
-        loop {
-            match stdin().read_line(&mut input) {
-                Ok(0) => break 'main_loop,
-                Ok(_) => (),
-                Err(err) => panic!("input error: {}", err),
+        let readline = rl.readline("rhai-repl> ");
+
+        match readline {
+            Ok(line) => {
+                rl.add_history_entry(line.as_str());
+                input = line;
+            },
+
+            Err(ReadlineError::Interrupted) |  Err(ReadlineError::Eof) => {
+                break 'main_loop
+            },
+
+            Err(err) => {
+                eprintln!("Error: {:?}", err);
+                break 'main_loop
             }
-
-            let line = input.as_str().trim_end();
-
-            // Allow line continuation
-            if line.ends_with('\\') {
-                let len = line.len();
-                input.truncate(len - 1);
-                input.push('\n');
-            } else {
-                break;
-            }
-
-            print!("> ");
-            stdout().flush().expect("couldn't flush stdout");
         }
+
+        //loop {
+        //    match stdin().read_line(&mut input) {
+        //        Ok(0) => break 'main_loop,
+        //        Ok(_) => (),
+        //        Err(err) => panic!("input error: {}", err),
+        //    }
+
+        //    let line = input.as_str().trim_end();
+
+        //    // Allow line continuation
+        //    if line.ends_with('\\') {
+        //        let len = line.len();
+        //        input.truncate(len - 1);
+        //        input.push('\n');
+        //    } else {
+        //        break;
+        //    }
+
+        //    print!("> ");
+        //    stdout().flush().expect("couldn't flush stdout");
+        //}
 
         let script = input.trim();
 
@@ -343,4 +366,6 @@ fn main() {
         // Throw away all the statements, leaving only the functions
         main_ast.clear_statements();
     }
+
+    rl.save_history(".rhai-repl-history.txt").unwrap();
 }


### PR DESCRIPTION
saw discussion about this (https://github.com/rhaiscript/rhai/issues/323) but did not understand what the hurdle was to adding rustyline as an optional dep. perhaps I am missing something but I believe this pull request does accomplish that goal - rustyline only needed to build the repl. to me the ability to navigate command history in a repl is a huge deal!

this is a quickie, poc implementation of this to gauge interest. one known shortcoming is it breaks the use of `\` to continue the code onto the next line. also - not sure if you want to be saving the repl history in the local directory like I did. but let me know what you think!