### PR TITLE
codegen: Fix hygiene mismatch between function `args` uses and definitions

### DIFF
--- a/codegen/src/function.rs
+++ b/codegen/src/function.rs
@@ -774,14 +774,14 @@ impl ExportedFn {
                         syn::Type::Path(ref p) if p.path == string_type_path => {
                             is_string = true;
                             is_ref = false;
-                            quote_spanned!(arg_type.span() =>
+                            quote_spanned!(arg_type.span().resolved_at(Span::call_site()) =>
                                 mem::take(args[#i]).into_string().unwrap()
                             )
                         }
                         _ => {
                             is_string = false;
                             is_ref = false;
-                            quote_spanned!(arg_type.span() =>
+                            quote_spanned!(arg_type.span().resolved_at(Span::call_site()) =>
                                 mem::take(args[#i]).cast::<#arg_type>()
                             )
                         }


### PR DESCRIPTION
Fixes rhai proc macros to work with rustc changes from https://github.com/rust-lang/rust/pull/92472.

Without this patch definitions and uses of `args` may be generated with different hygienic contexts causing name resolution errors.
One context is `Span::call_site()` used by default by `quote!`, and another is inherited from `arg_type` and used by `quote_spanned!(arg_type.span() => ...)`.
This PR changes context for all `args` to `Span::call_site()`, so they can always be resolved.