### PR TITLE
Fix code example for stateful event handler

### DIFF
--- a/examples/event_handler_map/main.rs
+++ b/examples/event_handler_map/main.rs
@@ -76,7 +76,7 @@ pub fn main() {
     states.insert("bool_state".into(), Dynamic::FALSE);
 
     // Add the main states-holding object map and call it 'state'
-    scope.push("state", Map::new());
+    scope.push("state", states);
 
     // Compile the handler script.
     println!("> Loading script file: {}", path);


### PR DESCRIPTION
As resolved in https://github.com/rhaiscript/book/pull/13, the created map is not introduced to the scope in the example.