### PR TITLE
chore: remove clippy redundant_allocation since it has been resolved in clippy#7592

### DIFF
--- a/src/types/dynamic.rs
+++ b/src/types/dynamic.rs
@@ -186,7 +186,6 @@ pub enum Union {
     TimeStamp(Box<Instant>, Tag, AccessMode),
 
     /// Any type as a trait object.
-    #[allow(clippy::redundant_allocation)]
     Variant(Box<Box<dyn Variant>>, Tag, AccessMode),
 
     /// A _shared_ value of any type.


### PR DESCRIPTION
ref: https://github.com/rust-lang/rust-clippy/pull/7592