### PR TITLE
CustomType : example and fixes

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,14 +1,13 @@
-Sample Applications
-===================
+# Sample Applications
 
-Standard Examples
------------------
+## Standard Examples
 
 | Example                                                   | Description                                                                                                                                         |
 | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`arrays_and_structs`](arrays_and_structs.rs)             | shows how to register a Rust type and using it with arrays                                                                                          |
 | [`callback`](callback.rs)                                 | shows how to store a Rhai closure and call it later within Rust                                                                                     |
 | [`custom_types_and_methods`](custom_types_and_methods.rs) | shows how to register a Rust type and methods/getters/setters for it                                                                                |
+| [`custom_types`](custom_types.rs)                         | shows how to register a Rust type and methods/getters/setters using the `CustomType` trait.                                                         |
 | [`definitions`](./definitions)                            | shows how to generate definition files for use with the [Rhai Language Server](https://github.com/rhaiscript/lsp) (requires the `metadata` feature) |
 | [`hello`](hello.rs)                                       | simple example that evaluates an expression and prints the result                                                                                   |
 | [`reuse_scope`](reuse_scope.rs)                           | evaluates two pieces of code in separate runs, but using a common `Scope`                                                                           |
@@ -17,9 +16,7 @@ Standard Examples
 | [`strings`](strings.rs)                                   | shows different ways to register Rust functions taking string arguments                                                                             |
 | [`threading`](threading.rs)                               | shows how to communicate with an `Engine` running in a separate thread via an MPSC channel                                                          |
 
-
-Scriptable Event Handler With State Examples
--------------------------------------------
+## Scriptable Event Handler With State Examples
 
 Because of its popularity, included are sample implementations for the pattern
 [_Scriptable Event Handler With State_](https://rhai.rs/book/patterns/events.html) in different styles.
@@ -30,9 +27,7 @@ Because of its popularity, included are sample implementations for the pattern
 | [`event_handler_js`](event_handler_js)     | [`event_handler_js/script.rhai`](event_handler_js/script.rhai)     |  [_JS Style_](https://rhai.rs/book/patterns/events-2.html)  |
 | [`event_handler_map`](event_handler_map)   | [`event_handler_map/script.rhai`](event_handler_map/script.rhai)   | [_Map Style_](https://rhai.rs/book/patterns/events-3.html)  |
 
-
-Running Examples
-----------------
+## Running Examples
 
 Examples can be run with the following command:
 

--- a/examples/custom_types.rs
+++ b/examples/custom_types.rs
@@ -1,0 +1,75 @@
+//! An example showing how to register a Rust type and methods/getters/setters using the `CustomType` trait.
+
+#[cfg(feature = "no_object")]
+fn main() {
+    panic!("This example does not run under 'no_object'.");
+}
+
+use rhai::{CustomType, Engine, EvalAltResult, TypeBuilder};
+
+#[cfg(not(feature = "no_object"))]
+fn main() -> Result<(), Box<EvalAltResult>> {
+    #[derive(Debug, Clone)]
+    struct TestStruct {
+        x: i64,
+    }
+
+    impl TestStruct {
+        pub fn new() -> Self {
+            Self { x: 1 }
+        }
+        pub fn update(&mut self) {
+            self.x += 1000;
+        }
+        pub fn calculate(&mut self, data: i64) -> i64 {
+            self.x * data
+        }
+        pub fn get_x(&mut self) -> i64 {
+            self.x
+        }
+        pub fn set_x(&mut self, value: i64) {
+            self.x = value;
+        }
+    }
+
+    impl CustomType for TestStruct {
+        fn build(mut builder: TypeBuilder<Self>) {
+            #[allow(deprecated)] // The TypeBuilder api is volatile.
+            builder
+                .with_name("TestStruct")
+                .with_fn("new_ts", Self::new)
+                .with_fn("update", Self::update)
+                .with_fn("calc", Self::calculate)
+                .with_get_set("x", Self::get_x, Self::set_x);
+        }
+    }
+
+    let mut engine = Engine::new();
+
+    engine.build_type::<TestStruct>();
+
+    #[cfg(feature = "metadata")]
+    {
+        println!("Functions registered:");
+
+        engine
+            .gen_fn_signatures(false)
+            .into_iter()
+            .for_each(|func| println!("{}", func));
+
+        println!();
+    }
+
+    let result = engine.eval::<i64>(
+        "
+            let x = new_ts();
+            x.x = 42;
+            x.update();
+            x.calc(x.x)
+        ",
+    )?;
+
+    println!("result: {}", result); // prints 1085764
+
+    Ok(())
+}

--- a/src/api/build_type.rs
+++ b/src/api/build_type.rs
@@ -76,7 +76,6 @@ impl Engine {
     /// i.e. register the type and its getters, setters, methods, etc...
     ///
     /// See [`CustomType`].
-    #[deprecated = "This API is NOT deprecated, but it is considered volatile and may change in the future."]
     #[inline]
     pub fn build_type<T>(&mut self) -> &mut Self
     where

--- a/src/api/build_type.rs
+++ b/src/api/build_type.rs
@@ -38,8 +38,7 @@ use crate::{
 ///         builder
 ///             .with_name("TestStruct")
 ///             .with_fn("new_ts", Self::new)
-///             .with_fn("update", Self::update)
-///             .with_get_set("value", Self::get_value, Self::set_value);
+///             .with_fn("update", Self::update);
 ///     }
 /// }
 ///
@@ -57,11 +56,6 @@ use crate::{
 ///     TestStruct { field: 42 }
 /// );
 ///
-/// # #[cfg(not(feature = "no_object"))]
-/// assert_eq!(
-///     engine.eval::<TestStruct>("let x = new_ts(); x.value = 5 + x.value; x")?,
-///     TestStruct { field: 6 }
-/// );
 /// # Ok(())
 /// # }
 /// ```


### PR DESCRIPTION
Extension of #609 

- Add an example for `CustomType`.
- Remove volatile note on `Engine::build_type` : this method isn't likely to change. Only `TypeBuilder` api is likely to change.
- Fix `CustomType` doc