### PR TITLE
perf: change BTreeMap to StraightHashMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ rhai_codegen = { version = "1.4.1", path = "codegen", default-features = false }
 
 no-std-compat = { version = "0.4", default-features = false, features = ["alloc"], optional = true }
 libm = { version = "0.2", default-features = false, optional = true }
+hashbrown = { version = "0.12", optional = true }
 core-error = { version = "0.0", default-features = false, features = ["alloc"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
@@ -63,7 +64,7 @@ debugging = ["internals"]       # enable debugging
 serde = ["dep:serde", "smartstring/serde", "smallvec/serde"] # implement serde for rhai types
 
 # compiling for no-std
-no_std = ["no-std-compat", "num-traits/libm", "core-error", "libm", "ahash/compile-time-rng"]
+no_std = ["no-std-compat", "num-traits/libm", "core-error", "libm", "ahash/compile-time-rng", "hashbrown"]
 
 # compiling for WASM
 wasm-bindgen = ["instant/wasm-bindgen"]

--- a/src/eval/cache.rs
+++ b/src/eval/cache.rs
@@ -1,10 +1,10 @@
 //! System caches.
 
-use crate::func::CallableFunction;
+use crate::func::{CallableFunction, StraightHashMap};
 use crate::{Identifier, StaticVec};
+use std::marker::PhantomData;
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
-use std::{collections::BTreeMap, marker::PhantomData};
 
 /// _(internals)_ An entry in a function resolution cache.
 /// Exported under the `internals` feature only.
@@ -21,7 +21,7 @@ pub struct FnResolutionCacheEntry {
 ///
 /// [`FnResolutionCacheEntry`] is [`Box`]ed in order to pack as many entries inside a single B-Tree
 /// level as possible.
-pub type FnResolutionCache = BTreeMap<u64, Option<FnResolutionCacheEntry>>;
+pub type FnResolutionCache = StraightHashMap<u64, Option<FnResolutionCacheEntry>>;
 
 /// _(internals)_ A type containing system-wide caches.
 /// Exported under the `internals` feature only.
@@ -66,7 +66,7 @@ impl Caches<'_> {
     #[allow(dead_code)]
     #[inline(always)]
     pub fn push_fn_resolution_cache(&mut self) {
-        self.fn_resolution.push(BTreeMap::new());
+        self.fn_resolution.push(StraightHashMap::default());
     }
     /// Rewind the function resolution caches stack to a particular size.
     #[inline(always)]

--- a/src/eval/expr.rs
+++ b/src/eval/expr.rs
@@ -10,9 +10,10 @@ use crate::func::{
 };
 use crate::types::dynamic::AccessMode;
 use crate::{Dynamic, Engine, Module, Position, RhaiResult, RhaiResultOf, Scope, ERR};
+use std::collections::hash_map::Entry;
+use std::num::NonZeroUsize;
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
-use std::{collections::btree_map::Entry, num::NonZeroUsize};
 
 impl Engine {
     /// Search for a module within an imports stack.

--- a/src/eval/expr.rs
+++ b/src/eval/expr.rs
@@ -10,6 +10,9 @@ use crate::func::{
 };
 use crate::types::dynamic::AccessMode;
 use crate::{Dynamic, Engine, Module, Position, RhaiResult, RhaiResultOf, Scope, ERR};
+#[cfg(feature = "no_std")]
+use hashbrown::hash_map::Entry;
+#[cfg(not(feature = "no_std"))]
 use std::collections::hash_map::Entry;
 use std::num::NonZeroUsize;
 #[cfg(feature = "no_std")]

--- a/src/func/hashing.rs
+++ b/src/func/hashing.rs
@@ -4,8 +4,12 @@
 use std::prelude::v1::*;
 use std::{
     any::TypeId,
+    collections::{HashMap, HashSet},
     hash::{BuildHasher, Hash, Hasher},
 };
+
+pub type StraightHashMap<K, V> = HashMap<K, V, StraightHasherBuilder>;
+pub type StraightHashSet<K> = HashSet<K, StraightHasherBuilder>;
 
 /// Dummy hash value to map zeros to. This value can be anything.
 ///
@@ -30,7 +34,7 @@ pub const ALT_ZERO_HASH: u64 = 42;
 ///
 /// Panics when hashing any data type other than a [`u64`].
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
-struct StraightHasher(u64);
+pub struct StraightHasher(u64);
 
 impl Hasher for StraightHasher {
     #[inline(always)]
@@ -38,23 +42,18 @@ impl Hasher for StraightHasher {
         self.0
     }
     #[inline]
-    fn write(&mut self, bytes: &[u8]) {
-        assert_eq!(bytes.len(), 8, "StraightHasher can only hash u64 values");
+    fn write(&mut self, _bytes: &[u8]) {
+        panic!("StraightHasher can only hash u64 values");
+    }
 
-        let mut key = [0_u8; 8];
-        key.copy_from_slice(bytes);
-
-        self.0 = u64::from_ne_bytes(key);
-
-        if self.0 == 0 {
-            self.0 = ALT_ZERO_HASH;
-        }
+    fn write_u64(&mut self, i: u64) {
+        self.0 = i;
     }
 }
 
 /// A hash builder for `StraightHasher`.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
-struct StraightHasherBuilder;
+pub struct StraightHasherBuilder;
 
 impl BuildHasher for StraightHasherBuilder {
     type Hasher = StraightHasher;

--- a/src/func/hashing.rs
+++ b/src/func/hashing.rs
@@ -4,12 +4,18 @@
 use std::prelude::v1::*;
 use std::{
     any::TypeId,
-    collections::{HashMap, HashSet},
     hash::{BuildHasher, Hash, Hasher},
 };
 
-pub type StraightHashMap<K, V> = HashMap<K, V, StraightHasherBuilder>;
-pub type StraightHashSet<K> = HashSet<K, StraightHasherBuilder>;
+#[cfg(feature = "no_std")]
+pub type StraightHashMap<K, V> = hashbrown::HashMap<K, V, StraightHasherBuilder>;
+#[cfg(feature = "no_std")]
+pub type StraightHashSet<K> = hashbrown::HashSet<K, StraightHasherBuilder>;
+
+#[cfg(not(feature = "no_std"))]
+pub type StraightHashMap<K, V> = std::collections::HashMap<K, V, StraightHasherBuilder>;
+#[cfg(not(feature = "no_std"))]
+pub type StraightHashSet<K> = std::collections::HashSet<K, StraightHasherBuilder>;
 
 /// Dummy hash value to map zeros to. This value can be anything.
 ///
@@ -47,7 +53,11 @@ impl Hasher for StraightHasher {
     }
 
     fn write_u64(&mut self, i: u64) {
-        self.0 = i;
+        if i == 0 {
+            self.0 = ALT_ZERO_HASH;
+        } else {
+            self.0 = i;
+        }
     }
 }
 

--- a/src/func/mod.rs
+++ b/src/func/mod.rs
@@ -21,7 +21,7 @@ pub use callable_function::CallableFunction;
 pub use func::Func;
 pub use hashing::{
     calc_fn_hash, calc_fn_params_hash, calc_qualified_fn_hash, calc_qualified_var_hash,
-    combine_hashes, get_hasher,
+    combine_hashes, get_hasher, StraightHashMap, StraightHashSet,
 };
 pub use native::{
     locked_read, locked_write, shared_get_mut, shared_make_mut, shared_take, shared_take_or_clone,

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -23,6 +23,8 @@ use std::{
 #[cfg(any(not(feature = "no_index"), not(feature = "no_object")))]
 use crate::func::register::Mut;
 
+use crate::func::{StraightHashMap, StraightHashSet};
+
 /// A type representing the namespace of a function.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(feature = "metadata", derive(serde::Serialize))]
@@ -267,18 +269,18 @@ pub struct Module {
     /// [`Module`] variables.
     variables: BTreeMap<Identifier, Dynamic>,
     /// Flattened collection of all [`Module`] variables, including those in sub-modules.
-    all_variables: BTreeMap<u64, Dynamic>,
+    all_variables: StraightHashMap<u64, Dynamic>,
     /// Functions (both native Rust and scripted).
-    functions: BTreeMap<u64, Box<FuncInfo>>,
+    functions: StraightHashMap<u64, Box<FuncInfo>>,
     /// Flattened collection of all functions, native Rust and scripted.
     /// including those in sub-modules.
-    all_functions: BTreeMap<u64, CallableFunction>,
+    all_functions: StraightHashMap<u64, CallableFunction>,
     /// Native Rust functions (in scripted hash format) that contain [`Dynamic`] parameters.
-    dynamic_functions: BTreeSet<u64>,
+    dynamic_functions: StraightHashSet<u64>,
     /// Iterator functions, keyed by the type producing the iterator.
-    type_iterators: BTreeMap<TypeId, Shared<IteratorFn>>,
+    type_iterators: StraightHashMap<TypeId, Shared<IteratorFn>>,
     /// Flattened collection of iterator functions, including those in sub-modules.
-    all_type_iterators: BTreeMap<TypeId, Shared<IteratorFn>>,
+    all_type_iterators: StraightHashMap<TypeId, Shared<IteratorFn>>,
     /// Is the [`Module`] indexed?
     indexed: bool,
     /// Does the [`Module`] contain indexed functions that have been exposed to the global namespace?
@@ -372,12 +374,12 @@ impl Module {
             custom_types: CustomTypesCollection::new(),
             modules: BTreeMap::new(),
             variables: BTreeMap::new(),
-            all_variables: BTreeMap::new(),
-            functions: BTreeMap::new(),
-            all_functions: BTreeMap::new(),
-            dynamic_functions: BTreeSet::new(),
-            type_iterators: BTreeMap::new(),
-            all_type_iterators: BTreeMap::new(),
+            all_variables: StraightHashMap::default(),
+            functions: StraightHashMap::default(),
+            all_functions: StraightHashMap::default(),
+            dynamic_functions: StraightHashSet::default(),
+            type_iterators: StraightHashMap::default(),
+            all_type_iterators: StraightHashMap::default(),
             indexed: true,
             contains_indexed_global_functions: false,
         }
@@ -2137,9 +2139,9 @@ impl Module {
         fn index_module<'a>(
             module: &'a Module,
             path: &mut Vec<&'a str>,
-            variables: &mut BTreeMap<u64, Dynamic>,
-            functions: &mut BTreeMap<u64, CallableFunction>,
-            type_iterators: &mut BTreeMap<TypeId, Shared<IteratorFn>>,
+            variables: &mut StraightHashMap<u64, Dynamic>,
+            functions: &mut StraightHashMap<u64, CallableFunction>,
+            type_iterators: &mut StraightHashMap<TypeId, Shared<IteratorFn>>,
         ) -> bool {
             let mut contains_indexed_global_functions = false;
 
@@ -2201,9 +2203,9 @@ impl Module {
 
         if !self.indexed {
             let mut path = Vec::with_capacity(4);
-            let mut variables = BTreeMap::new();
-            let mut functions = BTreeMap::new();
-            let mut type_iterators = BTreeMap::new();
+            let mut variables = StraightHashMap::default();
+            let mut functions = StraightHashMap::default();
+            let mut type_iterators = StraightHashMap::default();
 
             path.push("");
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,7 +9,7 @@ use crate::ast::{
 };
 use crate::engine::{Precedence, KEYWORD_THIS, OP_CONTAINS};
 use crate::eval::GlobalRuntimeState;
-use crate::func::hashing::get_hasher;
+use crate::func::{hashing::get_hasher, StraightHashMap};
 use crate::tokenizer::{
     is_keyword_function, is_valid_function_name, is_valid_identifier, Token, TokenStream,
     TokenizerControl,
@@ -32,7 +32,7 @@ use std::{
 
 pub type ParseResult<T> = Result<T, ParseError>;
 
-type FnLib = BTreeMap<u64, Shared<ScriptFnDef>>;
+type FnLib = StraightHashMap<u64, Shared<ScriptFnDef>>;
 
 const KEYWORD_SEMICOLON: &str = Token::SemiColon.literal_syntax();
 
@@ -3790,7 +3790,7 @@ impl Engine {
         state: &mut ParseState,
         _optimization_level: OptimizationLevel,
     ) -> ParseResult<AST> {
-        let mut functions = BTreeMap::new();
+        let mut functions = StraightHashMap::default();
 
         let mut options = self.options;
         options.remove(LangOptions::STMT_EXPR);
@@ -3850,7 +3850,7 @@ impl Engine {
         state: &mut ParseState,
     ) -> ParseResult<(StmtBlockContainer, StaticVec<Shared<ScriptFnDef>>)> {
         let mut statements = StmtBlockContainer::new_const();
-        let mut functions = BTreeMap::new();
+        let mut functions = StraightHashMap::default();
 
         while !input.peek().expect(NEVER_ENDS).0.is_eof() {
             let settings = ParseSettings {

--- a/src/types/interner.rs
+++ b/src/types/interner.rs
@@ -1,10 +1,9 @@
-use crate::func::hashing::get_hasher;
+use crate::func::{hashing::get_hasher, StraightHashMap};
 use crate::ImmutableString;
 
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
 use std::{
-    collections::BTreeMap,
     fmt,
     hash::{Hash, Hasher},
     marker::PhantomData,
@@ -21,14 +20,14 @@ pub const MAX_STRING_LEN: usize = 24;
 /// Exported under the `internals` feature only.
 ///
 /// Normal identifiers, property getters and setters are interned separately.
-#[derive(Clone, Hash)]
+#[derive(Clone)]
 pub struct StringsInterner<'a> {
     /// Maximum number of strings interned.
     pub capacity: usize,
     /// Maximum string length.
     pub max_string_len: usize,
     /// Normal strings.
-    strings: BTreeMap<u64, ImmutableString>,
+    strings: StraightHashMap<u64, ImmutableString>,
     /// Take care of the lifetime parameter.
     dummy: PhantomData<&'a ()>,
 }
@@ -55,7 +54,7 @@ impl StringsInterner<'_> {
         Self {
             capacity: MAX_INTERNED_STRINGS,
             max_string_len: MAX_STRING_LEN,
-            strings: BTreeMap::new(),
+            strings: StraightHashMap::default(),
             dummy: PhantomData,
         }
     }


### PR DESCRIPTION
I was writing some simple scripts to test the performance, and through profiler, I found that BTreeMap related calls occupied more call stack (flamegraph attached):

![flamegraph](https://user-images.githubusercontent.com/8990/188359602-e4721d6d-fe8c-45f1-8f84-87d564199657.svg)

And through search, I found that PR #375 changed HashMap to BTreeMap. However, according to the experience of previous projects, for small data volume of HashMap, its performance should be better than BTreeMap. I think it's possible that the original StraightHasher did unnecessary `assert_eq` and `copy_slice`.

This PR modifies the code of `StraightHasher` by writing the u64 directly, and the benchmark shows that most of the performance comparisons are improved:

```
 name                                    master ns/iter   pr ns/iter           diff ns/iter   diff %  speedup 
 bench_engine_new                        325,830          205,061               -120,769  -37.07%   x 1.59 
 bench_engine_new_raw                    229              214                        -15   -6.55%   x 1.07 
 bench_engine_new_raw_core               227              211                        -16   -7.05%   x 1.08 
 bench_engine_register_fn                513              501                        -12   -2.34%   x 1.02 
 bench_eval_array_large_get              1,502            1,630                      128    8.52%   x 0.92 
 bench_eval_array_large_set              1,541            1,529                      -12   -0.78%   x 1.01 
 bench_eval_array_loop                   5,137,024        4,444,591             -692,433  -13.48%   x 1.16 
 bench_eval_array_small_get              517              497                        -20   -3.87%   x 1.04 
 bench_eval_array_small_set              532              509                        -23   -4.32%   x 1.05 
 bench_eval_call                         16,061           15,535                    -526   -3.28%   x 1.03 
 bench_eval_call_expression              15,541           14,499                  -1,042   -6.70%   x 1.07 
 bench_eval_deeply_nested                17,471           16,719                    -752   -4.30%   x 1.04 
 bench_eval_expression_number_literal    330              287                        -43  -13.03%   x 1.15 
 bench_eval_expression_number_operators  505              417                        -88  -17.43%   x 1.21 
 bench_eval_expression_optimized_full    66               60                          -6   -9.09%   x 1.10 
 bench_eval_expression_optimized_simple  66               61                          -5   -7.58%   x 1.08 
 bench_eval_expression_single            65               66                           1    1.54%   x 0.98 
 bench_eval_function_call                974              842                       -132  -13.55%   x 1.16 
 bench_eval_loop_number                  1,616,313        1,550,376              -65,937   -4.08%   x 1.04 
 bench_eval_loop_strings_build           2,924,981        2,911,378              -13,603   -0.47%   x 1.00 
 bench_eval_loop_strings_no_build        1,692,284        1,604,832              -87,452   -5.17%   x 1.05 
 bench_eval_map_large_get                2,728            2,703                      -25   -0.92%   x 1.01 
 bench_eval_map_large_set                2,801            2,670                     -131   -4.68%   x 1.05 
 bench_eval_map_small_get                705              654                        -51   -7.23%   x 1.08 
 bench_eval_map_small_set                705              780                         75   10.64%   x 0.90 
 bench_eval_module                       913              797                       -116  -12.71%   x 1.15 
 bench_eval_nested_if                    12,988           12,614                    -374   -2.88%   x 1.03 
 bench_eval_primes                       1,111,801        1,093,280              -18,521   -1.67%   x 1.02 
 bench_eval_scope_complex                514              465                        -49   -9.53%   x 1.11 
 bench_eval_scope_longer                 736              636                       -100  -13.59%   x 1.16 
 bench_eval_scope_multiple               378              343                        -35   -9.26%   x 1.10 
 bench_eval_scope_single                 387              341                        -46  -11.89%   x 1.13 
 bench_eval_switch                       5,733            5,560                     -173   -3.02%   x 1.03 
 bench_iterations_1000                   234,154          233,938                   -216   -0.09%   x 1.00 
 bench_iterations_array                  302,204          303,243                  1,039    0.34%   x 1.00 
 bench_iterations_blob                   300,123          301,097                    974    0.32%   x 1.00 
 bench_iterations_fibonacci              12,140,478       12,333,908             193,430    1.59%   x 0.98 
 bench_parse_array                       2,885            2,907                       22    0.76%   x 0.99 
 bench_parse_full                        13,360           13,327                     -33   -0.25%   x 1.00 
 bench_parse_map                         4,429            4,524                       95    2.14%   x 0.98 
 bench_parse_optimize_full               17,024           15,522                  -1,502   -8.82%   x 1.10 
 bench_parse_optimize_simple             15,332           14,709                    -623   -4.06%   x 1.04 
 bench_parse_primes                      34,533           32,481                  -2,052   -5.94%   x 1.06 
 bench_parse_simple                      3,593            3,397                     -196   -5.46%   x 1.06 
 bench_parse_single                      637              588                        -49   -7.69%   x 1.08 
 bench_type_field                        300              246                        -54  -18.00%   x 1.22 
 bench_type_method                       375              316                        -59  -15.73%   x 1.19 
 bench_type_method_nested                517              454                        -63  -12.19%   x 1.14 
 bench_type_method_with_params           422              372                        -50  -11.85%   x 1.13 
```

btw, I don't understand the purpose of `ALT_ZERO_HASH`, it doesn't seem to be a necessary conversion to me, can you clarify its purpose?