### PR TITLE
pref: tweak code to improve performance

### DIFF
--- a/src/eval/expr.rs
+++ b/src/eval/expr.rs
@@ -6,7 +6,7 @@ use crate::engine::{KEYWORD_THIS, OP_CONCAT};
 use crate::eval::FnResolutionCacheEntry;
 use crate::func::{
     calc_fn_params_hash, combine_hashes, gen_fn_call_signature, get_builtin_binary_op_fn,
-    CallableFunction, FnAny,
+    CallableFunction,
 };
 use crate::types::dynamic::AccessMode;
 use crate::{Dynamic, Engine, Module, Position, RhaiResult, RhaiResultOf, Scope, ERR};
@@ -269,7 +269,7 @@ impl Engine {
                     if let Some(f) = func {
                         &entry
                             .insert(Some(FnResolutionCacheEntry {
-                                func: CallableFunction::from_method(Box::new(f) as Box<FnAny>),
+                                func: CallableFunction::from_fn_builtin(f),
                                 source: None,
                             }))
                             .as_ref()

--- a/src/eval/expr.rs
+++ b/src/eval/expr.rs
@@ -261,7 +261,7 @@ impl Engine {
             let func = match cache.entry(hash) {
                 Entry::Vacant(entry) => {
                     let func = if args.len() == 2 {
-                        get_builtin_binary_op_fn(&name, operands[0], operands[1])
+                        get_builtin_binary_op_fn(name, operands[0], operands[1])
                     } else {
                         None
                     };

--- a/src/eval/target.rs
+++ b/src/eval/target.rs
@@ -253,7 +253,7 @@ impl<'a> Target<'a> {
     #[must_use]
     pub fn source(&self) -> &Dynamic {
         match self {
-            Self::RefMut(r) => *r,
+            Self::RefMut(r) => r,
             #[cfg(not(feature = "no_closure"))]
             Self::SharedValue { source, .. } => source,
             Self::TempValue(v) => v,
@@ -401,9 +401,9 @@ impl Deref for Target<'_> {
     #[inline]
     fn deref(&self) -> &Dynamic {
         match self {
-            Self::RefMut(r) => *r,
+            Self::RefMut(r) => r,
             #[cfg(not(feature = "no_closure"))]
-            Self::SharedValue { source, .. } => &**source,
+            Self::SharedValue { source, .. } => source,
             Self::TempValue(ref r) => r,
             #[cfg(not(feature = "no_index"))]
             Self::Bit { ref value, .. }
@@ -425,7 +425,7 @@ impl DerefMut for Target<'_> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Dynamic {
         match self {
-            Self::RefMut(r) => *r,
+            Self::RefMut(r) => r,
             #[cfg(not(feature = "no_closure"))]
             Self::SharedValue { source, .. } => &mut *source,
             Self::TempValue(ref mut r) => r,

--- a/src/func/call.rs
+++ b/src/func/call.rs
@@ -1,7 +1,6 @@
 //! Implement function-calling mechanism for [`Engine`].
 
 use super::callable_function::CallableFunction;
-use super::native::FnAny;
 use super::{get_builtin_binary_op_fn, get_builtin_op_assignment_fn};
 use crate::api::default_limits::MAX_DYNAMIC_PARAMETERS;
 use crate::ast::{Expr, FnCallHashes, Stmt};
@@ -289,18 +288,14 @@ impl Engine {
 
                                 get_builtin_op_assignment_fn(fn_name, *first_arg, rest_args[0]).map(
                                     |f| FnResolutionCacheEntry {
-                                        func: CallableFunction::from_method(
-                                            Box::new(f) as Box<FnAny>
-                                        ),
+                                        func: CallableFunction::from_fn_builtin(f),
                                         source: None,
                                     },
                                 )
                             } else {
                                 get_builtin_binary_op_fn(fn_name, args[0], args[1]).map(|f| {
                                     FnResolutionCacheEntry {
-                                        func: CallableFunction::from_method(
-                                            Box::new(f) as Box<FnAny>
-                                        ),
+                                        func: CallableFunction::from_fn_builtin(f),
                                         source: None,
                                     }
                                 })

--- a/src/func/callable_function.rs
+++ b/src/func/callable_function.rs
@@ -1,6 +1,6 @@
 //! Module defining the standard Rhai function type.
 
-use super::native::{FnAny, FnPlugin, IteratorFn, SendSync};
+use super::native::{FnAny, FnBuiltin, FnPlugin, IteratorFn, SendSync};
 use crate::ast::FnAccess;
 use crate::plugin::PluginFunction;
 use crate::Shared;
@@ -197,23 +197,17 @@ impl CallableFunction {
             Self::Script(..) => None,
         }
     }
-    /// Create a new [`CallableFunction::Pure`].
+    /// Create a new [`CallableFunction::Method`] from `FnBuiltin`.
     #[inline(always)]
     #[must_use]
-    pub fn from_pure(func: Box<FnAny>) -> Self {
-        Self::Pure(func.into())
-    }
-    /// Create a new [`CallableFunction::Method`].
-    #[inline(always)]
-    #[must_use]
-    pub fn from_method(func: Box<FnAny>) -> Self {
-        Self::Method(func.into())
+    pub fn from_fn_builtin(func: FnBuiltin) -> Self {
+        Self::Method(Shared::new(func))
     }
     /// Create a new [`CallableFunction::Plugin`].
     #[inline(always)]
     #[must_use]
     pub fn from_plugin(func: impl PluginFunction + 'static + SendSync) -> Self {
-        Self::Plugin((Box::new(func) as Box<FnPlugin>).into())
+        Self::Plugin(Shared::new(func))
     }
 }
 

--- a/src/func/hashing.rs
+++ b/src/func/hashing.rs
@@ -96,18 +96,15 @@ pub fn get_hasher() -> ahash::AHasher {
 #[inline]
 #[must_use]
 pub fn calc_qualified_var_hash<'a>(
-    modules: impl IntoIterator<Item = &'a str>,
+    modules: impl IntoIterator<Item = &'a str, IntoIter = impl ExactSizeIterator<Item = &'a str>>,
     var_name: &str,
 ) -> u64 {
     let s = &mut get_hasher();
 
     // We always skip the first module
-    let mut len = 0;
-    modules
-        .into_iter()
-        .inspect(|_| len += 1)
-        .skip(1)
-        .for_each(|m| m.hash(s));
+    let iter = modules.into_iter();
+    let len = iter.len();
+    iter.skip(1).for_each(|m| m.hash(s));
     len.hash(s);
     var_name.hash(s);
 
@@ -133,19 +130,16 @@ pub fn calc_qualified_var_hash<'a>(
 #[inline]
 #[must_use]
 pub fn calc_qualified_fn_hash<'a>(
-    modules: impl IntoIterator<Item = &'a str>,
+    modules: impl IntoIterator<Item = &'a str, IntoIter = impl ExactSizeIterator<Item = &'a str>>,
     fn_name: &str,
     num: usize,
 ) -> u64 {
     let s = &mut get_hasher();
 
     // We always skip the first module
-    let mut len = 0;
-    modules
-        .into_iter()
-        .inspect(|_| len += 1)
-        .skip(1)
-        .for_each(|m| m.hash(s));
+    let iter = modules.into_iter();
+    let len = iter.len();
+    iter.skip(1).for_each(|m| m.hash(s));
     len.hash(s);
     fn_name.hash(s);
     num.hash(s);
@@ -179,11 +173,13 @@ pub fn calc_fn_hash(fn_name: &str, num: usize) -> u64 {
 /// If the hash happens to be zero, it is mapped to `DEFAULT_HASH`.
 #[inline]
 #[must_use]
-pub fn calc_fn_params_hash(params: impl IntoIterator<Item = TypeId>) -> u64 {
+pub fn calc_fn_params_hash(
+    params: impl IntoIterator<Item = TypeId, IntoIter = impl ExactSizeIterator<Item = TypeId>>,
+) -> u64 {
     let s = &mut get_hasher();
-    let mut len = 0;
-    params.into_iter().for_each(|t| {
-        len += 1;
+    let iter = params.into_iter();
+    let len = iter.len();
+    iter.for_each(|t| {
         t.hash(s);
     });
     len.hash(s);

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -1263,7 +1263,7 @@ impl Module {
             access,
             None,
             arg_types,
-            CallableFunction::from_method(Box::new(f)),
+            CallableFunction::Method(Shared::new(f)),
         )
     }
 

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -239,7 +239,7 @@ impl FuncInfo {
 /// The first module name is skipped.  Hashing starts from the _second_ module in the chain.
 #[inline]
 pub fn calc_native_fn_hash<'a>(
-    modules: impl IntoIterator<Item = &'a str>,
+    modules: impl IntoIterator<Item = &'a str, IntoIter = impl ExactSizeIterator<Item = &'a str>>,
     fn_name: &str,
     params: &[TypeId],
 ) -> u64 {


### PR DESCRIPTION
This PR makes 3 minor changes to improve performance:
1. use `HashMap#Entry` api to reduce one hashmap lookup
2. use `ExactSizeIterator` to eliminate the loop/counter updating
3. use `Rc/Arc#new` directly to eliminate the unnecessary Box => Rc conversions

this is the benchcmp result on my local machine:
```
 name                                    main ns/iter  pr ns/iter  diff ns/iter   diff %  speedup 
 bench_engine_new                        204,665       180,687          -23,978  -11.72%   x 1.13 
 bench_engine_new_raw                    208           167                  -41  -19.71%   x 1.25 
 bench_engine_new_raw_core               197           174                  -23  -11.68%   x 1.13 
 bench_engine_register_fn                478           412                  -66  -13.81%   x 1.16 
 bench_eval_array_large_get              1,478         1,356               -122   -8.25%   x 1.09 
 bench_eval_array_large_set              1,474         1,363               -111   -7.53%   x 1.08 
 bench_eval_array_loop                   4,416,053     4,117,429       -298,624   -6.76%   x 1.07 
 bench_eval_array_small_get              485           447                  -38   -7.84%   x 1.09 
 bench_eval_array_small_set              546           476                  -70  -12.82%   x 1.15 
 bench_eval_call                         15,594        14,886              -708   -4.54%   x 1.05 
 bench_eval_call_expression              14,203        13,938              -265   -1.87%   x 1.02 
 bench_eval_deeply_nested                16,646        16,214              -432   -2.60%   x 1.03 
 bench_eval_expression_number_literal    311           259                  -52  -16.72%   x 1.20 
 bench_eval_expression_number_operators  417           393                  -24   -5.76%   x 1.06 
 bench_eval_expression_optimized_full    61            57                    -4   -6.56%   x 1.07 
 bench_eval_expression_optimized_simple  60            58                    -2   -3.33%   x 1.03 
 bench_eval_expression_single            60            56                    -4   -6.67%   x 1.07 
 bench_eval_function_call                840           807                  -33   -3.93%   x 1.04 
 bench_eval_loop_number                  1,520,661     1,465,426        -55,235   -3.63%   x 1.04 
 bench_eval_loop_strings_build           2,955,438     2,842,443       -112,995   -3.82%   x 1.04 
 bench_eval_loop_strings_no_build        1,621,209     1,535,012        -86,197   -5.32%   x 1.06 
 bench_eval_map_large_get                2,852         2,578               -274   -9.61%   x 1.11 
 bench_eval_map_large_set                2,703         2,644                -59   -2.18%   x 1.02 
 bench_eval_map_small_get                656           663                    7    1.07%   x 0.99 
 bench_eval_map_small_set                686           670                  -16   -2.33%   x 1.02 
 bench_eval_module                       794           762                  -32   -4.03%   x 1.04 
 bench_eval_nested_if                    12,428        12,333               -95   -0.76%   x 1.01 
 bench_eval_primes                       1,104,000     1,063,406        -40,594   -3.68%   x 1.04 
 bench_eval_scope_complex                498           436                  -62  -12.45%   x 1.14 
 bench_eval_scope_longer                 645           607                  -38   -5.89%   x 1.06 
 bench_eval_scope_multiple               346           330                  -16   -4.62%   x 1.05 
 bench_eval_scope_single                 341           323                  -18   -5.28%   x 1.06 
 bench_eval_switch                       5,451         5,349               -102   -1.87%   x 1.02 
 bench_iterations_1000                   240,063       222,147          -17,916   -7.46%   x 1.08 
 bench_iterations_array                  296,836       284,320          -12,516   -4.22%   x 1.04 
 bench_iterations_blob                   293,536       280,669          -12,867   -4.38%   x 1.05 
 bench_iterations_fibonacci              12,199,384    11,898,525      -300,859   -2.47%   x 1.03 
 bench_parse_array                       2,893         2,807                -86   -2.97%   x 1.03 
 bench_parse_full                        13,396        13,299               -97   -0.72%   x 1.01 
 bench_parse_map                         4,546         4,575                 29    0.64%   x 0.99 
 bench_parse_optimize_full               16,215        15,784              -431   -2.66%   x 1.03 
 bench_parse_optimize_simple             14,825        14,525              -300   -2.02%   x 1.02 
 bench_parse_primes                      32,548        32,769               221    0.68%   x 0.99 
 bench_parse_simple                      3,492         3,388               -104   -2.98%   x 1.03 
 bench_parse_single                      583           597                   14    2.40%   x 0.98 
 bench_type_field                        257           239                  -18   -7.00%   x 1.08 
 bench_type_method                       319           305                  -14   -4.39%   x 1.05 
 bench_type_method_nested                471           456                  -15   -3.18%   x 1.03 
 bench_type_method_with_params           356           331                  -25   -7.02%   x 1.08 
```