### PR TITLE
Minimal wasm ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,32 @@ jobs:
       with:
         command: build
         args: --manifest-path=no_std/no_std_test/Cargo.toml ${{matrix.flags}}
+  wasm:
+    name: Check Wasm build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        flags:
+          - ""
+          - "--no-default-features"
+          - "--features wasm-bindgen"
+          - "--no-default-features --features wasm-bindgen"
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_MSRV }}
+          override: true
+          target: wasm32-unknown-unknown
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target wasm32-unknown-unknown ${{matrix.flags}}
+
   rustfmt:
     name: Check Formatting
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,9 +116,10 @@ jobs:
     strategy:
       matrix:
         flags:
-          - ""
+# These fail currently, future PR should fix them
+#          - ""
+#          - "--features wasm-bindgen"
           - "--no-default-features"
-          - "--features wasm-bindgen"
           - "--no-default-features --features wasm-bindgen"
       fail-fast: false
     steps:


### PR DESCRIPTION
Factored out from #653 

Just add wasm build to the CI and only test those that currently work (with `--no-default-features`)

A future PR can improve the state and add more tests