### PR TITLE
Make time references an optional import

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 [features]
 default = ["std", "ahash/runtime-rng"]  # ahash/runtime-rng trumps ahash/compile-time-rng
 std = ["ahash/std", "num-traits/std", "smartstring/std"]
+no_time = []                    # remove all time-related imports
 unchecked = []                  # unchecked arithmetic
 sync = []                       # restrict to only types that implement Send + Sync
 no_position = []                # do not track position in the parser
@@ -64,7 +65,7 @@ debugging = ["internals"]       # enable debugging
 serde = ["dep:serde", "smartstring/serde", "smallvec/serde"] # implement serde for rhai types
 
 # compiling for no-std
-no_std = ["no-std-compat", "num-traits/libm", "core-error", "libm", "hashbrown"]
+no_std = ["no_time", "no-std-compat", "num-traits/libm", "core-error", "libm", "hashbrown"]
 
 # compiling for WASM
 wasm-bindgen = ["instant/wasm-bindgen"]

--- a/src/packages/mod.rs
+++ b/src/packages/mod.rs
@@ -38,7 +38,7 @@ pub use pkg_core::CorePackage;
 pub use pkg_std::StandardPackage;
 pub use string_basic::BasicStringPackage;
 pub use string_more::MoreStringPackage;
-#[cfg(not(feature = "no_std"))]
+#[cfg(not(feature = "no_time"))]
 pub use time_basic::BasicTimePackage;
 
 /// Trait that all packages must implement.

--- a/src/packages/pkg_std.rs
+++ b/src/packages/pkg_std.rs
@@ -26,7 +26,7 @@ def_package! {
             #[cfg(not(feature = "no_index"))] BasicArrayPackage,
             #[cfg(not(feature = "no_index"))] BasicBlobPackage,
             #[cfg(not(feature = "no_object"))] BasicMapPackage,
-            #[cfg(not(feature = "no_std"))] BasicTimePackage,
+            #[cfg(not(feature = "no_time"))] BasicTimePackage,
             MoreStringPackage
     {
         lib.standard = true;

--- a/src/packages/time_basic.rs
+++ b/src/packages/time_basic.rs
@@ -1,4 +1,4 @@
-#![cfg(not(feature = "no_std"))]
+#![cfg(not(feature = "no_time"))]
 
 use super::arithmetic::make_err as make_arithmetic_err;
 use crate::plugin::*;


### PR DESCRIPTION
When I compile this to wasm with the new format

`cargo build --target wasm32-unknown-unknown --no-default-features --features std`

It works properly, but it creates an `env.now` import, to load system time. I am not running in a browser, but in another embedded environment, that doesn't have access to clock time (or random number generators, already removed). So, the final *.wasm output doesn't run properly ("unsupported import").

I noticed this time dependency was conditionally disabled for `no_std`, but `no_std` is incompatible with `wasm32-unknown-unknown` builds. 

My decision was to change the conditions for time to a new `no_time` feature (like many of the other `no_*` features) and then include `no_time` when `no_std` is defined. This allows any "normal" `std` build also disable the system time dependency if desired.

I know it does add one more feature flag, but it is strictly optional and the features involved we already conditionally compiled, just I moved to a different flag.

Using this patch, the resulting code runs properly in my environment.