### PR TITLE
CI: add `cargo hack check --feature-powerset`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,18 @@ jobs:
         command: test
         args: ${{matrix.flags}}
 
+  feature_powerset:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack@0.5.25
+      - run: cargo hack check --feature-powerset --depth 2 --no-dev-deps --exclude-features "stdweb wasm-bindgen f32_float"
+
   # no-std builds are a bit more extensive to test
   no_std_build:
     name: NoStdBuild

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,18 +88,6 @@ jobs:
         command: test
         args: ${{matrix.flags}}
 
-  feature_powerset:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: stable
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-hack@0.5.25
-      - run: cargo hack check --feature-powerset --depth 2 --no-dev-deps --exclude-features "stdweb wasm-bindgen f32_float"
-
   # no-std builds are a bit more extensive to test
   no_std_build:
     name: NoStdBuild

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,25 @@
+name: Manual CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      depth:
+        description: "Specify a max number of simultaneous feature flags"
+        required: true
+        type: string
+        default: "2"
+
+jobs:
+  feature_powerset:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack@0.5.25
+      - run: cargo hack check --feature-powerset --depth ${{ inputs.depth }} --no-dev-deps --exclude-features $FEATURE_EXCLUDE
+        env:
+          FEATURE_EXCLUDE: "no_std stdweb wasm-bindgen f32_float only_i32 unicode-xid-ident bin-features"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,6 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack@0.5.25
-      - run: cargo hack check --feature-powerset --depth ${{ inputs.depth }} --no-dev-deps --exclude-features $FEATURE_EXCLUDE
+      - run: cargo hack check --feature-powerset --depth ${{ inputs.depth }} --no-dev-deps --exclude-features "$FEATURE_EXCLUDE"
         env:
           FEATURE_EXCLUDE: "no_std stdweb wasm-bindgen f32_float only_i32 unicode-xid-ident bin-features"


### PR DESCRIPTION
# Context

Following #688 

This PR add checks concerning the cargo feature flags.

The command `cargo check --no-default-features --features bin-features,no_std` produce an build error.