### PR TITLE
Fix compilation for thumbv6m-none-eabi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bitflags = { version = "1", default-features = false }
 smartstring = { version = "1", default-features = false }
 rhai_codegen = { version = "1.5.0", path = "codegen", default-features = false }
 
-no-std-compat = { version = "0.4", default-features = false, features = ["alloc"], optional = true }
+no-std-compat = { git = "https://gitlab.com/jD91mZM2/no-std-compat", default-features = false, features = ["alloc"], optional = true }
 libm = { version = "0.2", default-features = false, optional = true }
 hashbrown = { version = "0.13", optional = true }
 core-error = { version = "0.0", default-features = false, features = ["alloc"], optional = true }

--- a/src/config/hashing.rs
+++ b/src/config/hashing.rs
@@ -50,7 +50,8 @@ impl HokmaLock {
 
     pub fn write(&'static self) -> WhenTheHokmaSuppression {
         loop {
-            let previous = self.lock.swap(1, Ordering::SeqCst);
+            let previous = self.lock.load(Ordering::SeqCst);
+            self.lock.store(1, Ordering::SeqCst);
 
             if previous != 1 {
                 return WhenTheHokmaSuppression {


### PR DESCRIPTION
I was trying to get rhai running on Raspberry Pi Pico but no-std-compat failed compiling. no-std-compat already fixed that years ago but its not yet been (and may never will be) to crates.io. First commit fixex that, second one fixes error ".swap() not found for AtomicUsize" on thumbv6m-none-eabi.

This merge request fixes compilation but I can't test it because rhai binary is larger than 2MiB (rpi pico flash size).