### PR TITLE
change HokmaLock::write() to use atomic compare_exchange

### DIFF
--- a/src/config/hashing.rs
+++ b/src/config/hashing.rs
@@ -55,12 +55,11 @@ impl HokmaLock {
                 .lock
                 .compare_exchange(1, 1, Ordering::Acquire, Ordering::Relaxed)
             {
-                if previous != 1 {
-                    return WhenTheHokmaSuppression {
-                        hokma: self,
-                        state: previous,
-                    };
-                }
+                // If we failed, previous cannot be 1
+                return WhenTheHokmaSuppression {
+                    hokma: self,
+                    state: previous,
+                };
             }
         }
     }

--- a/src/config/hashing.rs
+++ b/src/config/hashing.rs
@@ -53,7 +53,7 @@ impl HokmaLock {
             // We are only interested in error results
             if let Err(previous) = self
                 .lock
-                .compare_exchange(1, 1, Ordering::Acquire, Ordering::Relaxed)
+                .compare_exchange(1, 1, Ordering::SeqCst, Ordering::SeqCst)
             {
                 // If we failed, previous cannot be 1
                 return WhenTheHokmaSuppression {


### PR DESCRIPTION
I think this fix solves [the issue we have observed on the router](https://github.com/apollographql/router/issues/3213) with hanging `Rhai` tests.

My suggested change is minimal since I want to focus on the main motivation for the change (use compare_exchange() to maintain atomic comparison), but I think this could be improved even further by more reworking. 

I realise that it's a fairly risky change, due to its importance in the code base, so I'm happy to perform any additional testing you may suggest. Our CI environment has tested it on multiple platforms.
