### PR TITLE
Update cargo manifest (dependencies and formatting) + dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,20 @@
 [workspace]
+resolver = "2"
 members = [".", "codegen"]
+
+[workspace.package]
+rust-version = "1.61.0"
+edition = "2021"
+
+[workspace.dependencies]
+rhai = { path = "." }
+rhai_codegen = { path = "codegen" }
 
 [package]
 name = "rhai"
 version = "1.16.0"
-rust-version = "1.61.0"
-edition = "2018"
-resolver = "2"
+rust-version.workspace = true
+edition.workspace = true
 authors = ["Jonathan Turner", "Lukáš Hozda", "Stephen Chung", "jhwgh1968"]
 description = "Embedded scripting for Rust"
 homepage = "https://rhai.rs"
@@ -18,34 +26,48 @@ keywords = ["scripting", "scripting-engine", "scripting-language", "embedded"]
 categories = ["no-std", "embedded", "wasm", "parser-implementations"]
 
 [dependencies]
-smallvec = { version = "1.7", default-features = false, features = ["union", "const_new", "const_generics"] }
-ahash = { version = "0.8.2", default-features = false, features = ["compile-time-rng"] }
-num-traits = { version = "0.2", default-features = false }
-once_cell = { version = "1", default-features = false, features = ["race"] }
-bitflags = { version = "2", default-features = false }
-smartstring = { version = "1", default-features = false }
-rhai_codegen = { version = "1.5.0", path = "codegen", default-features = false }
+smallvec = { version = "1.11.0", default-features = false, features = ["union", "const_new", "const_generics"] }
+ahash = { version = "0.8.3", default-features = false, features = ["compile-time-rng"] }
+num-traits = { version = "0.2.16", default-features = false }
+once_cell = { version = "1.18.0", default-features = false, features = ["race"] }
+bitflags = { version = "2.3.3", default-features = false }
+smartstring = { version = "1.0.1", default-features = false }
+rhai_codegen = { workspace = true, default-features = false }
 
-no-std-compat = { git = "https://gitlab.com/jD91mZM2/no-std-compat", version = "0.4.1", default-features = false, features = ["alloc"], optional = true }
-libm = { version = "0.2", default-features = false, optional = true }
-hashbrown = { version = "0.13", optional = true }
-core-error = { version = "0.0", default-features = false, features = ["alloc"], optional = true }
-serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
-serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
-unicode-xid = { version = "0.2", default-features = false, optional = true }
-rust_decimal = { version = "1.16", default-features = false, features = ["maths"], optional = true }
-getrandom = { version = "0.2", optional = true }
-rustyline = { version = "11", optional = true }
-document-features = { version = "0.2", optional = true }
+libm = { version = "0.2.7", default-features = false, optional = true }
+hashbrown = { version = "0.14.0", default-features = false, features = [
+    "ahash",
+    "inline-more",
+    "allocator-api2",
+], optional = true }
+core-error = { version = "0.0.1-rc4", default-features = false, features = ["alloc"], optional = true }
+serde = { version = "1.0.176", default-features = false, features = ["derive", "alloc"], optional = true }
+serde_json = { version = "1.0.104", default-features = false, features = ["alloc"], optional = true }
+unicode-xid = { version = "0.2.4", default-features = false, optional = true }
+rust_decimal = { version = "1.30.0", default-features = false, features = ["maths"], optional = true }
+getrandom = { version = "0.2.10", default-features = false, optional = true }
+rustyline = { version = "12.0.0", default-features = false, features = [
+    "custom-bindings",
+    "with-dirs",
+    "with-file-history"
+], optional = true }
+document-features = { version = "0.2.7", default-features = false, optional = true }
+
+[dependencies.no-std-compat]
+version = "0.4.1"
+git = "https://gitlab.com/jD91mZM2/no-std-compat"
+default-features = false
+features = ["alloc"]
+optional = true
 
 [dev-dependencies]
-rmp-serde = "1.1"
-serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+rmp-serde = { version = "1.1.2", default-features = false }
+serde_json = { version = "1.0.104", default-features = false, features = ["alloc"] }
 
 [features]
 
 ## Default features: `std`, uses runtime random numbers for hashing.
-default = ["std", "ahash/runtime-rng"]  # ahash/runtime-rng trumps ahash/compile-time-rng
+default = ["std", "ahash/runtime-rng"] # ahash/runtime-rng trumps ahash/compile-time-rng
 ## Standard features: uses compile-time random number for hashing.
 std = ["once_cell/std", "ahash/std", "num-traits/std", "smartstring/std"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,57 +1,57 @@
-[workspace]
-resolver = "2"
-members = [".", "codegen"]
+[package]
+name = "rhai"
+version = "1.16.0"
+authors = ["Jonathan Turner", "Lukáš Hozda", "Stephen Chung", "jhwgh1968"]
+categories = ["no-std", "embedded", "wasm", "parser-implementations"]
+edition.workspace = true
+homepage = "https://rhai.rs"
+include = ["/src/**/*", "/Cargo.toml", "/README.md", "LICENSE*"]
+keywords = ["scripting", "scripting-engine", "scripting-language", "embedded"]
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+repository.workspace = true
+rust-version.workspace = true
+description = "Embedded scripting for Rust"
 
-[workspace.package]
-rust-version = "1.61.0"
-edition = "2021"
+[package.metadata.docs.rs]
+features = ["document-features", "metadata", "serde", "internals", "decimal", "debugging"]
+
+[workspace]
+members = [".", "codegen"]
+resolver = "2"
 
 [workspace.dependencies]
 rhai = { path = "." }
 rhai_codegen = { path = "codegen" }
 
-[package]
-name = "rhai"
-version = "1.16.0"
-rust-version.workspace = true
-edition.workspace = true
-authors = ["Jonathan Turner", "Lukáš Hozda", "Stephen Chung", "jhwgh1968"]
-description = "Embedded scripting for Rust"
-homepage = "https://rhai.rs"
-repository = "https://github.com/rhaiscript"
-readme = "README.md"
-license = "MIT OR Apache-2.0"
-include = ["/src/**/*", "/Cargo.toml", "/README.md", "LICENSE*"]
-keywords = ["scripting", "scripting-engine", "scripting-language", "embedded"]
-categories = ["no-std", "embedded", "wasm", "parser-implementations"]
+[workspace.package]
+rust-version = "1.61.0"
+edition = "2021"
+repository = "https://github.com/rhaiscript/rhai"
 
 [dependencies]
-smallvec = { version = "1.11.0", default-features = false, features = ["union", "const_new", "const_generics"] }
 ahash = { version = "0.8.3", default-features = false, features = ["compile-time-rng"] }
+bitflags = { version = "2.3.3", default-features = false }
+document-features = { version = "0.2.7", default-features = false, optional = true }
+getrandom = { version = "0.2.10", default-features = false, optional = true }
+libm = { version = "0.2.7", default-features = false, optional = true }
 num-traits = { version = "0.2.16", default-features = false }
 once_cell = { version = "1.18.0", default-features = false, features = ["race"] }
-bitflags = { version = "2.3.3", default-features = false }
-smartstring = { version = "1.0.1", default-features = false }
 rhai_codegen = { workspace = true, default-features = false }
-
-libm = { version = "0.2.7", default-features = false, optional = true }
-hashbrown = { version = "0.14.0", default-features = false, features = [
-    "ahash",
-    "inline-more",
-    "allocator-api2",
-], optional = true }
-core-error = { version = "0.0.1-rc4", default-features = false, features = ["alloc"], optional = true }
-serde = { version = "1.0.176", default-features = false, features = ["derive", "alloc"], optional = true }
-serde_json = { version = "1.0.104", default-features = false, features = ["alloc"], optional = true }
+smartstring = { version = "1.0.1", default-features = false }
 unicode-xid = { version = "0.2.4", default-features = false, optional = true }
-rust_decimal = { version = "1.30.0", default-features = false, features = ["maths"], optional = true }
-getrandom = { version = "0.2.10", default-features = false, optional = true }
-rustyline = { version = "12.0.0", default-features = false, features = [
-    "custom-bindings",
-    "with-dirs",
-    "with-file-history"
-], optional = true }
-document-features = { version = "0.2.7", default-features = false, optional = true }
+
+[dependencies.core-error]
+version = "0.0.1-rc4"
+default-features = false
+features = ["alloc"]
+optional = true
+
+[dependencies.hashbrown]
+version = "0.14.0"
+default-features = false
+features = ["ahash", "inline-more", "allocator-api2"]
+optional = true
 
 [dependencies.no-std-compat]
 version = "0.4.1"
@@ -59,6 +59,35 @@ git = "https://gitlab.com/jD91mZM2/no-std-compat"
 default-features = false
 features = ["alloc"]
 optional = true
+
+[dependencies.rust_decimal]
+version = "1.30.0"
+default-features = false
+features = ["maths"]
+optional = true
+
+[dependencies.rustyline]
+version = "12.0.0"
+default-features = false
+features = ["custom-bindings", "with-dirs", "with-file-history"]
+optional = true
+
+[dependencies.serde]
+version = "1.0.176"
+default-features = false
+features = ["derive", "alloc"]
+optional = true
+
+[dependencies.serde_json]
+version = "1.0.104"
+default-features = false
+features = ["alloc"]
+optional = true
+
+[dependencies.smallvec]
+version = "1.11.0"
+default-features = false
+features = ["union", "const_new", "const_generics"]
 
 [dev-dependencies]
 rmp-serde = { version = "1.1.2", default-features = false }
@@ -171,10 +200,7 @@ codegen-units = 1
 #panic = 'abort'     # remove stack backtrace for no-std
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-instant = { version = "0.1.10" } # WASM implementation of std::time::Instant
-
-[package.metadata.docs.rs]
-features = ["document-features", "metadata", "serde", "internals", "decimal", "debugging"]
+instant = { version = "0.1.12", default-features = false } # WASM implementation of std::time::Instant
 
 [patch.crates-io]
 # Notice that a custom modified version of `rustyline` is used which supports bracketed paste on Windows.

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,21 +1,15 @@
 [package]
 name = "rhai_codegen"
 version = "1.5.0"
-rust-version.workspace = true
-edition.workspace = true
 authors = ["jhwgh1968", "Stephen Chung"]
-description = "Procedural macros support package for Rhai, a scripting language and engine for Rust"
-keywords = [
-    "scripting",
-    "scripting-engine",
-    "scripting-language",
-    "embedded",
-    "plugin",
-]
 categories = ["no-std", "embedded", "wasm", "parser-implementations"]
+edition.workspace = true
 homepage = "https://rhai.rs/book/plugins/index.html"
-repository = "https://github.com/rhaiscript/rhai"
+keywords = ["scripting", "scripting-engine", "scripting-language", "embedded", "plugin"]
 license = "MIT OR Apache-2.0"
+repository.workspace = true
+rust-version.workspace = true
+description = "Procedural macros support package for Rhai, a scripting language and engine for Rust"
 
 [lib]
 proc-macro = true
@@ -25,16 +19,25 @@ default = []
 metadata = []
 
 [dependencies]
-proc-macro2 = "1.0.66"
-syn = { version = "2.0.27", features = [
+proc-macro2 = { version = "1.0.66", default-features = false, features = ["proc-macro"] }
+quote = { version = "1.0.32", default-features = false, features = ["proc-macro"] }
+
+[dependencies.syn]
+version = "2.0.27"
+default-features = false
+features = [
     "full",
     "parsing",
     "printing",
     "proc-macro",
     "extra-traits",
-] }
-quote = "1.0.32"
+    "derive",
+    "parsing",
+    "printing",
+    "clone-impls",
+    "proc-macro"
+]
 
 [dev-dependencies]
 rhai = { workspace = true, features = ["metadata"] }
-trybuild = "1.0.82"
+trybuild = { version = "1.0.82", default-features = false }

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,11 +1,17 @@
 [package]
 name = "rhai_codegen"
 version = "1.5.0"
-edition = "2018"
-resolver = "2"
+rust-version.workspace = true
+edition.workspace = true
 authors = ["jhwgh1968", "Stephen Chung"]
 description = "Procedural macros support package for Rhai, a scripting language and engine for Rust"
-keywords = ["scripting", "scripting-engine", "scripting-language", "embedded", "plugin"]
+keywords = [
+    "scripting",
+    "scripting-engine",
+    "scripting-language",
+    "embedded",
+    "plugin",
+]
 categories = ["no-std", "embedded", "wasm", "parser-implementations"]
 homepage = "https://rhai.rs/book/plugins/index.html"
 repository = "https://github.com/rhaiscript/rhai"
@@ -19,10 +25,16 @@ default = []
 metadata = []
 
 [dependencies]
-proc-macro2 = "1"
-syn = { version = "1.0", features = ["full", "parsing", "printing", "proc-macro", "extra-traits"] }
-quote = "1"
+proc-macro2 = "1.0.66"
+syn = { version = "2.0.27", features = [
+    "full",
+    "parsing",
+    "printing",
+    "proc-macro",
+    "extra-traits",
+] }
+quote = "1.0.32"
 
 [dev-dependencies]
-rhai = { path = "..", version = "1.12", features = ["metadata"] }
-trybuild = "1"
+rhai = { workspace = true, features = ["metadata"] }
+trybuild = "1.0.82"

--- a/codegen/src/function.rs
+++ b/codegen/src/function.rs
@@ -39,17 +39,12 @@ pub enum Property {
     Set(syn::Ident),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Default, Debug, Eq, PartialEq, Hash)]
 pub enum FnSpecialAccess {
+    #[default]
     None,
     Index(Index),
     Property(Property),
-}
-
-impl Default for FnSpecialAccess {
-    fn default() -> FnSpecialAccess {
-        FnSpecialAccess::None
-    }
 }
 
 impl FnSpecialAccess {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+format_cargo_toml = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,0 @@
-format_cargo_toml = true


### PR DESCRIPTION
# Summary of changes

## Changed

* in `Cargo.toml`s, specify the compete version of the dependencies ([see this article](https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277))
* in `Cargo.toml`s, use the [`workspace` notation](https://doc.rust-lang.org/cargo/reference/workspaces.html) when relevant
* for all dependencies, explicitly use `default-features = false` and list the features used
* bump `syn` to `>=2`, and update the implementation accordingly
* bump `package.edition` to `2021`

## Style

* format the `Cargo.toml`s files using [`not yet merged rustfmt`](https://github.com/rust-lang/rustfmt/pull/5240), especially [this](https://github.com/rust-lang/rustfmt/pull/5240#issuecomment-1519977712).

## Fixed

* two [derivable_impls](https://rust-lang.github.io/rust-clippy/master/index.html#/derivable_impls) clippy warnings using [`#[default] enum variants`](https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html#default-enum-variants)

## Added

* dependabot files with weekly update on cargo and github actions dependencies udpate