### PR TITLE
Add a derive macro for CustomType

### DIFF
--- a/codegen/src/custom_type.rs
+++ b/codegen/src/custom_type.rs
@@ -48,8 +48,8 @@ pub fn derive_custom_type_impl(input: DeriveInput) -> TokenStream {
 
     quote! {
         impl ::rhai::CustomType for #name {
-            fn build(builder: ::rhai::TypeBuilder<'_, Self>) {
-                #accessors
+            fn build(mut builder: ::rhai::TypeBuilder<'_, Self>) {
+                #accessors;
             }
         }
     }
@@ -63,11 +63,11 @@ fn generate_accessor_fns(
 ) -> proc_macro2::TokenStream {
     let get = get
         .map(|func| quote! {#func})
-        .unwrap_or_else(|| quote! {|obj| obj.#field.clone()});
+        .unwrap_or_else(|| quote! {|obj: &mut Self| obj.#field.clone()});
 
     let set = set
         .map(|func| quote! {#func})
-        .unwrap_or_else(|| quote! {|obj, val| obj.#field = val});
+        .unwrap_or_else(|| quote! {|obj: &mut Self, val| obj.#field = val});
 
     if readonly {
         quote! {

--- a/codegen/src/custom_type.rs
+++ b/codegen/src/custom_type.rs
@@ -1,0 +1,85 @@
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use syn::DeriveInput;
+
+pub fn derive_custom_type_impl(input: DeriveInput) -> TokenStream {
+    let name = input.ident;
+
+    let accessors = match input.data {
+        syn::Data::Struct(ref data) => match data.fields {
+            syn::Fields::Named(ref fields) => {
+                let iter = fields.named.iter().map(|field| {
+                    let mut get_fn = None;
+                    let mut set_fn = None;
+                    let mut readonly = false;
+                    for attr in field.attrs.iter() {
+                        if attr.path().is_ident("get") {
+                            get_fn = Some(
+                                attr.parse_args()
+                                    .unwrap_or_else(syn::Error::into_compile_error),
+                            );
+                        } else if attr.path().is_ident("set") {
+                            set_fn = Some(
+                                attr.parse_args()
+                                    .unwrap_or_else(syn::Error::into_compile_error),
+                            );
+                        } else if attr.path().is_ident("readonly") {
+                            readonly = true;
+                        }
+                    }
+
+                    generate_accessor_fns(&field.ident.as_ref().unwrap(), get_fn, set_fn, readonly)
+                });
+                quote! {#(#iter)*}
+            }
+            syn::Fields::Unnamed(_) => {
+                syn::Error::new(Span::call_site(), "tuple structs are not yet implemented")
+                    .into_compile_error()
+            }
+            syn::Fields::Unit => quote! {},
+        },
+        syn::Data::Enum(_) => {
+            syn::Error::new(Span::call_site(), "enums are not yet implemented").into_compile_error()
+        }
+        syn::Data::Union(_) => {
+            syn::Error::new(Span::call_site(), "unions are not supported").into_compile_error()
+        }
+    };
+
+    quote! {
+        impl ::rhai::CustomType for #name {
+            fn build(builder: ::rhai::TypeBuilder<'_, Self>) {
+                #accessors
+            }
+        }
+    }
+}
+
+fn generate_accessor_fns(
+    field: &Ident,
+    get: Option<TokenStream>,
+    set: Option<TokenStream>,
+    readonly: bool,
+) -> proc_macro2::TokenStream {
+    let get = get
+        .map(|func| quote! {#func})
+        .unwrap_or_else(|| quote! {|obj| obj.#field.clone()});
+
+    let set = set
+        .map(|func| quote! {#func})
+        .unwrap_or_else(|| quote! {|obj, val| obj.#field = val});
+
+    if readonly {
+        quote! {
+            builder.with_get("#field", #get);
+        }
+    } else {
+        quote! {
+            builder.with_get_set(
+                "#field",
+                #get,
+                #set,
+            );
+        }
+    }
+}

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -88,9 +88,10 @@
 //!
 
 use quote::quote;
-use syn::{parse_macro_input, spanned::Spanned};
+use syn::{parse_macro_input, spanned::Spanned, DeriveInput};
 
 mod attrs;
+mod custom_type;
 mod function;
 mod module;
 mod register;
@@ -409,4 +410,11 @@ pub fn set_exported_global_fn(args: proc_macro::TokenStream) -> proc_macro::Toke
         }
         Err(e) => e.to_compile_error().into(),
     }
+}
+
+#[proc_macro_derive(CustomType, attributes(get, set, readonly))]
+pub fn derive_custom_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let expanded = custom_type::derive_custom_type_impl(input);
+    expanded.into()
 }

--- a/codegen/tests/test_derive.rs
+++ b/codegen/tests/test_derive.rs
@@ -1,0 +1,15 @@
+use rhai_codegen::CustomType;
+
+// Sanity check to make sure everything compiles
+#[derive(Clone, CustomType)]
+pub struct Foo {
+    #[get(get_bar)]
+    bar: i32,
+    #[readonly]
+    baz: String,
+    qux: Vec<i32>,
+}
+
+fn get_bar(_this: &mut Foo) -> i32 {
+    42
+}


### PR DESCRIPTION
The macro currently generates getters and setters for all fields in the struct, and has helper attributes for overriding generated getter/setter functions. There is also a `readonly` helper attribute that prevents a setter from being registered.

TODOs:
- [ ] Docs docs docs
- [ ] More tests
- [ ] Register a pretty-print name for types
- [ ] Attribute for calling a user-provided function with the `TypeBuilder` passed in
    - What would it be called?
    - Do we call it before or after registering everything else?
- [ ] Attribute for skipping a field entirely
- [ ] Support for tuple structs
    - What would the fields be named? `field0`, `field1`, etc perhaps?
- [ ] Support for enums as [described in the book](https://rhai.rs/book/patterns/enums.html)