### PR TITLE
Added alias to ThinVec with internals feature

### DIFF
--- a/src/ast/ast.rs
+++ b/src/ast/ast.rs
@@ -1,7 +1,7 @@
 //! Module defining the AST (abstract syntax tree).
 
 use super::{ASTFlags, Expr, FnAccess, Stmt};
-use crate::{Dynamic, FnNamespace, ImmutableString, Position};
+use crate::{Dynamic, FnNamespace, ImmutableString, Position, ThinVec};
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
 use std::{
@@ -11,7 +11,6 @@ use std::{
     ops::{Add, AddAssign},
     ptr,
 };
-use thin_vec::ThinVec;
 
 /// Compiled AST (abstract syntax tree) of a Rhai script.
 ///

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -6,7 +6,7 @@ use crate::tokenizer::Token;
 use crate::types::dynamic::Union;
 use crate::{
     calc_fn_hash, Dynamic, FnArgsVec, FnPtr, Identifier, ImmutableString, Position, SmartString,
-    StaticVec, INT,
+    StaticVec, ThinVec, INT,
 };
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
@@ -19,7 +19,6 @@ use std::{
     mem,
     num::{NonZeroU8, NonZeroUsize},
 };
-use thin_vec::ThinVec;
 
 /// _(internals)_ A binary expression.
 /// Exported under the `internals` feature only.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,6 +454,11 @@ type StaticVec<T> = smallvec::SmallVec<[T; STATIC_VEC_INLINE_SIZE]>;
 #[cfg(feature = "internals")]
 pub type StaticVec<T> = smallvec::SmallVec<[T; STATIC_VEC_INLINE_SIZE]>;
 
+/// _(internals)_ Alias to [`thin_vec::ThinVec<T>`](https://crates.io/crates/thin_vec).
+/// Exported under the `internals` feature only.
+#[cfg(feature = "internals")]
+pub type ThinVec<T> = thin_vec::ThinVec<T>;
+
 /// Number of items to keep inline for [`FnArgsVec`].
 #[cfg(not(feature = "no_closure"))]
 const FN_ARGS_VEC_INLINE_SIZE: usize = 5;


### PR DESCRIPTION
Added alias to avoid importing [thinvec](https://docs.rs/thin-vec/latest/thin_vec/) separately as `Expr::InterpolatedString` accepts ThinVec now.