### PR TITLE
feat: range indexing on strings

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -530,6 +530,9 @@ impl Expr {
                             Self::IntegerConstant(ref start, ..),
                             Self::IntegerConstant(ref end, ..),
                         ) => (*start..*end).into(),
+                        (Self::IntegerConstant(ref start, ..), Self::Unit(..)) => {
+                            (*start..INT::MAX).into()
+                        }
                         _ => return None,
                     },
                     // x..=y
@@ -538,6 +541,9 @@ impl Expr {
                             Self::IntegerConstant(ref start, ..),
                             Self::IntegerConstant(ref end, ..),
                         ) => (*start..=*end).into(),
+                        (Self::IntegerConstant(ref start, ..), Self::Unit(..)) => {
+                            (*start..=INT::MAX).into()
+                        }
                         _ => return None,
                     },
                     _ => return None,

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -60,7 +60,10 @@ fn test_string_index() {
     // char index
     assert_eq!(engine.eval::<char>(r#"let y = "hello"; y[-4]"#).unwrap(), 'e');
 
-    // slice index
+    // range index
+
+    // range index returns a string
+    assert_eq!(engine.eval::<char>(r#"let y = "hello"; y[1..2]"#).unwrap_err().to_string(), "Output type incorrect: string (expecting char)");
 
     // 1..3
     assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[1..3]"#).unwrap(), "el");
@@ -105,7 +108,29 @@ fn test_string_index() {
     assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[1..=2] = "iii"; y"#).unwrap(), "hiiilo");
     assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[1..=2] = y[2..]; y"#).unwrap(), "hllolo");
 
+    // new string will not be affected by mut slice index on old string.
     assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[1..=2] = y[2..]; let s2 = y[1..]; s2[1..20] = "abc"; y"#).unwrap(), "hllolo");
+
+    assert_eq!(
+        engine
+            .eval::<String>(
+                r#"
+                    let y = "hello";
+                    let s2 = y[1..];
+                    s2[1..20] = "abc";
+                    if (s2 == "eabc") {
+                        y[2] = 'd';
+                    }
+                    y[3..] = "xyz";
+                    y[4] = '\u2764';
+                    y[6..] = "\u2764\u2764";
+                    
+                    y
+                "#
+            )
+            .unwrap(),
+        "hedx❤z❤❤"
+    );
 }
 #[test]
 fn test_string_dynamic() {

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -53,7 +53,60 @@ fn test_string() {
     #[cfg(not(feature = "no_float"))]
     assert_eq!(engine.eval::<String>(r#""foo" + 123.4556"#).unwrap(), "foo123.4556");
 }
+#[cfg(not(feature = "no_index"))]
+#[test]
+fn test_string_index() {
+    let engine = Engine::new();
+    // char index
+    assert_eq!(engine.eval::<char>(r#"let y = "hello"; y[-4]"#).unwrap(), 'e');
 
+    // slice index
+
+    // 1..3
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[1..3]"#).unwrap(), "el");
+    // 0..5
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[..]"#).unwrap(), "hello");
+    // 0..2
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[..2]"#).unwrap(), "he");
+    // 1..4
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[1..-1]"#).unwrap(), "ell");
+    // 1..1
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[1..-4]"#).unwrap(), "");
+    // 2..1
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[2..-4]"#).unwrap(), "");
+    // overflow index
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[0..18]"#).unwrap(), "hello");
+    // overflow negative index
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[2..-18]"#).unwrap(), "");
+
+    // inclusive range
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[1..=3]"#).unwrap(), "ell");
+    // 0..=5
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[..=]"#).unwrap(), "hello");
+    // 0..=2
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[..=2]"#).unwrap(), "hel");
+    // 1..=4
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[1..=-1]"#).unwrap(), "ello");
+    // 1..=1
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[1..=-4]"#).unwrap(), "");
+    // 2..=1
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[2..-4]"#).unwrap(), "");
+    // overflow index
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[0..18]"#).unwrap(), "hello");
+    // overflow negative index
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[2..-18]"#).unwrap(), "");
+
+    // mut slice index
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[1] = 'i'; y"#).unwrap(), "hillo");
+    // mut slice index
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[1..2] = "i"; y"#).unwrap(), "hillo");
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[1..3] = "i"; y"#).unwrap(), "hilo");
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[1..3] = "iii"; y"#).unwrap(), "hiiilo");
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[1..=2] = "iii"; y"#).unwrap(), "hiiilo");
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[1..=2] = y[2..]; y"#).unwrap(), "hllolo");
+
+    assert_eq!(engine.eval::<String>(r#"let y = "hello"; y[1..=2] = y[2..]; let s2 = y[1..]; s2[1..20] = "abc"; y"#).unwrap(), "hllolo");
+}
 #[test]
 fn test_string_dynamic() {
     let engine = Engine::new();


### PR DESCRIPTION
Now we support range indexing on strings, including ref/mut impls.

For example, you can use range indexing intead of sub_of_string() method like bellow:

```rust
let s1 = "abcde";
let s2 = s1[1..4]; // "bcd"
s1[1..4] = "f"; // s1: "afe", s2: "bcd"
```

Close #841