### PR TITLE
Replace update_fn_comments with get_fn_metadata_mut.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Bug fixes
 * The position of an undefined operation call now points to the operator instead of the first operand.
 * The `optimize` command in `rhai-repl` now works properly and cycles through `None`->`Simple`->`Full`.
 * `Engine::call_fn_XXX` no longer return errors unnecessarily wrapped in `EvalAltResult::ErrorInFunctionCall`.
+* Some tests that panic on 32-bit architecture are fixed.
 
 Deprecated API's
 ----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ New features
 * New options `Engine::set_max_strings_interned` and `Engine::max_strings_interned` are added to limit the maximum number of strings interned in the `Engine`'s string interner.
 * A new advanced callback, `Engine::on_invalid_array_index`, is added (gated under the `internals` feature) to handle access to missing properties in object maps.
 * A new advanced callback, `Engine::on_missing_map_property`, is added (gated under the `internals` feature) to handle out-of-bound index into arrays.
+* Doc-comments are now automatically added to function registrations and custom types via the `CustomType` derive macro.
 
 Enhancements
 ------------

--- a/codegen/ui_tests/rhai_mod_inner_cfg_false.stderr
+++ b/codegen/ui_tests/rhai_mod_inner_cfg_false.stderr
@@ -3,3 +3,10 @@ error[E0433]: failed to resolve: could not find `test_mod` in `test_module`
    |
 24 |     if test_module::test_mod::test_fn(n) {
    |                     ^^^^^^^^ could not find `test_mod` in `test_module`
+   |
+note: found an item that was configured out
+  --> ui_tests/rhai_mod_inner_cfg_false.rs:12:13
+   |
+12 |     pub mod test_mod {
+   |             ^^^^^^^^
+   = note: the item is gated behind the `unset_feature` feature

--- a/src/bin/rhai-repl.rs
+++ b/src/bin/rhai-repl.rs
@@ -563,7 +563,6 @@ fn main() {
             .compile_with_scope(&scope, &input)
             .map_err(Into::into)
             .and_then(|r| {
-                println!("AST: {r:#?}");
                 #[cfg(not(feature = "no_optimize"))]
                 {
                     ast_u = r.clone();

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -1483,20 +1483,14 @@ impl Module {
         self
     }
 
-    /// _(metadata)_ Update the comments of a registered function.
-    /// Exported under the `metadata` feature only.
-    #[cfg(feature = "metadata")]
+    /// Get a registered function's metadata.
     #[inline]
-    pub(crate) fn update_fn_comments<S: AsRef<str>>(
-        &mut self,
-        hash_fn: u64,
-        comments: impl IntoIterator<Item = S>,
-    ) -> &mut Self {
-        if let Some((_, f)) = self.functions.as_mut().and_then(|m| m.get_mut(&hash_fn)) {
-            f.comments = comments.into_iter().map(|s| s.as_ref().into()).collect();
-        }
-
-        self
+    #[allow(dead_code)]
+    pub(crate) fn get_fn_metadata_mut(&mut self, hash_fn: u64) -> Option<&mut FuncMetadata> {
+        self.functions
+            .as_mut()
+            .and_then(|m| m.get_mut(&hash_fn))
+            .map(|(_, f)| f.as_mut())
     }
 
     /// Remap type ID.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15,7 +15,16 @@ fn check_struct_sizes() {
     ));
     const WORD_SIZE: usize = size_of::<usize>();
 
-    assert_eq!(size_of::<Dynamic>(), if PACKED { 8 } else { 16 });
+    assert_eq!(
+        size_of::<Dynamic>(),
+        if PACKED {
+            8
+        } else if IS_32_BIT {
+            12
+        } else {
+            16
+        }
+    );
     assert_eq!(size_of::<Option<Dynamic>>(), if PACKED { 8 } else { 16 });
     assert_eq!(
         size_of::<Position>(),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -25,12 +25,32 @@ fn check_struct_sizes() {
             16
         }
     );
-    assert_eq!(size_of::<Option<Dynamic>>(), if PACKED { 8 } else { 16 });
+    assert_eq!(
+        size_of::<Option<Dynamic>>(),
+        if PACKED {
+            8
+        } else if IS_32_BIT {
+            12
+        } else {
+            16
+        }
+    );
     assert_eq!(
         size_of::<Position>(),
         if cfg!(feature = "no_position") { 0 } else { 4 }
     );
-    assert_eq!(size_of::<tokenizer::Token>(), 2 * WORD_SIZE);
+    assert_eq!(
+        size_of::<tokenizer::Token>(),
+        if IS_32_BIT {
+            if cfg!(feature = "only_i32") {
+                2 * WORD_SIZE
+            } else {
+                3 * WORD_SIZE
+            }
+        } else {
+            2 * WORD_SIZE
+        }
+    );
     assert_eq!(size_of::<ast::Expr>(), if PACKED { 12 } else { 16 });
     assert_eq!(size_of::<Option<ast::Expr>>(), if PACKED { 12 } else { 16 });
     assert_eq!(size_of::<ast::Stmt>(), if IS_32_BIT { 12 } else { 16 });


### PR DESCRIPTION
`update_fn_comments` is replaced by the potentially more useful `get_fn_metadata_mut` which allows changing other fields in `FuncMetadata`.
