### PR TITLE
Make `Dynamic::try_cast_raw` public

### DIFF
--- a/src/api/call_fn.rs
+++ b/src/api/call_fn.rs
@@ -183,7 +183,7 @@ impl Engine {
             options,
         )
         .and_then(|result| {
-            result.try_cast_raw().map_err(|r| {
+            result.try_cast_result().map_err(|r| {
                 let result_type = self.map_type_name(r.type_name());
                 let cast_type = match type_name::<T>() {
                     typ if typ.contains("::") => self.map_type_name(typ),

--- a/src/api/eval.rs
+++ b/src/api/eval.rs
@@ -198,7 +198,7 @@ impl Engine {
             return Ok(reify! { result => T });
         }
 
-        result.try_cast_raw::<T>().map_err(|v| {
+        result.try_cast_result::<T>().map_err(|v| {
             let typename = match type_name::<T>() {
                 typ if typ.contains("::") => self.map_type_name(typ),
                 typ => typ,

--- a/src/eval/stmt.rs
+++ b/src/eval/stmt.rs
@@ -903,7 +903,7 @@ impl Engine {
 
                 let v = self.eval_expr(global, caches, scope, this_ptr, expr)?;
 
-                let path = v.try_cast_raw::<crate::ImmutableString>().map_err(|v| {
+                let path = v.try_cast_result::<crate::ImmutableString>().map_err(|v| {
                     self.make_type_mismatch_err::<crate::ImmutableString>(
                         v.type_name(),
                         expr.position(),

--- a/src/func/call.rs
+++ b/src/func/call.rs
@@ -791,12 +791,15 @@ impl Engine {
                 }
 
                 // FnPtr call on object
-                let fn_ptr = call_args[0].take().try_cast_raw::<FnPtr>().map_err(|v| {
-                    self.make_type_mismatch_err::<FnPtr>(
-                        self.map_type_name(v.type_name()),
-                        first_arg_pos,
-                    )
-                })?;
+                let fn_ptr = call_args[0]
+                    .take()
+                    .try_cast_result::<FnPtr>()
+                    .map_err(|v| {
+                        self.make_type_mismatch_err::<FnPtr>(
+                            self.map_type_name(v.type_name()),
+                            first_arg_pos,
+                        )
+                    })?;
 
                 #[cfg(not(feature = "no_function"))]
                 let (
@@ -1033,7 +1036,7 @@ impl Engine {
                 let (first_arg_value, first_arg_pos) =
                     self.get_arg_value(global, caches, scope, this_ptr.as_deref_mut(), arg)?;
 
-                let fn_ptr = first_arg_value.try_cast_raw::<FnPtr>().map_err(|v| {
+                let fn_ptr = first_arg_value.try_cast_result::<FnPtr>().map_err(|v| {
                     self.make_type_mismatch_err::<FnPtr>(
                         self.map_type_name(v.type_name()),
                         first_arg_pos,
@@ -1128,7 +1131,7 @@ impl Engine {
                 let (first_arg_value, first_arg_pos) =
                     self.get_arg_value(global, caches, scope, this_ptr.as_deref_mut(), first)?;
 
-                let mut fn_ptr = first_arg_value.try_cast_raw::<FnPtr>().map_err(|v| {
+                let mut fn_ptr = first_arg_value.try_cast_result::<FnPtr>().map_err(|v| {
                     self.make_type_mismatch_err::<FnPtr>(
                         self.map_type_name(v.type_name()),
                         first_arg_pos,

--- a/src/func/native.rs
+++ b/src/func/native.rs
@@ -296,7 +296,7 @@ impl<'a> NativeCallContext<'a> {
 
         self._call_fn_raw(fn_name, args, false, false, false)
             .and_then(|result| {
-                result.try_cast_raw().map_err(|r| {
+                result.try_cast_result().map_err(|r| {
                     let result_type = self.engine().map_type_name(r.type_name());
                     let cast_type = match type_name::<T>() {
                         typ if typ.contains("::") => self.engine.map_type_name(typ),
@@ -329,7 +329,7 @@ impl<'a> NativeCallContext<'a> {
 
         self._call_fn_raw(fn_name, args, true, false, false)
             .and_then(|result| {
-                result.try_cast_raw().map_err(|r| {
+                result.try_cast_result().map_err(|r| {
                     let result_type = self.engine().map_type_name(r.type_name());
                     let cast_type = match type_name::<T>() {
                         typ if typ.contains("::") => self.engine.map_type_name(typ),

--- a/src/types/dynamic.rs
+++ b/src/types/dynamic.rs
@@ -1441,7 +1441,7 @@ impl Dynamic {
     #[must_use]
     #[allow(unused_mut)]
     pub fn try_cast<T: Any>(mut self) -> Option<T> {
-        self.try_cast_raw().ok()
+        self.try_cast_result().ok()
     }
     /// Convert the [`Dynamic`] value into specific type.
     ///
@@ -1463,7 +1463,7 @@ impl Dynamic {
     ///
     /// These normally shouldn't occur since most operations in Rhai are single-threaded.
     #[allow(unused_mut)]
-    pub(crate) fn try_cast_raw<T: Any>(mut self) -> Result<T, Self> {
+    pub fn try_cast_result<T: Any>(mut self) -> Result<T, Self> {
         // Coded this way in order to maximally leverage potentials for dead-code removal.
 
         #[cfg(not(feature = "no_closure"))]

--- a/src/types/fn_ptr.rs
+++ b/src/types/fn_ptr.rs
@@ -163,7 +163,7 @@ impl FnPtr {
         let ctx = (engine, self.fn_name(), None, &*global, Position::NONE).into();
 
         self.call_raw(&ctx, None, arg_values).and_then(|result| {
-            result.try_cast_raw().map_err(|r| {
+            result.try_cast_result().map_err(|r| {
                 let result_type = engine.map_type_name(r.type_name());
                 let cast_type = match type_name::<T>() {
                     typ if typ.contains("::") => engine.map_type_name(typ),
@@ -190,7 +190,7 @@ impl FnPtr {
         args.parse(&mut arg_values);
 
         self.call_raw(context, None, arg_values).and_then(|result| {
-            result.try_cast_raw().map_err(|r| {
+            result.try_cast_result().map_err(|r| {
                 let result_type = context.engine().map_type_name(r.type_name());
                 let cast_type = match type_name::<T>() {
                     typ if typ.contains("::") => context.engine().map_type_name(typ),


### PR DESCRIPTION
This function is useful for error-reporting. With `try_cast`, one has to do one of the following:
1. Pre-clone the `Dynamic`.
2. Check `Dynamic::is` first, and still handle the `None` case of `try_cast`.