### PR TITLE
Silence some compiler warnings about unused imports

### DIFF
--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,6 +1,6 @@
 #![cfg(not(feature = "no_index"))]
-use rhai::{Array, Dynamic, Engine, EvalAltResult, ParseErrorType, Position, INT};
-use std::{convert::TryInto, iter::FromIterator};
+use rhai::{Array, Dynamic, Engine, ParseErrorType, INT};
+use std::iter::FromIterator;
 
 #[test]
 fn test_arrays() {
@@ -504,6 +504,9 @@ fn test_arrays_elvis() {
 #[test]
 #[cfg(feature = "internals")]
 fn test_array_invalid_index_callback() {
+    use rhai::{EvalAltResult, Position};
+    use std::convert::TryInto;
+
     let mut engine = Engine::new();
 
     engine.on_invalid_array_index(|arr, index, _| match index {

--- a/tests/custom_syntax.rs
+++ b/tests/custom_syntax.rs
@@ -1,6 +1,6 @@
 #![cfg(not(feature = "no_custom_syntax"))]
 
-use rhai::{Dynamic, Engine, EvalAltResult, FnPtr, ImmutableString, LexError, ParseErrorType, Position, Scope, INT};
+use rhai::{Dynamic, Engine, EvalAltResult, ImmutableString, LexError, ParseErrorType, Position, Scope, INT};
 
 #[test]
 fn test_custom_syntax() {

--- a/tests/maps.rs
+++ b/tests/maps.rs
@@ -1,6 +1,5 @@
 #![cfg(not(feature = "no_object"))]
-use rhai::{Dynamic, Engine, EvalAltResult, Map, ParseErrorType, Position, Scope, INT};
-use std::convert::TryInto;
+use rhai::{Engine, EvalAltResult, Map, ParseErrorType, Scope, INT};
 
 #[test]
 fn test_map_indexing() {
@@ -260,6 +259,9 @@ fn test_map_oop() {
 #[test]
 #[cfg(feature = "internals")]
 fn test_map_missing_property_callback() {
+    use rhai::{Dynamic, Position};
+    use std::convert::TryInto;
+
     let mut engine = Engine::new();
 
     engine.on_map_missing_property(|map, prop, _| match prop {

--- a/tests/optimizer.rs
+++ b/tests/optimizer.rs
@@ -1,5 +1,5 @@
 #![cfg(not(feature = "no_optimize"))]
-use rhai::{Engine, FuncRegistration, Module, OptimizationLevel, Scope, INT};
+use rhai::{Engine, FuncRegistration, OptimizationLevel, Scope, INT};
 
 #[test]
 fn test_optimizer() {
@@ -61,6 +61,8 @@ fn test_optimizer_run() {
 #[cfg(not(feature = "no_position"))]
 #[test]
 fn test_optimizer_parse() {
+    use rhai::Module;
+
     let mut engine = Engine::new();
 
     engine.set_optimization_level(OptimizationLevel::Simple);


### PR DESCRIPTION
While trying something with the tests I noticed that there're some unused import warnings which can easily be silenced.