### PR TITLE
Add web-time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,8 @@ codegen-units = 1
 #panic = 'abort'     # remove stack backtrace for no-std
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-web-time = { version = "1.1.0" }# WASM implementation of std::time::Instant
+[target.'cfg(not(feature = "no_time"))'.dependencies]
+web-time = { version = "1.1.0" ,optional = true}# WASM implementation of std::time::Instant
 
 [package.metadata.docs.rs]
 features = ["document-features", "metadata", "serde", "internals", "decimal", "debugging"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,9 +118,9 @@ no_std = ["no-std-compat", "num-traits/libm", "core-error", "libm", "hashbrown",
 #! ### JavaScript Interface for WASM
 
 ## Use [`wasm-bindgen`](https://crates.io/crates/wasm-bindgen) as JavaScript interface.
-wasm-bindgen = ["getrandom/js", "instant/wasm-bindgen"]
+wasm-bindgen = ["getrandom/js"]
 ## Use [`stdweb`](https://crates.io/crates/stdweb) as JavaScript interface.
-stdweb = ["getrandom/js", "instant/stdweb"]
+stdweb = ["getrandom/js"]
 
 #! ### Features used in testing environments only
 
@@ -156,7 +156,7 @@ codegen-units = 1
 #panic = 'abort'     # remove stack backtrace for no-std
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-instant = { version = "0.1.10" } # WASM implementation of std::time::Instant
+web-time = { version = "1.1.0" }# WASM implementation of std::time::Instant
 
 [package.metadata.docs.rs]
 features = ["document-features", "metadata", "serde", "internals", "decimal", "debugging"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,9 +155,8 @@ codegen-units = 1
 #opt-level = "z"     # optimize for size
 #panic = 'abort'     # remove stack backtrace for no-std
 
-[target.'cfg(target_family = "wasm")'.dependencies]
-[target.'cfg(not(feature = "no_time"))'.dependencies]
-web-time = { version = "1.1.0" ,optional = true}# WASM implementation of std::time::Instant
+[target.'cfg(all(target_family = "wasm", not(feature = "no_time")))'.dependencies]
+web-time = { version = "1.1.0" }# WASM implementation of std::time::Instant
 
 [package.metadata.docs.rs]
 features = ["document-features", "metadata", "serde", "internals", "decimal", "debugging"]

--- a/src/packages/time_basic.rs
+++ b/src/packages/time_basic.rs
@@ -11,7 +11,7 @@ use crate::FLOAT;
 use std::time::{Duration, Instant};
 
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
-use instant::{Duration, Instant};
+use web_time::{Duration, Instant};
 
 def_package! {
     /// Package of basic timing utilities.

--- a/src/types/dynamic.rs
+++ b/src/types/dynamic.rs
@@ -20,7 +20,7 @@ pub use std::time::Instant;
 
 #[cfg(not(feature = "no_time"))]
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
-pub use instant::Instant;
+pub use web_time::Instant;
 
 #[cfg(not(feature = "no_index"))]
 use crate::{Array, Blob};


### PR DESCRIPTION
according to https://github.com/rhaiscript/rhai/issues/891, since [instant](https://crates.io/crates/instant) is no longer maintained, we should use [web-time](https://crates.io/crates/web-time) to replace it. Actually I have built WASM to make sure it works in it, but it seems that I don't find unit tests for WASM.