### PR TITLE
Added rust-style raw string syntax support for the Rhai Tokenizer

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1199,22 +1199,12 @@ pub trait InputStream {
 /// |`r"hello"`                 |`StringConstant("hello")`            |
 /// |`r"hello`_{EOF}_           |`LexError`                           |
 /// |`r#" "hello" "`_{EOF}_     |`LexError`                           |
-/// |`r#""hello""#`             |`StringConstant(""hello"")`          |
+/// |`r#""hello""#`             |`StringConstant("\"hello\"")`        |
 /// |`r##"hello #"# world"##`   |`StringConstant("hello #\"# world")` |
 /// |`r"R"`                     |`StringConstant("R")`                |
-/// |`r"\x52"`                  |`StringConstant("\x52")`             |
+/// |`r"\x52"`                  |`StringConstant("\\x52")`            |
 ///
-/// This function does not throw a `LexError` for the following conditions:
-///
-/// * Unterminated literal string at _{EOF}_
-///
-/// * Unterminated normal string with continuation at _{EOF}_
-///
-/// This is to facilitate using this function to parse a script line-by-line, where the end of the
-/// line (i.e. _{EOF}_) is not necessarily the end of the script.
-///
-/// Any time a [`StringConstant`][`Token::StringConstant`] is returned with
-/// `state.is_within_text_terminated_by` set to `Some(_)` is one of the above conditions.
+/// This function throws a `LexError` for an unterminated literal string at _{EOF}_.
 pub fn parse_raw_string_literal(
     stream: &mut (impl InputStream + ?Sized),
     state: &mut TokenizeState,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1224,27 +1224,22 @@ pub fn parse_raw_string_literal(
     match stream.get_next() {
         Some('"') => pos.advance(),
         Some(c) => return Err((LERR::UnexpectedInput(c.to_string()), start)),
-        None => {
-            return Err((LERR::UnterminatedString, start));
-        }
+        None => return Err((LERR::UnterminatedString, start))
     }
 
-    let mut seen_hashes: Option<u8> = None;
     // Match everything until the same number of '#'s are seen, prepended by a '"'
+
+    // Counts the number of '#' characters seen after a quotation mark.
+    // Becomes Some(0) after a quote is seen, but resets to None if a hash doesn't follow.
+    let mut seen_hashes: Option<u8> = None;
     let mut result = SmartString::new_const();
+
 
     loop {
         let next_char = match stream.get_next() {
-            Some(ch) => {
-                pos.advance();
-                ch
-            }
-            None => {
-                pos.advance();
-                return Err((LERR::UnterminatedString, start));
-            }
+            Some(ch) => ch,
+            None => return Err((LERR::UnterminatedString, start))
         };
-        pos.advance();
 
         match (next_char, &mut seen_hashes) {
             // Begin attempt to close string
@@ -1282,9 +1277,7 @@ pub fn parse_raw_string_literal(
                 seen_hashes = None;
             }
             // Normal new character seen
-            (c, None) => {
-                result.push(c);
-            }
+            (c, None) => result.push(c)
         }
 
         if next_char == '\n' {
@@ -1324,7 +1317,7 @@ pub fn parse_raw_string_literal(
 /// |`` `hello``_{LF}{EOF}_           |`StringConstant("hello\n")` |``Some('`')``                       |
 /// |`` `hello ${``                   |`InterpolatedString("hello ")`<br/>next token is `{`|`None`      |
 /// |`` } hello` ``                   |`StringConstant(" hello")`  |`None`                              |
-/// |`} hello`_{EOF}_                 |`StringConstant(" hello")`  |``Some('`')``                       |                            |
+/// |`} hello`_{EOF}_                 |`StringConstant(" hello")`  |``Some('`')``                       |
 ///
 /// This function does not throw a `LexError` for the following conditions:
 ///

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -17,6 +17,9 @@ fn test_string() {
     assert_eq!(engine.eval::<String>("     `\r\nTest string: \\u2764\nhello,\\nworld!`").unwrap(), "Test string: \\u2764\nhello,\\nworld!");
     assert_eq!(engine.eval::<String>(r#""Test string: \x58""#).unwrap(), "Test string: X");
     assert_eq!(engine.eval::<String>(r#""\"hello\"""#).unwrap(), r#""hello""#);
+    assert_eq!(engine.eval::<String>(r#"r"Test""#).unwrap(), "Test");
+    assert_eq!(engine.eval::<String>(r##"r"Test string: \\u2764\nhello,\nworld!""##).unwrap(), r"Test string: \\u2764\nhello,\nworld!");
+    assert_eq!(engine.eval::<String>(r###"r##"Test string: r#"\\u2764\nhello,\\nworld!"#"##"###).unwrap(), r##"Test string: r#"\\u2764\nhello,\\nworld!"#"##);
 
     assert_eq!(engine.eval::<String>(r#""foo" + "bar""#).unwrap(), "foobar");
 

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -1,4 +1,4 @@
-use rhai::{Engine, EvalAltResult, ImmutableString, Scope, INT};
+use rhai::{Engine, EvalAltResult, ImmutableString, LexError, ParseErrorType, Position, Scope, INT};
 
 #[test]
 fn test_string() {
@@ -18,8 +18,28 @@ fn test_string() {
     assert_eq!(engine.eval::<String>(r#""Test string: \x58""#).unwrap(), "Test string: X");
     assert_eq!(engine.eval::<String>(r#""\"hello\"""#).unwrap(), r#""hello""#);
     assert_eq!(engine.eval::<String>(r#"r"Test""#).unwrap(), "Test");
-    assert_eq!(engine.eval::<String>(r##"r"Test string: \\u2764\nhello,\nworld!""##).unwrap(), r"Test string: \\u2764\nhello,\nworld!");
+    assert_eq!(engine.eval::<String>(r#"r"Test string: \\u2764\nhello,\nworld!""#).unwrap(), r#"Test string: \\u2764\nhello,\nworld!"#);
     assert_eq!(engine.eval::<String>(r###"r##"Test string: r#"\\u2764\nhello,\\nworld!"#"##"###).unwrap(), r##"Test string: r#"\\u2764\nhello,\\nworld!"#"##);
+    assert_eq!(engine.eval::<String>(r###"r##"Test string: "## + "\u2764""###).unwrap(), "Test string: ❤");
+    let bad_result = *engine.eval::<String>(r###"r#"Test string: \"##"###).unwrap_err();
+    if let EvalAltResult::ErrorParsing(parse_error, pos) = bad_result {
+        assert_eq!(parse_error, ParseErrorType::UnknownOperator("#".to_string()));
+        assert_eq!(pos, Position::new(1, 19));
+    } else {
+        panic!("Wrong error type: {}", bad_result);
+    }
+    let bad_result = *engine
+        .eval::<String>(
+            r###"r##"Test string:
+    \"#"###,
+        )
+        .unwrap_err();
+    if let EvalAltResult::ErrorParsing(parse_error, pos) = bad_result {
+        assert_eq!(parse_error, ParseErrorType::BadInput(LexError::UnterminatedString));
+        assert_eq!(pos, Position::new(1, 1));
+    } else {
+        panic!("Wrong error type: {}", bad_result);
+    }
 
     assert_eq!(engine.eval::<String>(r#""foo" + "bar""#).unwrap(), "foobar");
 


### PR DESCRIPTION
Added support for [Rust-style raw-string literal syntax](https://doc.rust-lang.org/reference/tokens.html#raw-string-literals) in Rhai.

Example:
```rust
let example_raw_string: string = r##"I can use quotes and / and even one "# without escaping this string
How about we put a newline in it too!"##;
```