### PR TITLE
Use Locked constructor instead of into

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -35,7 +35,7 @@ pub mod deprecated;
 
 use crate::func::{locked_read, locked_write};
 use crate::types::StringsInterner;
-use crate::{Dynamic, Engine, Identifier};
+use crate::{Dynamic, Engine, Identifier, Locked};
 
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
@@ -63,7 +63,7 @@ impl Engine {
                 guard.set_max(max);
             }
         } else {
-            self.interned_strings = Some(StringsInterner::new(max).into());
+            self.interned_strings = Some(Locked::new(StringsInterner::new(max)));
         }
         self
     }


### PR DESCRIPTION
I don't know why but when I was building this lib for my little micro controller in no_std, I was getting this error:

```
error[E0277]: the trait bound `RwLock<StringsInterner>: core::convert::From<StringsInterner>` is not satisfied
  --> /Users/katzen/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rhai-1.19.0/src/api/mod.rs:66:68
   |
66 |             self.interned_strings = Some(StringsInterner::new(max).into());
   |                                                                    ^^^^ the trait `core::convert::From<StringsInterner>` is not implemented for `RwLock<StringsInterner>`, which is required by `StringsInterner: core::convert::Into<_>`
   |
   = note: required for `StringsInterner` to implement `core::convert::Into<RwLock<StringsInterner>>`
```

So I tried just pulling in the Locked type and using that instead. Seemed to fix things.

Here is my a snippet of my dependency list if it's interesting:

```toml
[dependencies]
# TODO: had to add this because rhai isn't requesting a feature it relies on.
once_cell = { version = "1.19.0", default-features = false, features = [
    "alloc",
] }
# https://rhai.rs/book/start/builds/minimal.html
rhai = { version = "1.19.0", default-features = false, features = [
    "no_std",
    "sync",
    "only_i32",
    "f32_float",
    "no_custom_syntax",
    "no_time",
] }
```