### PR TITLE
Add support for serializing/deserializing AST statements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,8 @@ debugging = ["internals"]
 bin-features = ["decimal", "metadata", "serde", "debugging", "rustyline"]
 ## Enable fuzzing via the [`arbitrary`](https://crates.io/crates/arbitrary) crate.
 fuzz = ["arbitrary", "rust_decimal/rust-fuzz", "serde"]
+## Enable serialization/deserialization of AST.
+ast_serde = ["serde","bitflags/serde"]
 
 #! ### System Configuration Features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ bin-features = ["decimal", "metadata", "serde", "debugging", "rustyline"]
 ## Enable fuzzing via the [`arbitrary`](https://crates.io/crates/arbitrary) crate.
 fuzz = ["arbitrary", "rust_decimal/rust-fuzz", "serde"]
 ## Enable serialization/deserialization of AST.
-ast_serde = ["serde","bitflags/serde"]
+ast-serde = ["internals","serde","bitflags/serde"]
 
 #! ### System Configuration Features
 

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -23,6 +23,7 @@ use std::{
 /// _(internals)_ A binary expression.
 /// Exported under the `internals` feature only.
 #[derive(Debug, Clone, Hash, Default)]
+#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BinaryExpr {
     /// LHS expression.
     pub lhs: Expr,
@@ -36,6 +37,7 @@ pub struct BinaryExpr {
 /// Not available under `no_custom_syntax`.
 #[cfg(not(feature = "no_custom_syntax"))]
 #[derive(Debug, Clone, Hash)]
+#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CustomExpr {
     /// List of keywords.
     pub inputs: FnArgsVec<Expr>,
@@ -90,6 +92,7 @@ impl CustomExpr {
 ///   name plus the types of the arguments.  This is due to possible function overloading for
 ///   different parameter types.
 #[derive(Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FnCallHashes {
     /// Pre-calculated hash for a script-defined function ([`None`] if native functions only).
     #[cfg(not(feature = "no_function"))]
@@ -182,6 +185,7 @@ impl FnCallHashes {
 /// _(internals)_ A function call.
 /// Exported under the `internals` feature only.
 #[derive(Clone, Hash)]
+#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FnCallExpr {
     /// Namespace of the function, if any.
     #[cfg(not(feature = "no_module"))]
@@ -255,6 +259,7 @@ impl FnCallExpr {
 #[derive(Clone, Hash)]
 #[non_exhaustive]
 #[allow(clippy::type_complexity)]
+#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Expr {
     /// Dynamic constant.
     ///

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -23,7 +23,7 @@ use std::{
 /// _(internals)_ A binary expression.
 /// Exported under the `internals` feature only.
 #[derive(Debug, Clone, Hash, Default)]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BinaryExpr {
     /// LHS expression.
     pub lhs: Expr,
@@ -37,7 +37,7 @@ pub struct BinaryExpr {
 /// Not available under `no_custom_syntax`.
 #[cfg(not(feature = "no_custom_syntax"))]
 #[derive(Debug, Clone, Hash)]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CustomExpr {
     /// List of keywords.
     pub inputs: FnArgsVec<Expr>,
@@ -92,7 +92,7 @@ impl CustomExpr {
 ///   name plus the types of the arguments.  This is due to possible function overloading for
 ///   different parameter types.
 #[derive(Clone, Copy, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FnCallHashes {
     /// Pre-calculated hash for a script-defined function ([`None`] if native functions only).
     #[cfg(not(feature = "no_function"))]
@@ -185,7 +185,7 @@ impl FnCallHashes {
 /// _(internals)_ A function call.
 /// Exported under the `internals` feature only.
 #[derive(Clone, Hash)]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FnCallExpr {
     /// Namespace of the function, if any.
     #[cfg(not(feature = "no_module"))]
@@ -259,7 +259,7 @@ impl FnCallExpr {
 #[derive(Clone, Hash)]
 #[non_exhaustive]
 #[allow(clippy::type_complexity)]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Expr {
     /// Dynamic constant.
     ///

--- a/src/ast/flags.rs
+++ b/src/ast/flags.rs
@@ -44,6 +44,7 @@ bitflags! {
     /// _(internals)_ Bit-flags containing [`AST`][crate::AST] node configuration options.
     /// Exported under the `internals` feature only.
     #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+    #[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize),serde(transparent))]
     pub struct ASTFlags: u8 {
         /// The [`AST`][crate::AST] node is read-only.
         const CONSTANT = 0b_0000_0001;

--- a/src/ast/flags.rs
+++ b/src/ast/flags.rs
@@ -44,7 +44,7 @@ bitflags! {
     /// _(internals)_ Bit-flags containing [`AST`][crate::AST] node configuration options.
     /// Exported under the `internals` feature only.
     #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
-    #[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize),serde(transparent))]
+    #[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize),serde(transparent))]
     pub struct ASTFlags: u8 {
         /// The [`AST`][crate::AST] node is read-only.
         const CONSTANT = 0b_0000_0001;

--- a/src/ast/ident.rs
+++ b/src/ast/ident.rs
@@ -8,6 +8,7 @@ use std::{borrow::Borrow, fmt, hash::Hash};
 /// _(internals)_ An identifier containing a name and a [position][Position].
 /// Exported under the `internals` feature only.
 #[derive(Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Ident {
     /// Identifier name.
     pub name: ImmutableString,

--- a/src/ast/ident.rs
+++ b/src/ast/ident.rs
@@ -8,7 +8,7 @@ use std::{borrow::Borrow, fmt, hash::Hash};
 /// _(internals)_ An identifier containing a name and a [position][Position].
 /// Exported under the `internals` feature only.
 #[derive(Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Ident {
     /// Identifier name.
     pub name: ImmutableString,

--- a/src/ast/namespace.rs
+++ b/src/ast/namespace.rs
@@ -19,6 +19,7 @@ use std::{fmt, num::NonZeroUsize};
 /// one level, and it is wasteful to always allocate a [`Vec`] with one element.
 #[derive(Clone, Eq, PartialEq, Default, Hash)]
 #[non_exhaustive]
+#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Namespace {
     /// Path segments.
     pub path: StaticVec<Ident>,

--- a/src/ast/namespace.rs
+++ b/src/ast/namespace.rs
@@ -19,7 +19,7 @@ use std::{fmt, num::NonZeroUsize};
 /// one level, and it is wasteful to always allocate a [`Vec`] with one element.
 #[derive(Clone, Eq, PartialEq, Default, Hash)]
 #[non_exhaustive]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Namespace {
     /// Path segments.
     pub path: StaticVec<Ident>,

--- a/src/ast/stmt.rs
+++ b/src/ast/stmt.rs
@@ -40,7 +40,7 @@ pub struct OpAssignment {
     pos: Position,
 }
 
-#[cfg(feature = "ast_serde")]
+#[cfg(feature = "ast-serde")]
 impl serde::Serialize for OpAssignment {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -54,10 +54,10 @@ impl serde::Serialize for OpAssignment {
     } 
 }
 
-#[cfg(feature = "ast_serde")]
+#[cfg(feature = "ast-serde")]
 struct OpAssignmentVisitor;
 
-#[cfg(feature = "ast_serde")]
+#[cfg(feature = "ast-serde")]
 impl<'de> serde::de::Visitor<'de> for OpAssignmentVisitor {
     type Value = OpAssignment;
     #[inline(always)]
@@ -117,7 +117,7 @@ impl<'de> serde::de::Visitor<'de> for OpAssignmentVisitor {
     }
 }
 
-#[cfg(feature = "ast_serde")]
+#[cfg(feature = "ast-serde")]
 impl<'de> serde::Deserialize<'de> for OpAssignment {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -269,7 +269,7 @@ impl fmt::Debug for OpAssignment {
 /// _(internals)_ A type containing a range case for a `switch` statement.
 /// Exported under the `internals` feature only.
 #[derive(Clone, Hash)]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum RangeCase {
     /// Exclusive range.
     ExclusiveInt(Range<INT>, usize),
@@ -418,7 +418,7 @@ pub type CaseBlocksList = smallvec::SmallVec<[usize; 2]>;
 /// _(internals)_ A type containing all cases for a `switch` statement.
 /// Exported under the `internals` feature only.
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwitchCasesCollection {
     /// List of conditional expressions: LHS = condition, RHS = expression.
     pub expressions: FnArgsVec<BinaryExpr>,
@@ -464,7 +464,7 @@ pub type StmtBlockContainer = crate::StaticVec<Stmt>;
 /// _(internals)_ A scoped block of statements.
 /// Exported under the `internals` feature only.
 #[derive(Clone, Hash, Default)]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StmtBlock {
     /// List of [statements][Stmt].
     block: StmtBlockContainer,
@@ -663,7 +663,7 @@ impl Extend<Stmt> for StmtBlock {
 ///
 /// Exported under the `internals` feature only.
 #[derive(Debug, Clone, Hash)]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FlowControl {
     /// Flow control expression.
     pub expr: Expr,
@@ -678,7 +678,7 @@ pub struct FlowControl {
 #[derive(Debug, Clone, Hash)]
 #[non_exhaustive]
 #[allow(clippy::type_complexity)]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Stmt {
     /// No-op.
     Noop(Position),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -60,7 +60,7 @@ pub type TokenStream<'a> = Peekable<TokenIterator<'a>>;
 /// Exported under the `internals` feature only.
 #[derive(Debug, PartialEq, Clone, Hash)]
 #[non_exhaustive]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Token {
     /// An `INT` constant.
     IntegerConstant(INT),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -60,6 +60,7 @@ pub type TokenStream<'a> = Peekable<TokenIterator<'a>>;
 /// Exported under the `internals` feature only.
 #[derive(Debug, PartialEq, Clone, Hash)]
 #[non_exhaustive]
+#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Token {
     /// An `INT` constant.
     IntegerConstant(INT),

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -17,7 +17,7 @@ use num_traits::float::FloatCore as Float;
 /// Not available under `no_float`.
 #[derive(Clone, Copy, Eq, PartialEq, PartialOrd)]
 #[must_use]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize),serde(transparent))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize),serde(transparent))]
 pub struct FloatWrapper<F>(F);
 
 impl Hash for FloatWrapper<crate::FLOAT> {

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -17,6 +17,7 @@ use num_traits::float::FloatCore as Float;
 /// Not available under `no_float`.
 #[derive(Clone, Copy, Eq, PartialEq, PartialOrd)]
 #[must_use]
+#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize),serde(transparent))]
 pub struct FloatWrapper<F>(F);
 
 impl Hash for FloatWrapper<crate::FLOAT> {

--- a/src/types/parse_error.rs
+++ b/src/types/parse_error.rs
@@ -14,7 +14,7 @@ use std::prelude::v1::*;
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
 #[non_exhaustive]
 #[must_use]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum LexError {
     /// An unexpected symbol is encountered.
     UnexpectedInput(String),

--- a/src/types/parse_error.rs
+++ b/src/types/parse_error.rs
@@ -14,6 +14,7 @@ use std::prelude::v1::*;
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
 #[non_exhaustive]
 #[must_use]
+#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum LexError {
     /// An unexpected symbol is encountered.
     UnexpectedInput(String),

--- a/src/types/position.rs
+++ b/src/types/position.rs
@@ -17,6 +17,7 @@ use std::{
 ///
 /// Advancing beyond the maximum line length or maximum number of lines is not an error but has no effect.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
+#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Position {
     /// Line number: 0 = none
     line: u16,
@@ -192,6 +193,7 @@ impl AddAssign for Position {
 /// _(internals)_ A span consisting of a starting and an ending [positions][Position].
 /// Exported under the `internals` feature only.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
+#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Span {
     /// Starting [position][Position].
     start: Position,

--- a/src/types/position.rs
+++ b/src/types/position.rs
@@ -17,7 +17,7 @@ use std::{
 ///
 /// Advancing beyond the maximum line length or maximum number of lines is not an error but has no effect.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Position {
     /// Line number: 0 = none
     line: u16,
@@ -193,7 +193,7 @@ impl AddAssign for Position {
 /// _(internals)_ A span consisting of a starting and an ending [positions][Position].
 /// Exported under the `internals` feature only.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Span {
     /// Starting [position][Position].
     start: Position,

--- a/src/types/position_none.rs
+++ b/src/types/position_none.rs
@@ -11,7 +11,7 @@ use std::{
 
 /// A location (line number + character position) in the input script.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy, Default)]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Position;
 
 impl Position {
@@ -108,7 +108,7 @@ impl AddAssign for Position {
 /// _(internals)_ A span consisting of a starting and an ending [positions][Position].
 /// Exported under the `internals` feature only.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy, Default)]
-#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ast-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Span;
 
 impl Span {

--- a/src/types/position_none.rs
+++ b/src/types/position_none.rs
@@ -11,6 +11,7 @@ use std::{
 
 /// A location (line number + character position) in the input script.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy, Default)]
+#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Position;
 
 impl Position {
@@ -107,6 +108,7 @@ impl AddAssign for Position {
 /// _(internals)_ A span consisting of a starting and an ending [positions][Position].
 /// Exported under the `internals` feature only.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy, Default)]
+#[cfg_attr(feature = "ast_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Span;
 
 impl Span {


### PR DESCRIPTION
- Why?

[The Rhai book](https://rhai.rs/book/patterns/serialize-ast.html) has already explained that serializing an AST leads to larger storage cost and possibly slower restoring speed than recompiling the original script. Therefore, it is generally not recommended.

However, Serializing/deserializing AST may still be useful under certain conditions. For example, by distributing serialized ASTs instead of original scripts, you can prevent users from seeing the source code (especially when using a binary format), while Rhai scripts still work properly.

- Example

Cargo.toml

```toml
[package]
name = "rhai_ast_serde_test"
version = "0.1.0"
edition = "2021"

[dependencies]
serde = {version="1"}
serde_json = {version="1"}
rhai = { path = "../rhai" ,features=["ast-serde"]}
```

main.rs

```Rust
use rhai::{Engine, EvalAltResult, Stmt};

fn main() -> Result<(), Box<EvalAltResult>> {
    let script = "// Rhai script you want to run. For example:
let now = timestamp();
let x = 1_000_000;

print(\"Ready... Go!\");

while x > 0 {
    x -= 1;
}

print(`Finished. Run time = ${now.elapsed} seconds.`);";
    let engine = Engine::new();
    let ast = engine.compile(script)?;
    println!("=== Original AST ===");
    println!("{:?}", ast);
    let json = serde_json::to_string(ast.statements()).unwrap();
    println!("=== JSON ====");
    println!("{}", json);
    let stmts_restored = serde_json::from_str::<Vec<Stmt>>(&json).unwrap();
    let ast_restored = rhai::AST::new(stmts_restored, rhai::Module::default());
    println!("=== Restored AST ===");
    println!("{:?}", ast_restored);
    println!("=== Outputs ===");
    engine.run_ast(&ast_restored)?;

    Ok(())
}
```

- References

https://github.com/rhaiscript/rhai/issues/547

https://github.com/schungx/rhai/tree/ast_serde