### PR TITLE
fix extra newlines in raw strings

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1263,12 +1263,6 @@ pub fn parse_raw_string_literal(
         pos.advance();
 
         match (next_char, &mut seen_hashes) {
-            // New line
-            ('\n', _) => {
-                result.push('\n');
-                pos.new_line();
-            }
-
             // Begin attempt to close string
             ('"', None) => seen_hashes = Some(0),
             // Restart attempt to close string
@@ -1294,7 +1288,11 @@ pub fn parse_raw_string_literal(
                 result.push(c);
                 seen_hashes = None;
             }
-
+            // New line
+            ('\n', _) => {
+                result.push('\n');
+                pos.new_line();
+            }
             // Normal new character seen
             (c, None) => result.push(c),
         }

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -29,6 +29,15 @@ string: "## + "\u2764""###
             .unwrap(),
         "Test\nstring: ❤"
     );
+    assert_eq!(
+        engine
+            .eval::<String>(
+                r###"##"Test"
+string: "## + "\u2764""###
+            )
+            .unwrap(),
+        "Test\"\nstring: ❤"
+    );
     let bad_result = *engine.eval::<String>(r###"#"Test string: \"##"###).unwrap_err();
     if let EvalAltResult::ErrorParsing(parse_error, pos) = bad_result {
         assert_eq!(parse_error, ParseErrorType::UnknownOperator("#".to_string()));


### PR DESCRIPTION
fixes #941 

I wonder how it decides to call `pos.advance()` and `pos.newline()`