### PR TITLE
Use alloc for `Shared` type

### DIFF
--- a/src/func/native.rs
+++ b/src/func/native.rs
@@ -30,10 +30,10 @@ impl<T> SendSync for T {}
 
 /// Immutable reference-counted container.
 #[cfg(not(feature = "sync"))]
-pub use std::rc::Rc as Shared;
+pub use alloc::rc::Rc as Shared;
 /// Immutable reference-counted container.
 #[cfg(feature = "sync")]
-pub use std::sync::Arc as Shared;
+pub use alloc::sync::Arc as Shared;
 
 /// Synchronized shared object.
 #[cfg(not(feature = "sync"))]

--- a/src/func/native.rs
+++ b/src/func/native.rs
@@ -30,9 +30,16 @@ impl<T> SendSync for T {}
 
 /// Immutable reference-counted container.
 #[cfg(not(feature = "sync"))]
+// TODO: Further audit no_std compatibility
+// When building with no_std + sync features, explicit imports from alloc
+// are needed despite using no_std_compat. This fixed compilation errors
+// around missing trait implementations for some users.
 pub use alloc::rc::Rc as Shared;
 /// Immutable reference-counted container.
 #[cfg(feature = "sync")]
+// TODO: Further audit no_std compatibility
+// While no_std_compat should map std::sync::Arc to alloc::sync::Arc,
+// there appear to be cases where this mapping fails.
 pub use alloc::sync::Arc as Shared;
 
 /// Synchronized shared object.


### PR DESCRIPTION
fixes https://github.com/rhaiscript/rhai/issues/946

This was smallest possible changeset that got rhai compiling and building for my test setup with the two features `sync` and `no_std`, which is odd because I see a lot more references to `std` in `native.rs` but who knows

I still got two compilation warnings but I couldn't get them to go with any combination of cfg's

<details>
  <summary>Warnings</summary>

```
➜ cargo build
   Compiling rhai v1.20.1 (/Users/katzen/Documents/rhai)
warning: unused import: `num_traits::Float`
  --> /Users/katzen/Documents/rhai/src/func/call.rs:31:5
   |
31 | use num_traits::Float;
   |     ^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `num_traits::Float`
   --> /Users/katzen/Documents/rhai/src/packages/logic.rs:231:9
    |
231 |     use num_traits::Float;
    |         ^^^^^^^^^^^^^^^^^

warning: `rhai` (lib) generated 2 warnings
   Compiling test_rhai_embedded v0.1.0 (/Users/katzen/Documents/test_rhai_embedded)
```
</details>

I wonder if this fixes things for you too @jeromegn