### PR TITLE
Rm feature flag on `extern crate alloc`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,6 @@
 #![allow(clippy::no_effect_underscore_binding)] // Underscored variables may be used by code within feature guards
 #![allow(clippy::semicolon_if_nothing_returned)] // One-liner `match` cases are sometimes formatted as multi-line blocks
 
-#[cfg(feature = "no_std")]
 extern crate alloc;
 
 #[cfg(feature = "no_std")]


### PR DESCRIPTION
Try to fix the failing build here: https://github.com/rhaiscript/rhai/actions/runs/12616498242/job/35157801445

This is a very blunt solution but might be a good stop gap.