### PR TITLE
Use caller source instead of callee source

### DIFF
--- a/src/func/call.rs
+++ b/src/func/call.rs
@@ -397,7 +397,7 @@ impl Engine {
             // Run external function
             let context = func
                 .has_context()
-                .then(|| (self, name, source.as_deref(), &*global, pos).into());
+                .then(|| (self, name, global.source(), &*global, pos).into());
 
             let mut _result = match func {
                 // If function is not pure, there must be at least one argument

--- a/src/func/call.rs
+++ b/src/func/call.rs
@@ -355,7 +355,7 @@ impl Engine {
         let a = Some(&mut *args);
         let func = self.resolve_fn(global, caches, local_entry, op_token, hash, a, true);
 
-        if let Some(FnResolutionCacheEntry { func, source }) = func {
+        if let Some(FnResolutionCacheEntry { func, source: _ }) = func {
             debug_assert!(func.is_native());
 
             if non_volatile_only && func.is_volatile() {


### PR DESCRIPTION
Currently calling a function uses the source of the callee but the position of the caller. This seems strange. I think that the source of the caller should be used instead, although I'm not exactly sure what the expected behavior is.

This fixes #985 