### PR TITLE
Use `web-time` crate instead of unmaintained `instant` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ serde = { version = "1.0.136", default-features = false, features = ["derive", "
 serde_json = { version = "1.0.45", default-features = false, features = ["alloc"], optional = true }
 unicode-xid = { version = "0.2.0", default-features = false, optional = true }
 rust_decimal = { version = "1.24.0", default-features = false, features = ["maths"], optional = true }
-getrandom = { version = "0.2.7", optional = true }
 rustyline = { version = "15.0.0", optional = true }
 document-features = { version = "0.2.0", optional = true }
 arbitrary = { version = "1.3.2", optional = true, features = ["derive"] }
@@ -115,13 +114,6 @@ no_optimize = []
 ## Turn on `no-std` compilation (nightly only).
 no_std = ["no-std-compat", "num-traits/libm", "core-error", "libm", "hashbrown", "no_time"]
 
-#! ### JavaScript Interface for WASM
-
-## Use [`wasm-bindgen`](https://crates.io/crates/wasm-bindgen) as JavaScript interface.
-wasm-bindgen = ["getrandom/js", "instant/wasm-bindgen"]
-## Use [`stdweb`](https://crates.io/crates/stdweb) as JavaScript interface.
-stdweb = ["getrandom/js", "instant/stdweb"]
-
 #! ### Features used in testing environments only
 
 ## Compiled with a non-stable compiler (i.e. beta or nightly)
@@ -156,7 +148,8 @@ codegen-units = 1
 #panic = 'abort'     # remove stack backtrace for no-std
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-instant = { version = "0.1.10" } # WASM implementation of std::time::Instant
+web-time = { version = "1.1.0" } # WASM implementation of std::time::Instant
+getrandom = { version = "0.2.7", features = ["js"] }
 
 [package.metadata.docs.rs]
 features = ["document-features", "metadata", "serde", "internals", "decimal", "debugging"]

--- a/src/packages/time_basic.rs
+++ b/src/packages/time_basic.rs
@@ -11,7 +11,7 @@ use crate::FLOAT;
 use std::time::{Duration, Instant};
 
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
-use instant::{Duration, Instant};
+use web_time::{Duration, Instant};
 
 def_package! {
     /// Package of basic timing utilities.

--- a/src/types/dynamic.rs
+++ b/src/types/dynamic.rs
@@ -20,7 +20,7 @@ pub use std::time::Instant;
 
 #[cfg(not(feature = "no_time"))]
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
-pub use instant::Instant;
+pub use web_time::Instant;
 
 #[cfg(not(feature = "no_index"))]
 use crate::{Array, Blob};


### PR DESCRIPTION
The `instant` maintainer recommends switching to `web-time` instead. This also replaces #968 (from which I've shamelessly stolen the getrandom change) and fixes #891.