### PR TITLE
Fix buildscript: Don't write to source tree

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,20 +1,15 @@
-use std::{
-    env,
-    fs::File,
-    io::{Read, Write},
-};
+use std::env;
 
 fn main() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+
     // Tell Cargo that if the given environment variable changes, to rerun this build script.
     println!("cargo:rerun-if-changed=build.template");
     println!("cargo:rerun-if-env-changed=RHAI_AHASH_SEED");
     println!("cargo:rerun-if-env-changed=RHAI_HASHING_SEED");
-    let mut contents = String::new();
 
-    File::open("build.template")
-        .expect("cannot open `build.template`")
-        .read_to_string(&mut contents)
-        .expect("cannot read from `build.template`");
+    let mut contents =
+        std::fs::read_to_string("build.template").expect("cannot read from `build.template`");
 
     let seed = env::var("RHAI_HASHING_SEED")
         .or_else(|_| env::var("RHAI_AHASH_SEED"))
@@ -22,8 +17,12 @@ fn main() {
 
     contents = contents.replace("{{HASHING_SEED}}", &seed);
 
-    File::create("src/config/hashing_env.rs")
-        .expect("cannot create `config.rs`")
-        .write_all(contents.as_bytes())
-        .expect("cannot write to `config/hashing_env.rs`");
+    let hashing_env_path = std::path::Path::new(&out_dir).join("hashing_env.rs");
+
+    std::fs::write(&hashing_env_path, contents).unwrap_or_else(|error| {
+        panic!(
+            "cannot write to `{}`: {error:?}",
+            hashing_env_path.display()
+        )
+    });
 }

--- a/build.template
+++ b/build.template
@@ -1,3 +1,1 @@
-//! This file is automatically recreated during build time by `build.rs` from `build.template`.
-
 pub const HASHING_SEED: Option<[u64; 4]> = {{HASHING_SEED}};

--- a/src/config/hashing_env.rs
+++ b/src/config/hashing_env.rs
@@ -1,3 +1,1 @@
-//! This file is automatically recreated during build time by `build.rs` from `build.template`.
-
-pub const HASHING_SEED: Option<[u64; 4]> = None;
+include!(concat!(env!("OUT_DIR"), "/hashing_env.rs"));


### PR DESCRIPTION
This patch rewrites the buildscript to use OUT_DIR instead of writing to the source tree, which is the way to go.

Besides that we also replace the File::open and File::create shenanigans with the std::fs shortcuts provided by the standard library, to shorten the whole thing.

---

This one is a blocker for my work with rhai, so a patch release including this patch would be awesome! :heart: :laughing: 