### PR TITLE
fix: detect reserved keyword in functions params

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3654,6 +3654,12 @@ impl Engine {
                         params.push((s, pos));
                     }
                     (Token::LexError(err), pos) => return Err(err.into_err(pos)),
+                    (token, pos) if token.is_reserved() => {
+                        return Err(PERR::Reserved(token.to_string()).into_err(pos))
+                    }
+                    (token, pos) if token.is_standard_keyword() => {
+                        return Err(PERR::VariableExpected.into_err(pos))
+                    }
                     (.., pos) => {
                         return Err(PERR::MissingToken(
                             Token::RightParen.into(),
@@ -3816,6 +3822,12 @@ impl Engine {
                         params_list.push(s);
                     }
                     (Token::LexError(err), pos) => return Err(err.into_err(pos)),
+                    (token, pos) if token.is_reserved() => {
+                        return Err(PERR::Reserved(token.to_string()).into_err(pos))
+                    }
+                    (token, pos) if token.is_standard_keyword() => {
+                        return Err(PERR::VariableExpected.into_err(pos))
+                    }
                     (.., pos) => {
                         return Err(PERR::MissingToken(
                             Token::Pipe.into(),


### PR DESCRIPTION
Check if the token is a keyword or reserved in the function parameters, if it's returns a `Reserved` error.

Ref: https://github.com/rhaiscript/rhai/discussions/1045