### PR TITLE
Remove `#[cold]` on required trait method

### DIFF
--- a/src/packages/mod.rs
+++ b/src/packages/mod.rs
@@ -45,7 +45,6 @@ pub use time_basic::BasicTimePackage;
 pub trait Package {
     /// Initialize the package.
     /// Functions should be registered into `module` here.
-    #[cold]
     fn init(module: &mut Module);
 
     /// Initialize the package with an [`Engine`].


### PR DESCRIPTION
The Rust compiler accidentally accepted `#[cold]` attributes on required trait methods (trait methods without a default implementation). These attributes have never had any effect. In [this PR](https://github.com/rust-lang/rust/pull/148756#issuecomment-3582547004) to the Rust compiler, this will turn into a warning with the possibility of this being a hard error in the future.

This PR should make sure your project continues to build without warnings on new versions of Rust.