### PR TITLE
Bump getrandom to 0.4.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1.0.136", default-features = false, features = ["derive", "
 serde_json = { version = "1.0.45", default-features = false, features = ["alloc"], optional = true }
 unicode-xid = { version = "0.2.0", default-features = false, optional = true }
 rust_decimal = { version = "1.24.0", default-features = false, features = ["maths"], optional = true }
-getrandom = { version = "0.3.4", optional = true }
+getrandom = { version = "0.4.0", optional = true }
 rustyline = { version = "15.0.0", optional = true }
 document-features = { version = "0.2.0", optional = true }
 arbitrary = { version = "1.3.2", optional = true, features = ["derive"] }


### PR DESCRIPTION
getrandom 0.4.0 was released on 2026-02-02. It can be used without code change.