### PR TITLE
improvement: update macros to not require manual imports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,3 +199,8 @@ jobs:
       with:
         command: test
         args: --manifest-path=codegen/Cargo.toml ${{matrix.flags}}
+    - name: Build Project
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --manifest-path=codegen/tests/custom_root/Cargo.toml ${{matrix.flags}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "codegen"]
+members = [".", "codegen", "codegen/tests/custom_root"]
 
 [package]
 name = "rhai"

--- a/codegen/src/custom_type.rs
+++ b/codegen/src/custom_type.rs
@@ -14,6 +14,7 @@ const OPTION_GET_MUT: &str = "get_mut";
 const OPTION_SET: &str = "set";
 const OPTION_READONLY: &str = "readonly";
 const OPTION_EXTRA: &str = "extra";
+const OPTION_ROOT: &str = "root";
 
 /// Derive the `CustomType` trait for a struct.
 pub fn derive_custom_type_impl(input: DeriveInput) -> TokenStream {
@@ -22,6 +23,7 @@ pub fn derive_custom_type_impl(input: DeriveInput) -> TokenStream {
     let mut field_accessors = Vec::new();
     let mut extras = Vec::new();
     let mut errors = Vec::new();
+    let mut root: Path = syn::parse_quote!(::rhai);
 
     for attr in input.attrs.iter().filter(|a| a.path().is_ident(ATTR)) {
         let config_list: Result<Punctuated<Expr, Token![,]>, _> =
@@ -42,6 +44,11 @@ pub fn derive_custom_type_impl(input: DeriveInput) -> TokenStream {
                             } else if path.is_ident(OPTION_EXTRA) {
                                 match syn::parse2::<Path>(value.to_token_stream()) {
                                     Ok(path) => extras.push(path.to_token_stream()),
+                                    Err(err) => errors.push(err.into_compile_error()),
+                                }
+                            } else if path.is_ident(OPTION_ROOT) {
+                                match syn::parse2::<Path>(value.to_token_stream()) {
+                                    Ok(path) => root = path,
                                     Err(err) => errors.push(err.into_compile_error()),
                                 }
                             } else {
@@ -81,6 +88,7 @@ pub fn derive_custom_type_impl(input: DeriveInput) -> TokenStream {
             &f.named.iter().collect::<Vec<_>>(),
             &mut field_accessors,
             &mut errors,
+            &root,
         ),
 
         // struct Foo(...);
@@ -91,6 +99,7 @@ pub fn derive_custom_type_impl(input: DeriveInput) -> TokenStream {
             &f.unnamed.iter().collect::<Vec<_>>(),
             &mut field_accessors,
             &mut errors,
+            &root,
         ),
 
         // struct Foo;
@@ -174,8 +183,8 @@ pub fn derive_custom_type_impl(input: DeriveInput) -> TokenStream {
     }
 
     quote! {
-        impl #impl_generics ::rhai::CustomType for #type_name #generics {
-            fn build(mut builder: ::rhai::TypeBuilder<Self>) {
+        impl #impl_generics #root::CustomType for #type_name #generics {
+            fn build(mut builder: #root::TypeBuilder<Self>) {
                 #(#errors)*
                 #register
                 #(#field_accessors)*
@@ -226,7 +235,12 @@ fn extract_type_from_option(ty: &syn::Type) -> Option<&syn::Type> {
         })
 }
 
-fn scan_fields(fields: &[&Field], accessors: &mut Vec<TokenStream>, errors: &mut Vec<TokenStream>) {
+fn scan_fields(
+    fields: &[&Field],
+    accessors: &mut Vec<TokenStream>,
+    errors: &mut Vec<TokenStream>,
+    root: &Path,
+) {
     for (i, &field) in fields.iter().enumerate() {
         let mut map_name = None;
         let mut get_fn = None;
@@ -367,7 +381,7 @@ fn scan_fields(fields: &[&Field], accessors: &mut Vec<TokenStream>, errors: &mut
             (None, Some(func)) => quote! { |obj: &mut Self| #func(&*obj) },
             (None, None) => {
                 if option_type.is_some() {
-                    quote! { |obj: &mut Self| obj.#field_name.clone().map_or(::rhai::Dynamic::UNIT, ::rhai::Dynamic::from) }
+                    quote! { |obj: &mut Self| obj.#field_name.clone().map_or(#root::Dynamic::UNIT, #root::Dynamic::from) }
                 } else {
                     quote! { |obj: &mut Self| obj.#field_name.clone() }
                 }
@@ -377,7 +391,7 @@ fn scan_fields(fields: &[&Field], accessors: &mut Vec<TokenStream>, errors: &mut
         let set_impl = set_fn.unwrap_or_else(|| {
             if let Some(typ) = option_type {
                 quote! {
-                    |obj: &mut Self, val: ::rhai::Dynamic| {
+                    |obj: &mut Self, val: #root::Dynamic| {
                         if val.is_unit() {
                             obj.#field_name = None;
                             Ok(())
@@ -385,10 +399,10 @@ fn scan_fields(fields: &[&Field], accessors: &mut Vec<TokenStream>, errors: &mut
                             obj.#field_name = Some(x.clone());
                             Ok(())
                         } else {
-                            Err(Box::new(::rhai::EvalAltResult::ErrorMismatchDataType(
+                            Err(Box::new(#root::EvalAltResult::ErrorMismatchDataType(
                                 stringify!(#typ).to_string(),
                                 val.type_name().to_string(),
-                                ::rhai::Position::NONE
+                                #root::Position::NONE
                             )))
                         }
                     }

--- a/codegen/src/custom_type.rs
+++ b/codegen/src/custom_type.rs
@@ -172,8 +172,8 @@ pub fn derive_custom_type_impl(input: DeriveInput) -> TokenStream {
     }
 
     quote! {
-        impl #impl_generics CustomType for #type_name #generics {
-            fn build(mut builder: TypeBuilder<Self>) {
+        impl #impl_generics ::rhai::CustomType for #type_name #generics {
+            fn build(mut builder: ::rhai::TypeBuilder<Self>) {
                 #(#errors)*
                 #register
                 #(#field_accessors)*
@@ -365,7 +365,7 @@ fn scan_fields(fields: &[&Field], accessors: &mut Vec<TokenStream>, errors: &mut
             (None, Some(func)) => quote! { |obj: &mut Self| #func(&*obj) },
             (None, None) => {
                 if option_type.is_some() {
-                    quote! { |obj: &mut Self| obj.#field_name.clone().map_or(Dynamic::UNIT, Dynamic::from) }
+                    quote! { |obj: &mut Self| obj.#field_name.clone().map_or(::rhai::Dynamic::UNIT, ::rhai::Dynamic::from) }
                 } else {
                     quote! { |obj: &mut Self| obj.#field_name.clone() }
                 }
@@ -375,7 +375,7 @@ fn scan_fields(fields: &[&Field], accessors: &mut Vec<TokenStream>, errors: &mut
         let set_impl = set_fn.unwrap_or_else(|| {
             if let Some(typ) = option_type {
                 quote! {
-                    |obj: &mut Self, val: Dynamic| {
+                    |obj: &mut Self, val: ::rhai::Dynamic| {
                         if val.is_unit() {
                             obj.#field_name = None;
                             Ok(())
@@ -383,10 +383,10 @@ fn scan_fields(fields: &[&Field], accessors: &mut Vec<TokenStream>, errors: &mut
                             obj.#field_name = Some(x.clone());
                             Ok(())
                         } else {
-                            Err(Box::new(EvalAltResult::ErrorMismatchDataType(
+                            Err(Box::new(::rhai::EvalAltResult::ErrorMismatchDataType(
                                 stringify!(#typ).to_string(),
                                 val.type_name().to_string(),
-                                Position::NONE
+                                ::rhai::Position::NONE
                             )))
                         }
                     }

--- a/codegen/src/custom_type.rs
+++ b/codegen/src/custom_type.rs
@@ -123,9 +123,11 @@ pub fn derive_custom_type_impl(input: DeriveInput) -> TokenStream {
                 return syn::Error::new(Span::call_site(), "failed to parse doc comments")
                     .into_compile_error();
             };
-            // Not sure how to make a Vec<String> a literal, using a string instead.
-            let docs = proc_macro2::Literal::string(&docs.join("\n"));
-            quote! {  #method.with_comments(&#docs.lines().collect::<Vec<_>>()[..]); }
+            let docs: Vec<_> = docs
+                .iter()
+                .map(|d| proc_macro2::Literal::string(d))
+                .collect();
+            quote! { #method.with_comments(&[#(#docs),*]); }
         }
         #[cfg(not(feature = "metadata"))]
         quote! { #method; }
@@ -409,9 +411,11 @@ fn scan_fields(fields: &[&Field], accessors: &mut Vec<TokenStream>, errors: &mut
             {
                 match crate::attrs::doc_attributes(&field.attrs) {
                     Ok(docs) => {
-                        // Not sure how to make a Vec<String> a literal, using a string instead.
-                        let docs = proc_macro2::Literal::string(&docs.join("\n"));
-                        quote! { #method.and_comments(&#docs.lines().collect::<Vec<_>>()[..]); }
+                        let docs: Vec<_> = docs
+                            .iter()
+                            .map(|d| proc_macro2::Literal::string(d))
+                            .collect();
+                        quote! { #method.and_comments(&[#(#docs),*]); }
                     }
                     Err(_) => {
                         errors.push(

--- a/codegen/src/function.rs
+++ b/codegen/src/function.rs
@@ -625,7 +625,7 @@ impl ExportedFn {
         let mut dynamic_signature = self.signature.clone();
         dynamic_signature.ident = syn::Ident::new("dynamic_result_fn", Span::call_site());
         dynamic_signature.output = syn::parse2::<syn::ReturnType>(quote! {
-            -> RhaiResult
+            -> ::rhai::plugin::RhaiResult
         })
         .unwrap();
         let arguments: Vec<_> = dynamic_signature
@@ -651,7 +651,7 @@ impl ExportedFn {
                 #[doc(hidden)]
                 #[inline(always)]
                 pub #dynamic_signature {
-                    #name(#(#arguments),*).map(Dynamic::from)
+                    #name(#(#arguments),*).map(::rhai::Dynamic::from)
                 }
             }
         } else {
@@ -660,7 +660,7 @@ impl ExportedFn {
                 #[doc(hidden)]
                 #[inline(always)]
                 pub #dynamic_signature {
-                    Ok(Dynamic::from(#name(#(#arguments),*)))
+                    Ok(::rhai::Dynamic::from(#name(#(#arguments),*)))
                 }
             }
         }
@@ -717,7 +717,7 @@ impl ExportedFn {
                     input_type_names.push(arg_name);
                     input_type_exprs.push(
                         syn::parse2::<syn::Expr>(quote_spanned!(arg_type.span() =>
-                            TypeId::of::<#arg_type>()
+                            ::std::any::TypeId::of::<#arg_type>()
                         ))
                         .unwrap(),
                     );
@@ -754,7 +754,7 @@ impl ExportedFn {
                                 is_string = true;
                                 is_ref = true;
                                 quote_spanned!(arg_type.span().resolved_at(Span::call_site()) =>
-                                    mem::take(args[#i]).into_immutable_string().unwrap()
+                                    ::std::mem::take(args[#i]).into_immutable_string().unwrap()
                                 )
                             }
                             _ => unreachable!("why wasn't this found earlier!?"),
@@ -763,14 +763,14 @@ impl ExportedFn {
                             is_string = true;
                             is_ref = false;
                             quote_spanned!(arg_type.span().resolved_at(Span::call_site()) =>
-                                mem::take(args[#i]).into_string().unwrap()
+                                ::std::mem::take(args[#i]).into_string().unwrap()
                             )
                         }
                         _ => {
                             is_string = false;
                             is_ref = false;
                             quote_spanned!(arg_type.span().resolved_at(Span::call_site()) =>
-                                mem::take(args[#i]).cast::<#arg_type>()
+                                ::std::mem::take(args[#i]).cast::<#arg_type>()
                             )
                         }
                     };
@@ -786,14 +786,14 @@ impl ExportedFn {
                     if !is_string {
                         input_type_exprs.push(
                             syn::parse2::<syn::Expr>(quote_spanned!(arg_type.span() =>
-                                TypeId::of::<#arg_type>()
+                                ::std::any::TypeId::of::<#arg_type>()
                             ))
                             .unwrap(),
                         );
                     } else {
                         input_type_exprs.push(
                             syn::parse2::<syn::Expr>(quote_spanned!(arg_type.span() =>
-                                TypeId::of::<ImmutableString>()
+                                ::std::any::TypeId::of::<::rhai::ImmutableString>()
                             ))
                             .unwrap(),
                         );
@@ -826,11 +826,11 @@ impl ExportedFn {
             .resolved_at(Span::call_site());
         let return_expr = if self.params.return_raw.is_none() {
             quote_spanned! { return_span =>
-                Ok(Dynamic::from(#sig_name(#(#unpack_exprs),*)))
+                Ok(::rhai::Dynamic::from(#sig_name(#(#unpack_exprs),*)))
             }
         } else {
             quote_spanned! { return_span =>
-                #sig_name(#(#unpack_exprs),*).map(Dynamic::from)
+                #sig_name(#(#unpack_exprs),*).map(::rhai::Dynamic::from)
             }
         };
 
@@ -854,12 +854,12 @@ impl ExportedFn {
             #[doc(hidden)]
             impl #type_name {
                 #param_names
-                #[inline(always)] pub fn param_types() -> [TypeId; #arg_count] { [#(#input_type_exprs),*] }
+                #[inline(always)] pub fn param_types() -> [::std::any::TypeId; #arg_count] { [#(#input_type_exprs),*] }
             }
             #(#cfg_attrs)*
-            impl PluginFunc for #type_name {
+            impl ::rhai::plugin::PluginFunc for #type_name {
                 #[inline(always)]
-                fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
+                fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
                     #(#unpack_statements)*
                     #return_expr
                 }

--- a/codegen/src/function.rs
+++ b/codegen/src/function.rs
@@ -289,6 +289,10 @@ impl Parse for ExportedFn {
             syn::parse2::<syn::Path>(quote! { rhai::NativeCallContext }).unwrap();
         let context_type_path2x =
             syn::parse2::<syn::Path>(quote! { rhai::NativeCallContext<'_> }).unwrap();
+        let context_type_path3 =
+            syn::parse2::<syn::Path>(quote! { ::rhai::NativeCallContext }).unwrap();
+        let context_type_path3x =
+            syn::parse2::<syn::Path>(quote! { ::rhai::NativeCallContext<'_> }).unwrap();
         let mut pass_context = false;
 
         let cfg_attrs = crate::attrs::collect_cfg_attr(&fn_all.attrs);
@@ -302,7 +306,9 @@ impl Parse for ExportedFn {
                     if p.path == context_type_path1
                         || p.path == context_type_path1x
                         || p.path == context_type_path2
-                        || p.path == context_type_path2x =>
+                        || p.path == context_type_path2x
+                        || p.path == context_type_path3
+                        || p.path == context_type_path3x =>
                 {
                     pass_context = true;
                 }
@@ -717,7 +723,7 @@ impl ExportedFn {
                     input_type_names.push(arg_name);
                     input_type_exprs.push(
                         syn::parse2::<syn::Expr>(quote_spanned!(arg_type.span() =>
-                            ::std::any::TypeId::of::<#arg_type>()
+                            ::core::any::TypeId::of::<#arg_type>()
                         ))
                         .unwrap(),
                     );
@@ -754,7 +760,7 @@ impl ExportedFn {
                                 is_string = true;
                                 is_ref = true;
                                 quote_spanned!(arg_type.span().resolved_at(Span::call_site()) =>
-                                    ::std::mem::take(args[#i]).into_immutable_string().unwrap()
+                                    ::core::mem::take(args[#i]).into_immutable_string().unwrap()
                                 )
                             }
                             _ => unreachable!("why wasn't this found earlier!?"),
@@ -763,14 +769,14 @@ impl ExportedFn {
                             is_string = true;
                             is_ref = false;
                             quote_spanned!(arg_type.span().resolved_at(Span::call_site()) =>
-                                ::std::mem::take(args[#i]).into_string().unwrap()
+                                ::core::mem::take(args[#i]).into_string().unwrap()
                             )
                         }
                         _ => {
                             is_string = false;
                             is_ref = false;
                             quote_spanned!(arg_type.span().resolved_at(Span::call_site()) =>
-                                ::std::mem::take(args[#i]).cast::<#arg_type>()
+                                ::core::mem::take(args[#i]).cast::<#arg_type>()
                             )
                         }
                     };
@@ -786,14 +792,14 @@ impl ExportedFn {
                     if !is_string {
                         input_type_exprs.push(
                             syn::parse2::<syn::Expr>(quote_spanned!(arg_type.span() =>
-                                ::std::any::TypeId::of::<#arg_type>()
+                                ::core::any::TypeId::of::<#arg_type>()
                             ))
                             .unwrap(),
                         );
                     } else {
                         input_type_exprs.push(
                             syn::parse2::<syn::Expr>(quote_spanned!(arg_type.span() =>
-                                ::std::any::TypeId::of::<::rhai::ImmutableString>()
+                                ::core::any::TypeId::of::<::rhai::ImmutableString>()
                             ))
                             .unwrap(),
                         );
@@ -854,7 +860,7 @@ impl ExportedFn {
             #[doc(hidden)]
             impl #type_name {
                 #param_names
-                #[inline(always)] pub fn param_types() -> [::std::any::TypeId; #arg_count] { [#(#input_type_exprs),*] }
+                #[inline(always)] pub fn param_types() -> [::core::any::TypeId; #arg_count] { [#(#input_type_exprs),*] }
             }
             #(#cfg_attrs)*
             impl ::rhai::plugin::PluginFunc for #type_name {

--- a/codegen/src/function.rs
+++ b/codegen/src/function.rs
@@ -3,6 +3,7 @@ use quote::{quote, quote_spanned, ToTokens};
 use syn::{
     parse::{Parse, ParseStream},
     spanned::Spanned,
+    Path,
 };
 
 use std::borrow::Cow;
@@ -282,17 +283,6 @@ impl Parse for ExportedFn {
         let entire_span = fn_all.span();
         let str_type_path = syn::parse2::<syn::Path>(quote! { str }).unwrap();
 
-        let context_type_path1 = syn::parse2::<syn::Path>(quote! { NativeCallContext }).unwrap();
-        let context_type_path1x =
-            syn::parse2::<syn::Path>(quote! { NativeCallContext<'_> }).unwrap();
-        let context_type_path2 =
-            syn::parse2::<syn::Path>(quote! { rhai::NativeCallContext }).unwrap();
-        let context_type_path2x =
-            syn::parse2::<syn::Path>(quote! { rhai::NativeCallContext<'_> }).unwrap();
-        let context_type_path3 =
-            syn::parse2::<syn::Path>(quote! { ::rhai::NativeCallContext }).unwrap();
-        let context_type_path3x =
-            syn::parse2::<syn::Path>(quote! { ::rhai::NativeCallContext<'_> }).unwrap();
         let mut pass_context = false;
 
         let cfg_attrs = crate::attrs::collect_cfg_attr(&fn_all.attrs);
@@ -303,12 +293,8 @@ impl Parse for ExportedFn {
         if let Some(syn::FnArg::Typed(syn::PatType { ref ty, .. })) = fn_all.sig.inputs.first() {
             match flatten_type_groups(ty.as_ref()) {
                 syn::Type::Path(p)
-                    if p.path == context_type_path1
-                        || p.path == context_type_path1x
-                        || p.path == context_type_path2
-                        || p.path == context_type_path2x
-                        || p.path == context_type_path3
-                        || p.path == context_type_path3x =>
+                    if p.path.segments.last().map(|s| s.ident.to_string())
+                        == Some("NativeCallContext".to_owned()) =>
                 {
                     pass_context = true;
                 }
@@ -607,11 +593,11 @@ impl ExportedFn {
         Ok(())
     }
 
-    pub fn generate(self) -> TokenStream {
+    pub fn generate(self, root: &Path) -> TokenStream {
         let name: syn::Ident =
             syn::Ident::new(&format!("rhai_fn_{}", self.name()), self.name().span());
-        let impl_block = self.generate_impl("Token");
-        let dyn_result_fn_block = self.generate_dynamic_fn();
+        let impl_block = self.generate_impl("Token", root);
+        let dyn_result_fn_block = self.generate_dynamic_fn(root);
         let vis = self.visibility;
         quote! {
             #[automatically_derived]
@@ -625,13 +611,13 @@ impl ExportedFn {
         }
     }
 
-    pub fn generate_dynamic_fn(&self) -> TokenStream {
+    pub fn generate_dynamic_fn(&self, root: &Path) -> TokenStream {
         let name = self.name().clone();
 
         let mut dynamic_signature = self.signature.clone();
         dynamic_signature.ident = syn::Ident::new("dynamic_result_fn", Span::call_site());
         dynamic_signature.output = syn::parse2::<syn::ReturnType>(quote! {
-            -> ::rhai::plugin::RhaiResult
+            -> #root::plugin::RhaiResult
         })
         .unwrap();
         let arguments: Vec<_> = dynamic_signature
@@ -657,7 +643,7 @@ impl ExportedFn {
                 #[doc(hidden)]
                 #[inline(always)]
                 pub #dynamic_signature {
-                    #name(#(#arguments),*).map(::rhai::Dynamic::from)
+                    #name(#(#arguments),*).map(#root::Dynamic::from)
                 }
             }
         } else {
@@ -666,13 +652,13 @@ impl ExportedFn {
                 #[doc(hidden)]
                 #[inline(always)]
                 pub #dynamic_signature {
-                    Ok(::rhai::Dynamic::from(#name(#(#arguments),*)))
+                    Ok(#root::Dynamic::from(#name(#(#arguments),*)))
                 }
             }
         }
     }
 
-    pub fn generate_impl(&self, on_type_name: &str) -> TokenStream {
+    pub fn generate_impl(&self, on_type_name: &str, root: &Path) -> TokenStream {
         let sig_name = self.name().clone();
         let arg_count = self.arg_count();
         let is_method_call = self.mutable_receiver();
@@ -799,7 +785,7 @@ impl ExportedFn {
                     } else {
                         input_type_exprs.push(
                             syn::parse2::<syn::Expr>(quote_spanned!(arg_type.span() =>
-                                ::core::any::TypeId::of::<::rhai::ImmutableString>()
+                                ::core::any::TypeId::of::<#root::ImmutableString>()
                             ))
                             .unwrap(),
                         );
@@ -832,11 +818,11 @@ impl ExportedFn {
             .resolved_at(Span::call_site());
         let return_expr = if self.params.return_raw.is_none() {
             quote_spanned! { return_span =>
-                Ok(::rhai::Dynamic::from(#sig_name(#(#unpack_exprs),*)))
+                Ok(#root::Dynamic::from(#sig_name(#(#unpack_exprs),*)))
             }
         } else {
             quote_spanned! { return_span =>
-                #sig_name(#(#unpack_exprs),*).map(::rhai::Dynamic::from)
+                #sig_name(#(#unpack_exprs),*).map(#root::Dynamic::from)
             }
         };
 
@@ -863,9 +849,9 @@ impl ExportedFn {
                 #[inline(always)] pub fn param_types() -> [::core::any::TypeId; #arg_count] { [#(#input_type_exprs),*] }
             }
             #(#cfg_attrs)*
-            impl ::rhai::plugin::PluginFunc for #type_name {
+            impl #root::plugin::PluginFunc for #type_name {
                 #[inline(always)]
-                fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                fn call(&self, context: Option<#root::NativeCallContext>, args: &mut [&mut #root::Dynamic]) -> #root::plugin::RhaiResult {
                     #(#unpack_statements)*
                     #return_expr
                 }

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -241,7 +241,7 @@ pub fn set_exported_fn(args: TokenStream) -> TokenStream {
             let gen_mod_path = crate::register::generated_module_path(&rust_mod_path);
 
             let mut tokens = quote! {
-                let fx = FuncRegistration::new(#export_name).with_namespace(FnNamespace::Internal)
+                let fx = ::rhai::FuncRegistration::new(#export_name).with_namespace(::rhai::FnNamespace::Internal)
             };
             #[cfg(feature = "metadata")]
             tokens.extend(quote! {
@@ -272,7 +272,7 @@ pub fn set_exported_global_fn(args: TokenStream) -> TokenStream {
             let gen_mod_path = crate::register::generated_module_path(&rust_mod_path);
 
             let mut tokens = quote! {
-                let fx = FuncRegistration::new(#export_name).with_namespace(FnNamespace::Global)
+                let fx = ::rhai::FuncRegistration::new(#export_name).with_namespace(::rhai::FnNamespace::Global)
             };
             #[cfg(feature = "metadata")]
             tokens.extend(quote! {

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -34,7 +34,7 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, spanned::Spanned, DeriveInput};
+use syn::{parse_macro_input, spanned::Spanned, DeriveInput, Path};
 
 mod attrs;
 mod custom_type;
@@ -201,7 +201,10 @@ pub fn export_fn(args: TokenStream, input: TokenStream) -> TokenStream {
         return e.to_compile_error().into();
     }
 
-    output.extend(function_def.generate());
+    // This function is deprecated and does not have custom root support
+    let root: Path = syn::parse_quote!(::rhai);
+
+    output.extend(function_def.generate(&root));
     TokenStream::from(output)
 }
 
@@ -236,12 +239,15 @@ pub fn register_exported_fn(args: TokenStream) -> TokenStream {
 #[deprecated(since = "1.18.0")]
 #[proc_macro]
 pub fn set_exported_fn(args: TokenStream) -> TokenStream {
+    // This function is deprecated and does not have custom root support
+    let root: Path = syn::parse_quote!(::rhai);
+
     match crate::register::parse_register_macro(args) {
         Ok((module_expr, export_name, rust_mod_path)) => {
             let gen_mod_path = crate::register::generated_module_path(&rust_mod_path);
 
             let mut tokens = quote! {
-                let fx = ::rhai::FuncRegistration::new(#export_name).with_namespace(::rhai::FnNamespace::Internal)
+                let fx = #root::FuncRegistration::new(#export_name).with_namespace(#root::FnNamespace::Internal)
             };
             #[cfg(feature = "metadata")]
             tokens.extend(quote! {
@@ -267,12 +273,15 @@ pub fn set_exported_fn(args: TokenStream) -> TokenStream {
 #[deprecated(since = "1.18.0")]
 #[proc_macro]
 pub fn set_exported_global_fn(args: TokenStream) -> TokenStream {
+    // This function is deprecated and does not have custom root support
+    let root: Path = syn::parse_quote!(::rhai);
+
     match crate::register::parse_register_macro(args) {
         Ok((module_expr, export_name, rust_mod_path)) => {
             let gen_mod_path = crate::register::generated_module_path(&rust_mod_path);
 
             let mut tokens = quote! {
-                let fx = ::rhai::FuncRegistration::new(#export_name).with_namespace(::rhai::FnNamespace::Global)
+                let fx = #root::FuncRegistration::new(#export_name).with_namespace(#root::FnNamespace::Global)
             };
             #[cfg(feature = "metadata")]
             tokens.extend(quote! {
@@ -288,7 +297,7 @@ pub fn set_exported_global_fn(args: TokenStream) -> TokenStream {
     }
 }
 
-/// Macro to implement the [`CustomType`][rhai::CustomType] trait.
+/// Macro to implement the [`CustomType`][::rhai::CustomType] trait.
 ///
 /// # Usage
 ///

--- a/codegen/src/module.rs
+++ b/codegen/src/module.rs
@@ -1,4 +1,5 @@
 use quote::{quote, ToTokens};
+use syn::Path;
 use syn::{parse::Parse, parse::ParseStream};
 
 use std::borrow::Cow;
@@ -8,11 +9,23 @@ use crate::attrs::{AttrItem, ExportInfo, ExportScope, ExportedParams};
 use crate::function::ExportedFn;
 use crate::rhai_module::{ExportedConst, ExportedType};
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct ExportedModParams {
     pub name: String,
     skip: bool,
     pub scope: ExportScope,
+    root: Path,
+}
+
+impl Default for ExportedModParams {
+    fn default() -> Self {
+        Self {
+            name: Default::default(),
+            skip: Default::default(),
+            scope: Default::default(),
+            root: syn::parse_quote!(::rhai),
+        }
+    }
 }
 
 impl Parse for ExportedModParams {
@@ -39,6 +52,7 @@ impl ExportedParams for ExportedModParams {
         let mut name = String::new();
         let mut skip = false;
         let mut scope = None;
+        let mut root: Path = syn::parse_quote!(::rhai);
         for attr in attrs {
             let AttrItem { key, value, .. } = attr;
             match (key.to_string().as_ref(), value) {
@@ -65,6 +79,16 @@ impl ExportedParams for ExportedModParams {
                 ("export_all", Some(s)) => {
                     return Err(syn::Error::new(s.span(), "extraneous value"))
                 }
+                ("root", Some(s)) => {
+                    let Ok(new_root) = syn::parse_str(&s.value()) else {
+                        return Err(syn::Error::new(key.span(), "requires path"));
+                    };
+                    if root == new_root {
+                        return Err(syn::Error::new(key.span(), "conflicting name"));
+                    }
+                    root = new_root;
+                }
+                ("root", None) => return Err(syn::Error::new(key.span(), "requires value")),
                 (attr, ..) => {
                     return Err(syn::Error::new(
                         key.span(),
@@ -76,7 +100,12 @@ impl ExportedParams for ExportedModParams {
 
         let scope = scope.unwrap_or_default();
 
-        Ok(ExportedModParams { name, skip, scope })
+        Ok(ExportedModParams {
+            name,
+            skip,
+            scope,
+            root,
+        })
     }
 }
 
@@ -278,6 +307,7 @@ impl Module {
                 &custom_types,
                 &mut sub_modules,
                 &params.scope,
+                &params.root,
             );
 
             // NB: sub-modules must have their new items for exporting generated in depth-first order

--- a/codegen/src/rhai_module.rs
+++ b/codegen/src/rhai_module.rs
@@ -1,5 +1,6 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
+use syn::Path;
 
 use std::collections::BTreeMap;
 
@@ -32,6 +33,7 @@ pub fn generate_body(
     custom_types: &[ExportedType],
     sub_modules: &mut [Module],
     parent_scope: &ExportScope,
+    root: &Path,
 ) -> TokenStream {
     let mut set_fn_statements = Vec::new();
     let mut set_const_statements = Vec::new();
@@ -157,13 +159,13 @@ pub fn generate_body(
 
             let mut tokens = quote! {
                 #(#cfg_attrs)*
-                ::rhai::FuncRegistration::new(#fn_literal)
+                #root::FuncRegistration::new(#fn_literal)
             };
 
             match namespace {
                 FnNamespaceAccess::Unset => unreachable!("`namespace` should be set"),
                 FnNamespaceAccess::Global => {
-                    tokens.extend(quote! { .with_namespace(::rhai::FnNamespace::Global) })
+                    tokens.extend(quote! { .with_namespace(#root::FnNamespace::Global) })
                 }
                 FnNamespaceAccess::Internal => (),
             }
@@ -201,7 +203,7 @@ pub fn generate_body(
             pub struct #fn_token_name();
         });
 
-        gen_fn_tokens.push(function.generate_impl(&fn_token_name.to_string()));
+        gen_fn_tokens.push(function.generate_impl(&fn_token_name.to_string(), root));
     }
 
     let module_docs = if doc.is_empty() {
@@ -229,8 +231,8 @@ pub fn generate_body(
 
             #[doc(hidden)]
             #[inline(always)]
-            pub fn rhai_module_generate() -> ::rhai::Module {
-                let mut m = ::rhai::Module::new();
+            pub fn rhai_module_generate() -> #root::Module {
+                let mut m = #root::Module::new();
                 #module_docs
                 rhai_generate_into_module(&mut m, false);
                 m.build_index();
@@ -238,7 +240,7 @@ pub fn generate_body(
             }
             #[doc(hidden)]
             #[inline(always)]
-            pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+            pub fn rhai_generate_into_module(_m: &mut #root::Module, _flatten: bool) {
                 #(#set_fn_statements)*
                 #(#set_const_statements)*
                 #flatten

--- a/codegen/src/rhai_module.rs
+++ b/codegen/src/rhai_module.rs
@@ -163,7 +163,7 @@ pub fn generate_body(
             match namespace {
                 FnNamespaceAccess::Unset => unreachable!("`namespace` should be set"),
                 FnNamespaceAccess::Global => {
-                    tokens.extend(quote! { .with_namespace(rhai::FnNamespace::Global) })
+                    tokens.extend(quote! { .with_namespace(::rhai::FnNamespace::Global) })
                 }
                 FnNamespaceAccess::Internal => (),
             }

--- a/codegen/src/rhai_module.rs
+++ b/codegen/src/rhai_module.rs
@@ -157,13 +157,13 @@ pub fn generate_body(
 
             let mut tokens = quote! {
                 #(#cfg_attrs)*
-                FuncRegistration::new(#fn_literal)
+                ::rhai::FuncRegistration::new(#fn_literal)
             };
 
             match namespace {
                 FnNamespaceAccess::Unset => unreachable!("`namespace` should be set"),
                 FnNamespaceAccess::Global => {
-                    tokens.extend(quote! { .with_namespace(FnNamespace::Global) })
+                    tokens.extend(quote! { .with_namespace(rhai::FnNamespace::Global) })
                 }
                 FnNamespaceAccess::Internal => (),
             }
@@ -229,8 +229,8 @@ pub fn generate_body(
 
             #[doc(hidden)]
             #[inline(always)]
-            pub fn rhai_module_generate() -> Module {
-                let mut m = Module::new();
+            pub fn rhai_module_generate() -> ::rhai::Module {
+                let mut m = ::rhai::Module::new();
                 #module_docs
                 rhai_generate_into_module(&mut m, false);
                 m.build_index();
@@ -238,7 +238,7 @@ pub fn generate_body(
             }
             #[doc(hidden)]
             #[inline(always)]
-            pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+            pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                 #(#set_fn_statements)*
                 #(#set_const_statements)*
                 #flatten

--- a/codegen/src/test/custom_type.rs
+++ b/codegen/src/test/custom_type.rs
@@ -7,7 +7,7 @@ mod custom_type_tests {
     #[test]
     fn test_custom_type_tuple_struct() {
         let input = quote! {
-            #[derive(Clone, CustomType)]
+            #[derive(Clone, ::rhai::CustomType)]
             pub struct Bar(
                 #[rhai_type(skip)]
                 rhai::FLOAT,
@@ -23,8 +23,8 @@ mod custom_type_tests {
         );
 
         let expected = quote! {
-            impl CustomType for Bar {
-                fn build(mut builder: TypeBuilder<Self>) {
+            impl ::rhai::CustomType for Bar {
+                fn build(mut builder: ::rhai::TypeBuilder<Self>) {
                     builder.with_name(stringify!(Bar));
                     builder.with_get_set("field1",
                         |obj: &mut Self| obj.1.clone(),
@@ -64,8 +64,8 @@ mod custom_type_tests {
         );
 
         let expected = quote! {
-            impl CustomType for Foo {
-                fn build(mut builder: TypeBuilder<Self>) {
+            impl ::rhai::CustomType for Foo {
+                fn build(mut builder: ::rhai::TypeBuilder<Self>) {
                     builder.with_name("MyFoo");
                     builder.with_get_set(stringify!(bar),
                         |obj: &mut Self| get_bar(&*obj),
@@ -113,19 +113,19 @@ mod custom_type_tests {
         );
 
         let expected = quote! {
-            impl CustomType for Bar {
-                fn build(mut builder: TypeBuilder<Self>) {
-                    builder.with_name(stringify!(Bar)).with_comments(&"/// Bar comments.".lines().collect::<Vec<_>>()[..]);
+            impl ::rhai::CustomType for Bar {
+                fn build(mut builder: ::rhai::TypeBuilder<Self>) {
+                    builder.with_name(stringify!(Bar)).with_comments(&["/// Bar comments."]);
                     builder.with_get_set("field1",
                         |obj: &mut Self| obj.1.clone(),
                         |obj: &mut Self, val| obj.1 = val
-                    ).and_comments(&"".lines().collect::<Vec<_>>()[..]);
+                    ).and_comments(&[]);
                     builder.with_get("boo", |obj: &mut Self| obj.2.clone())
-                    .and_comments(&"/// boo comments.".lines().collect::<Vec<_>>()[..]);
+                    .and_comments(&["/// boo comments."]);
                     builder.with_get_set("field3",
                         |obj: &mut Self| obj.3.clone(),
                         |obj: &mut Self, val| obj.3 = val
-                    ).and_comments(&"/// This is a vector.".lines().collect::<Vec<_>>()[..]);
+                    ).and_comments(&["/// This is a vector."]);
                 }
             }
         };
@@ -157,19 +157,19 @@ mod custom_type_tests {
         );
 
         let expected = quote! {
-            impl CustomType for Foo {
-                fn build(mut builder: TypeBuilder<Self>) {
-                    builder.with_name("MyFoo").with_comments(&"/// Foo comments.".lines().collect::<Vec<_>>()[..]);
+            impl ::rhai::CustomType for Foo {
+                fn build(mut builder: ::rhai::TypeBuilder<Self>) {
+                    builder.with_name("MyFoo").with_comments(&["/// Foo comments."]);
                     builder.with_get_set(stringify!(bar),
                         |obj: &mut Self| get_bar(&*obj),
                         |obj: &mut Self, val| obj.bar = val
-                    ).and_comments(&"".lines().collect::<Vec<_>>()[..]);
+                    ).and_comments(&[]);
                     builder.with_get("boo", |obj: &mut Self| obj.baz.clone())
-                    .and_comments(&"/// boo comments.".lines().collect::<Vec<_>>()[..]);
+                    .and_comments(&["/// boo comments."]);
                     builder.with_get_set(stringify!(qux),
                         |obj: &mut Self| obj.qux.clone(),
                         Self::set_qux
-                    ).and_comments(&"".lines().collect::<Vec<_>>()[..]);
+                    ).and_comments(&[]);
                     Self::build_extra(&mut builder);
                 }
             }

--- a/codegen/src/test/function.rs
+++ b/codegen/src/test/function.rs
@@ -298,7 +298,10 @@ mod generate_tests {
         };
 
         let item_fn = syn::parse2::<ExportedFn>(input_tokens).unwrap();
-        assert_streams_eq(item_fn.generate(), expected_tokens);
+        assert_streams_eq(
+            item_fn.generate(&syn::parse_quote!(::rhai)),
+            expected_tokens,
+        );
     }
 
     #[test]
@@ -339,7 +342,10 @@ mod generate_tests {
         };
 
         let item_fn = syn::parse2::<ExportedFn>(input_tokens).unwrap();
-        assert_streams_eq(item_fn.generate(), expected_tokens);
+        assert_streams_eq(
+            item_fn.generate(&syn::parse_quote!(::rhai)),
+            expected_tokens,
+        );
     }
 
     #[test]
@@ -381,7 +387,55 @@ mod generate_tests {
 
         let item_fn = syn::parse2::<ExportedFn>(input_tokens).unwrap();
         // assert!(item_fn.pass_context());
-        assert_streams_eq(item_fn.generate(), expected_tokens);
+        assert_streams_eq(
+            item_fn.generate(&syn::parse_quote!(::rhai)),
+            expected_tokens,
+        );
+    }
+
+    #[test]
+    fn one_arg_fn_with_context_custom_root() {
+        let input_tokens: TokenStream = quote! {
+            pub fn do_something(context: customroot::NativeCallContext, x: usize) {}
+        };
+
+        let expected_tokens = quote! {
+            #[automatically_derived]
+            pub mod rhai_fn_do_something {
+                use super::*;
+                #[doc(hidden)]
+                pub struct Token();
+                #[doc(hidden)]
+                impl Token {
+                    pub const PARAM_NAMES: &'static [&'static str] = &["x: usize", "()"];
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 1usize] { [::core::any::TypeId::of::<usize>()] }
+                }
+                impl customroot::plugin::PluginFunc for Token {
+                    #[inline(always)]
+                    fn call(&self, context: Option<customroot::NativeCallContext>, args: &mut [&mut customroot::Dynamic]) -> customroot::plugin::RhaiResult {
+                        let arg0 = ::core::mem::take(args[0usize]).cast::<usize>();
+                        Ok(customroot::Dynamic::from(do_something(context.unwrap(), arg0)))
+                    }
+
+                    #[inline(always)] fn is_method_call(&self) -> bool { false }
+                    #[inline(always)] fn is_pure(&self) -> bool { true }
+                    #[inline(always)] fn is_volatile(&self) -> bool { false }
+                    #[inline(always)] fn has_context(&self) -> bool { true }
+                }
+                #[allow(unused)]
+                #[doc(hidden)]
+                #[inline(always)] pub fn dynamic_result_fn(context: customroot::NativeCallContext, x: usize) -> customroot::plugin::RhaiResult {
+                    Ok(customroot::Dynamic::from(do_something(context, x)))
+                }
+            }
+        };
+
+        let item_fn = syn::parse2::<ExportedFn>(input_tokens).unwrap();
+        // assert!(item_fn.pass_context());
+        assert_streams_eq(
+            item_fn.generate(&syn::parse_quote!(customroot)),
+            expected_tokens,
+        );
     }
 
     #[test]
@@ -423,7 +477,10 @@ mod generate_tests {
         };
 
         let item_fn = syn::parse2::<ExportedFn>(input_tokens).unwrap();
-        assert_streams_eq(item_fn.generate(), expected_tokens);
+        assert_streams_eq(
+            item_fn.generate(&syn::parse_quote!(::rhai)),
+            expected_tokens,
+        );
     }
 
     #[test]
@@ -453,7 +510,10 @@ mod generate_tests {
         };
 
         let item_fn = syn::parse2::<ExportedFn>(input_tokens).unwrap();
-        assert_streams_eq(item_fn.generate_impl("TestStruct"), expected_tokens);
+        assert_streams_eq(
+            item_fn.generate_impl("TestStruct", &syn::parse_quote!(::rhai)),
+            expected_tokens,
+        );
     }
 
     #[test]
@@ -495,7 +555,10 @@ mod generate_tests {
         };
 
         let item_fn = syn::parse2::<ExportedFn>(input_tokens).unwrap();
-        assert_streams_eq(item_fn.generate(), expected_tokens);
+        assert_streams_eq(
+            item_fn.generate(&syn::parse_quote!(::rhai)),
+            expected_tokens,
+        );
     }
 
     #[test]
@@ -538,7 +601,10 @@ mod generate_tests {
 
         let item_fn = syn::parse2::<ExportedFn>(input_tokens).unwrap();
         assert!(item_fn.mutable_receiver());
-        assert_streams_eq(item_fn.generate(), expected_tokens);
+        assert_streams_eq(
+            item_fn.generate(&syn::parse_quote!(::rhai)),
+            expected_tokens,
+        );
     }
 
     #[test]
@@ -580,6 +646,9 @@ mod generate_tests {
 
         let item_fn = syn::parse2::<ExportedFn>(input_tokens).unwrap();
         assert!(!item_fn.mutable_receiver());
-        assert_streams_eq(item_fn.generate(), expected_tokens);
+        assert_streams_eq(
+            item_fn.generate(&syn::parse_quote!(::rhai)),
+            expected_tokens,
+        );
     }
 }

--- a/codegen/src/test/function.rs
+++ b/codegen/src/test/function.rs
@@ -277,11 +277,11 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl Token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["()"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 0usize] { [] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 0usize] { [] }
                 }
-                impl PluginFunc for Token {
-                    #[inline(always)] fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        Ok(Dynamic::from(do_nothing()))
+                impl ::rhai::plugin::PluginFunc for Token {
+                    #[inline(always)] fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        Ok(::rhai::Dynamic::from(do_nothing()))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -291,8 +291,8 @@ mod generate_tests {
                 }
                 #[allow(unused)]
                 #[doc(hidden)]
-                #[inline(always)] pub fn dynamic_result_fn() -> RhaiResult {
-                    Ok(Dynamic::from(do_nothing()))
+                #[inline(always)] pub fn dynamic_result_fn() -> ::rhai::plugin::RhaiResult {
+                    Ok(::rhai::Dynamic::from(do_nothing()))
                 }
             }
         };
@@ -316,13 +316,13 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl Token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: usize", "()"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 1usize] { [TypeId::of::<usize>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 1usize] { [::core::any::TypeId::of::<usize>()] }
                 }
-                impl PluginFunc for Token {
+                impl ::rhai::plugin::PluginFunc for Token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg0 = mem::take(args[0usize]).cast::<usize>();
-                        Ok(Dynamic::from(do_something(arg0)))
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg0 = ::core::mem::take(args[0usize]).cast::<usize>();
+                        Ok(::rhai::Dynamic::from(do_something(arg0)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -332,8 +332,8 @@ mod generate_tests {
                 }
                 #[allow(unused)]
                 #[doc(hidden)]
-                #[inline(always)] pub fn dynamic_result_fn(x: usize) -> RhaiResult {
-                    Ok(Dynamic::from(do_something(x)))
+                #[inline(always)] pub fn dynamic_result_fn(x: usize) -> ::rhai::plugin::RhaiResult {
+                    Ok(::rhai::Dynamic::from(do_something(x)))
                 }
             }
         };
@@ -345,7 +345,7 @@ mod generate_tests {
     #[test]
     fn one_arg_fn_with_context() {
         let input_tokens: TokenStream = quote! {
-            pub fn do_something(context: NativeCallContext, x: usize) {}
+            pub fn do_something(context: ::rhai::NativeCallContext, x: usize) {}
         };
 
         let expected_tokens = quote! {
@@ -357,13 +357,13 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl Token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: usize", "()"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 1usize] { [TypeId::of::<usize>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 1usize] { [::core::any::TypeId::of::<usize>()] }
                 }
-                impl PluginFunc for Token {
+                impl ::rhai::plugin::PluginFunc for Token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg0 = mem::take(args[0usize]).cast::<usize>();
-                        Ok(Dynamic::from(do_something(context.unwrap(), arg0)))
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg0 = ::core::mem::take(args[0usize]).cast::<usize>();
+                        Ok(::rhai::Dynamic::from(do_something(context.unwrap(), arg0)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -373,14 +373,14 @@ mod generate_tests {
                 }
                 #[allow(unused)]
                 #[doc(hidden)]
-                #[inline(always)] pub fn dynamic_result_fn(context: NativeCallContext, x: usize) -> RhaiResult {
-                    Ok(Dynamic::from(do_something(context, x)))
+                #[inline(always)] pub fn dynamic_result_fn(context: ::rhai::NativeCallContext, x: usize) -> ::rhai::plugin::RhaiResult {
+                    Ok(::rhai::Dynamic::from(do_something(context, x)))
                 }
             }
         };
 
         let item_fn = syn::parse2::<ExportedFn>(input_tokens).unwrap();
-        assert!(item_fn.pass_context());
+        // assert!(item_fn.pass_context());
         assert_streams_eq(item_fn.generate(), expected_tokens);
     }
 
@@ -401,12 +401,12 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl Token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["rhai::Dynamic"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 0usize] { [] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 0usize] { [] }
                 }
-                impl PluginFunc for Token {
+                impl ::rhai::plugin::PluginFunc for Token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        Ok(Dynamic::from(return_dynamic()))
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        Ok(::rhai::Dynamic::from(return_dynamic()))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -416,8 +416,8 @@ mod generate_tests {
                 }
                 #[allow(unused)]
                 #[doc(hidden)]
-                #[inline(always)] pub fn dynamic_result_fn() -> RhaiResult {
-                    Ok(Dynamic::from(return_dynamic()))
+                #[inline(always)] pub fn dynamic_result_fn() -> ::rhai::plugin::RhaiResult {
+                    Ok(::rhai::Dynamic::from(return_dynamic()))
                 }
             }
         };
@@ -436,13 +436,13 @@ mod generate_tests {
             #[doc(hidden)]
             impl TestStruct {
                 pub const PARAM_NAMES: &'static [&'static str] = &["x: usize", "()"];
-                #[inline(always)] pub fn param_types() -> [TypeId; 1usize] { [TypeId::of::<usize>()] }
+                #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 1usize] { [::core::any::TypeId::of::<usize>()] }
             }
-            impl PluginFunc for TestStruct {
+            impl ::rhai::plugin::PluginFunc for TestStruct {
                 #[inline(always)]
-                fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                    let arg0 = mem::take(args[0usize]).cast::<usize>();
-                    Ok(Dynamic::from(do_something(arg0)))
+                fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                    let arg0 = ::core::mem::take(args[0usize]).cast::<usize>();
+                    Ok(::rhai::Dynamic::from(do_something(arg0)))
                 }
 
                 #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -471,14 +471,14 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl Token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: usize", "y: usize", "usize"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 2usize] { [TypeId::of::<usize>(), TypeId::of::<usize>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 2usize] { [::core::any::TypeId::of::<usize>(), ::core::any::TypeId::of::<usize>()] }
                 }
-                impl PluginFunc for Token {
+                impl ::rhai::plugin::PluginFunc for Token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg0 = mem::take(args[0usize]).cast::<usize>();
-                        let arg1 = mem::take(args[1usize]).cast::<usize>();
-                        Ok(Dynamic::from(add_together(arg0, arg1)))
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg0 = ::core::mem::take(args[0usize]).cast::<usize>();
+                        let arg1 = ::core::mem::take(args[1usize]).cast::<usize>();
+                        Ok(::rhai::Dynamic::from(add_together(arg0, arg1)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -488,8 +488,8 @@ mod generate_tests {
                 }
                 #[allow(unused)]
                 #[doc(hidden)]
-                #[inline(always)] pub fn dynamic_result_fn(x: usize, y: usize) -> RhaiResult {
-                    Ok(Dynamic::from(add_together(x, y)))
+                #[inline(always)] pub fn dynamic_result_fn(x: usize, y: usize) -> ::rhai::plugin::RhaiResult {
+                    Ok(::rhai::Dynamic::from(add_together(x, y)))
                 }
             }
         };
@@ -513,14 +513,14 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl Token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: &mut usize", "y: usize", "()"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 2usize] { [TypeId::of::<usize>(), TypeId::of::<usize>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 2usize] { [::core::any::TypeId::of::<usize>(), ::core::any::TypeId::of::<usize>()] }
                 }
-                impl PluginFunc for Token {
+                impl ::rhai::plugin::PluginFunc for Token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg1 = mem::take(args[1usize]).cast::<usize>();
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg1 = ::core::mem::take(args[1usize]).cast::<usize>();
                         let arg0 = &mut args[0usize].write_lock::<usize>().unwrap();
-                        Ok(Dynamic::from(increment(arg0, arg1)))
+                        Ok(::rhai::Dynamic::from(increment(arg0, arg1)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { true }
@@ -530,8 +530,8 @@ mod generate_tests {
                 }
                 #[allow(unused)]
                 #[doc(hidden)]
-                #[inline(always)] pub fn dynamic_result_fn(x: &mut usize, y: usize) -> RhaiResult {
-                    Ok(Dynamic::from(increment(x, y)))
+                #[inline(always)] pub fn dynamic_result_fn(x: &mut usize, y: usize) -> ::rhai::plugin::RhaiResult {
+                    Ok(::rhai::Dynamic::from(increment(x, y)))
                 }
             }
         };
@@ -556,13 +556,13 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl Token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["message: &str", "()"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 1usize] { [TypeId::of::<ImmutableString>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 1usize] { [::core::any::TypeId::of::<::rhai::ImmutableString>()] }
                 }
-                impl PluginFunc for Token {
+                impl ::rhai::plugin::PluginFunc for Token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg0 = mem::take(args[0usize]).into_immutable_string().unwrap();
-                        Ok(Dynamic::from(special_print(&arg0)))
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg0 = ::core::mem::take(args[0usize]).into_immutable_string().unwrap();
+                        Ok(::rhai::Dynamic::from(special_print(&arg0)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -572,8 +572,8 @@ mod generate_tests {
                 }
                 #[allow(unused)]
                 #[doc(hidden)]
-                #[inline(always)] pub fn dynamic_result_fn(message: &str) -> RhaiResult {
-                    Ok(Dynamic::from(special_print(message)))
+                #[inline(always)] pub fn dynamic_result_fn(message: &str) -> ::rhai::plugin::RhaiResult {
+                    Ok(::rhai::Dynamic::from(special_print(message)))
                 }
             }
         };

--- a/codegen/src/test/module.rs
+++ b/codegen/src/test/module.rs
@@ -295,15 +295,15 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                 }
             }
         };
@@ -333,16 +333,16 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("get_mystic_number").with_params_info(get_mystic_number_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("get_mystic_number").with_params_info(get_mystic_number_token::PARAM_NAMES)
                         .set_into_module_raw(_m, &get_mystic_number_token::param_types(), get_mystic_number_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -351,12 +351,12 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl get_mystic_number_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["INT"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 0usize] { [] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 0usize] { [] }
                 }
-                impl PluginFunc for get_mystic_number_token {
+                impl ::rhai::plugin::PluginFunc for get_mystic_number_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        Ok(Dynamic::from(get_mystic_number()))
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        Ok(::rhai::Dynamic::from(get_mystic_number()))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -426,8 +426,8 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     m.set_doc("/// This is the one_fn module!\n/** block doc-comment\n             *  multi-line\n             */\n/// Another line!\n/// Final line!");
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
@@ -435,8 +435,8 @@ mod generate_tests {
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("get_mystic_number").with_params_info(get_mystic_number_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("get_mystic_number").with_params_info(get_mystic_number_token::PARAM_NAMES)
                         .with_comments(&[
                             "/// This is a doc-comment.\n/// Another line.\n/// block doc-comment \n/// Final line.",
                             "/** doc-comment\n                    in multiple lines\n                 */"
@@ -450,12 +450,12 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl get_mystic_number_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["INT"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 0usize] { [] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 0usize] { [] }
                 }
-                impl PluginFunc for get_mystic_number_token {
+                impl ::rhai::plugin::PluginFunc for get_mystic_number_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        Ok(Dynamic::from(get_mystic_number()))
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        Ok(::rhai::Dynamic::from(get_mystic_number()))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -492,16 +492,16 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("add_one_to").with_namespace(FnNamespace::Global).with_params_info(add_one_to_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("add_one_to").with_namespace(::rhai::FnNamespace::Global).with_params_info(add_one_to_token::PARAM_NAMES)
                         .set_into_module_raw(_m, &add_one_to_token::param_types(), add_one_to_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -510,13 +510,13 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl add_one_to_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: INT", "INT"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 1usize] { [TypeId::of::<INT>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 1usize] { [::core::any::TypeId::of::<INT>()] }
                 }
-                impl PluginFunc for add_one_to_token {
+                impl ::rhai::plugin::PluginFunc for add_one_to_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg0 = mem::take(args[0usize]).cast::<INT>();
-                        Ok(Dynamic::from(add_one_to(arg0)))
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg0 = ::core::mem::take(args[0usize]).cast::<INT>();
+                        Ok(::rhai::Dynamic::from(add_one_to(arg0)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -552,16 +552,16 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("add_one_to").with_params_info(add_one_to_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("add_one_to").with_params_info(add_one_to_token::PARAM_NAMES)
                         .set_into_module_raw(_m, &add_one_to_token::param_types(), add_one_to_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -570,13 +570,13 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl add_one_to_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: INT", "INT"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 1usize] { [TypeId::of::<INT>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 1usize] { [::core::any::TypeId::of::<INT>()] }
                 }
-                impl PluginFunc for add_one_to_token {
+                impl ::rhai::plugin::PluginFunc for add_one_to_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg0 = mem::take(args[0usize]).cast::<INT>();
-                        Ok(Dynamic::from(add_one_to(arg0)))
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg0 = ::core::mem::take(args[0usize]).cast::<INT>();
+                        Ok(::rhai::Dynamic::from(add_one_to(arg0)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -623,18 +623,18 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("add_n").with_params_info(add_one_to_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("add_n").with_params_info(add_one_to_token::PARAM_NAMES)
                         .set_into_module_raw(_m, &add_one_to_token::param_types(), add_one_to_token().into());
-                    FuncRegistration::new("add_n").with_params_info(add_n_to_token::PARAM_NAMES)
+                    ::rhai::FuncRegistration::new("add_n").with_params_info(add_n_to_token::PARAM_NAMES)
                         .set_into_module_raw(_m, &add_n_to_token::param_types(), add_n_to_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -643,13 +643,13 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl add_one_to_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: INT", "INT"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 1usize] { [TypeId::of::<INT>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 1usize] { [::core::any::TypeId::of::<INT>()] }
                 }
-                impl PluginFunc for add_one_to_token {
+                impl ::rhai::plugin::PluginFunc for add_one_to_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg0 = mem::take(args[0usize]).cast::<INT>();
-                        Ok(Dynamic::from(add_one_to(arg0)))
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg0 = ::core::mem::take(args[0usize]).cast::<INT>();
+                        Ok(::rhai::Dynamic::from(add_one_to(arg0)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -664,14 +664,14 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl add_n_to_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: INT", "y: INT", "INT"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 2usize] { [TypeId::of::<INT>(), TypeId::of::<INT>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 2usize] { [::core::any::TypeId::of::<INT>(), ::core::any::TypeId::of::<INT>()] }
                 }
-                impl PluginFunc for add_n_to_token {
+                impl ::rhai::plugin::PluginFunc for add_n_to_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg0 = mem::take(args[0usize]).cast::<INT>();
-                        let arg1 = mem::take(args[1usize]).cast::<INT>();
-                        Ok(Dynamic::from(add_n_to(arg0, arg1)))
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg0 = ::core::mem::take(args[0usize]).cast::<INT>();
+                        let arg1 = ::core::mem::take(args[1usize]).cast::<INT>();
+                        Ok(::rhai::Dynamic::from(add_n_to(arg0, arg1)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -707,16 +707,16 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("add_together").with_params_info(add_together_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("add_together").with_params_info(add_together_token::PARAM_NAMES)
                         .set_into_module_raw(_m, &add_together_token::param_types(), add_together_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -725,14 +725,14 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl add_together_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: INT", "y: INT", "INT"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 2usize] { [TypeId::of::<INT>(), TypeId::of::<INT>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 2usize] { [::core::any::TypeId::of::<INT>(), ::core::any::TypeId::of::<INT>()] }
                 }
-                impl PluginFunc for add_together_token {
+                impl ::rhai::plugin::PluginFunc for add_together_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg0 = mem::take(args[0usize]).cast::<INT>();
-                        let arg1 = mem::take(args[1usize]).cast::<INT>();
-                        Ok(Dynamic::from(add_together(arg0, arg1)))
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg0 = ::core::mem::take(args[0usize]).cast::<INT>();
+                        let arg1 = ::core::mem::take(args[1usize]).cast::<INT>();
+                        Ok(::rhai::Dynamic::from(add_together(arg0, arg1)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -769,20 +769,20 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("add").with_params_info(add_together_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("add").with_params_info(add_together_token::PARAM_NAMES)
                         .set_into_module_raw(_m, &add_together_token::param_types(), add_together_token().into());
-                    FuncRegistration::new("+").with_params_info(add_together_token::PARAM_NAMES)
+                    ::rhai::FuncRegistration::new("+").with_params_info(add_together_token::PARAM_NAMES)
                         .set_into_module_raw(_m, &add_together_token::param_types(), add_together_token().into());
-                    FuncRegistration::new("add_together").with_params_info(add_together_token::PARAM_NAMES)
+                    ::rhai::FuncRegistration::new("add_together").with_params_info(add_together_token::PARAM_NAMES)
                         .set_into_module_raw(_m, &add_together_token::param_types(), add_together_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -791,14 +791,14 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl add_together_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: INT", "y: INT", "INT"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 2usize] { [TypeId::of::<INT>(), TypeId::of::<INT>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 2usize] { [::core::any::TypeId::of::<INT>(), ::core::any::TypeId::of::<INT>()] }
                 }
-                impl PluginFunc for add_together_token {
+                impl ::rhai::plugin::PluginFunc for add_together_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg0 = mem::take(args[0usize]).cast::<INT>();
-                        let arg1 = mem::take(args[1usize]).cast::<INT>();
-                        Ok(Dynamic::from(add_together(arg0, arg1)))
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg0 = ::core::mem::take(args[0usize]).cast::<INT>();
+                        let arg1 = ::core::mem::take(args[1usize]).cast::<INT>();
+                        Ok(::rhai::Dynamic::from(add_together(arg0, arg1)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -848,16 +848,16 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("get_mystic_number").with_params_info(get_mystic_number_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("get_mystic_number").with_params_info(get_mystic_number_token::PARAM_NAMES)
                         .set_into_module_raw(_m, &get_mystic_number_token::param_types(), get_mystic_number_token().into());
                     _m.set_var("MYSTIC_NUMBER", MYSTIC_NUMBER);
                     _m.set_custom_type::<Foo>("Hello");
@@ -869,13 +869,13 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl get_mystic_number_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: &mut Hello", "INT"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 1usize] { [TypeId::of::<Hello>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 1usize] { [::core::any::TypeId::of::<Hello>()] }
                 }
-                impl PluginFunc for get_mystic_number_token {
+                impl ::rhai::plugin::PluginFunc for get_mystic_number_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
                         let arg0 = &mut args[0usize].write_lock::<Hello>().unwrap();
-                        Ok(Dynamic::from(get_mystic_number(arg0)))
+                        Ok(::rhai::Dynamic::from(get_mystic_number(arg0)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { true }
@@ -907,15 +907,15 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                     _m.set_var("MYSTIC_NUMBER", MYSTIC_NUMBER);
                 }
             }
@@ -944,15 +944,15 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                     _m.set_var("MYSTIC_NUMBER", MYSTIC_NUMBER);
                 }
             }
@@ -983,15 +983,15 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                 }
             }
         };
@@ -1022,15 +1022,15 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                 }
             }
         };
@@ -1067,16 +1067,16 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("get_mystic_number").with_params_info(get_mystic_number_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("get_mystic_number").with_params_info(get_mystic_number_token::PARAM_NAMES)
                         .set_into_module_raw(_m, &get_mystic_number_token::param_types(), get_mystic_number_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -1085,12 +1085,12 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl get_mystic_number_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["INT"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 0usize] { [] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 0usize] { [] }
                 }
-                impl PluginFunc for get_mystic_number_token {
+                impl ::rhai::plugin::PluginFunc for get_mystic_number_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        Ok(Dynamic::from(get_mystic_number()))
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        Ok(::rhai::Dynamic::from(get_mystic_number()))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -1122,15 +1122,15 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                 }
             }
         };
@@ -1160,16 +1160,16 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("print_out_to").with_params_info(print_out_to_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("print_out_to").with_params_info(print_out_to_token::PARAM_NAMES)
                          .set_into_module_raw(_m, &print_out_to_token::param_types(), print_out_to_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -1178,13 +1178,13 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl print_out_to_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: &str", "()"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 1usize] { [TypeId::of::<ImmutableString>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 1usize] { [::core::any::TypeId::of::<::rhai::ImmutableString>()] }
                 }
-                impl PluginFunc for print_out_to_token {
+                impl ::rhai::plugin::PluginFunc for print_out_to_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg0 = mem::take(args[0usize]).into_immutable_string().unwrap();
-                        Ok(Dynamic::from(print_out_to(&arg0)))
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg0 = ::core::mem::take(args[0usize]).into_immutable_string().unwrap();
+                        Ok(::rhai::Dynamic::from(print_out_to(&arg0)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -1220,16 +1220,16 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("print_out_to").with_params_info(print_out_to_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("print_out_to").with_params_info(print_out_to_token::PARAM_NAMES)
                          .set_into_module_raw(_m, &print_out_to_token::param_types(), print_out_to_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -1238,13 +1238,13 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl print_out_to_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: String", "()"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 1usize] { [TypeId::of::<ImmutableString>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 1usize] { [::core::any::TypeId::of::<::rhai::ImmutableString>()] }
                 }
-                impl PluginFunc for print_out_to_token {
+                impl ::rhai::plugin::PluginFunc for print_out_to_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg0 = mem::take(args[0usize]).into_string().unwrap();
-                        Ok(Dynamic::from(print_out_to(arg0)))
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg0 = ::core::mem::take(args[0usize]).into_string().unwrap();
+                        Ok(::rhai::Dynamic::from(print_out_to(arg0)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { false }
@@ -1281,16 +1281,16 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("foo").with_params_info(foo_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("foo").with_params_info(foo_token::PARAM_NAMES)
                          .set_into_module_raw(_m, &foo_token::param_types(), foo_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -1299,14 +1299,14 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl foo_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: &mut FLOAT", "y: INT", "FLOAT"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 2usize] { [TypeId::of::<FLOAT>(), TypeId::of::<INT>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 2usize] { [::core::any::TypeId::of::<FLOAT>(), ::core::any::TypeId::of::<INT>()] }
                 }
-                impl PluginFunc for foo_token {
+                impl ::rhai::plugin::PluginFunc for foo_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg1 = mem::take(args[1usize]).cast::<INT>();
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg1 = ::core::mem::take(args[1usize]).cast::<INT>();
                         let arg0 = &mut args[0usize].write_lock::<FLOAT>().unwrap();
-                        Ok(Dynamic::from(foo(arg0, arg1)))
+                        Ok(::rhai::Dynamic::from(foo(arg0, arg1)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { true }
@@ -1342,16 +1342,16 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("increment").with_params_info(increment_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("increment").with_params_info(increment_token::PARAM_NAMES)
                          .set_into_module_raw(_m, &increment_token::param_types(), increment_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -1360,13 +1360,13 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl increment_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: &mut FLOAT", "()"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 1usize] { [TypeId::of::<FLOAT>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 1usize] { [::core::any::TypeId::of::<FLOAT>()] }
                 }
-                impl PluginFunc for increment_token {
+                impl ::rhai::plugin::PluginFunc for increment_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
                         let arg0 = &mut args[0usize].write_lock::<FLOAT>().unwrap();
-                        Ok(Dynamic::from(increment(arg0)))
+                        Ok(::rhai::Dynamic::from(increment(arg0)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { true }
@@ -1406,16 +1406,16 @@ mod generate_tests {
 
                     #[doc(hidden)]
                     #[inline(always)]
-                    pub fn rhai_module_generate() -> Module {
-                        let mut m = Module::new();
+                    pub fn rhai_module_generate() -> ::rhai::Module {
+                        let mut m = ::rhai::Module::new();
                         rhai_generate_into_module(&mut m, false);
                         m.build_index();
                         m
                     }
                     #[doc(hidden)]
                     #[inline(always)]
-                    pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("increment").with_params_info(increment_token::PARAM_NAMES)
+                    pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("increment").with_params_info(increment_token::PARAM_NAMES)
                              .set_into_module_raw(_m, &increment_token::param_types(), increment_token().into());
                     }
                     #[allow(non_camel_case_types)]
@@ -1424,13 +1424,13 @@ mod generate_tests {
                     #[doc(hidden)]
                     impl increment_token {
                         pub const PARAM_NAMES: &'static [&'static str] = &["x: &mut FLOAT", "()"];
-                        #[inline(always)] pub fn param_types() -> [TypeId; 1usize] { [TypeId::of::<FLOAT>()] }
+                        #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 1usize] { [::core::any::TypeId::of::<FLOAT>()] }
                     }
-                    impl PluginFunc for increment_token {
+                    impl ::rhai::plugin::PluginFunc for increment_token {
                         #[inline(always)]
-                        fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
+                        fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
                             let arg0 = &mut args[0usize].write_lock::<FLOAT>().unwrap();
-                            Ok(Dynamic::from(increment(arg0)))
+                            Ok(::rhai::Dynamic::from(increment(arg0)))
                         }
 
                         #[inline(always)] fn is_method_call(&self) -> bool { true }
@@ -1444,15 +1444,15 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                     if _flatten {
                         self::it_is::rhai_generate_into_module(_m, _flatten);
                     } else {
@@ -1491,16 +1491,16 @@ mod generate_tests {
 
                     #[doc(hidden)]
                     #[inline(always)]
-                    pub fn rhai_module_generate() -> Module {
-                        let mut m = Module::new();
+                    pub fn rhai_module_generate() -> ::rhai::Module {
+                        let mut m = ::rhai::Module::new();
                         rhai_generate_into_module(&mut m, false);
                         m.build_index();
                         m
                     }
                     #[doc(hidden)]
                     #[inline(always)]
-                    pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("increment").with_params_info(increment_token::PARAM_NAMES)
+                    pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("increment").with_params_info(increment_token::PARAM_NAMES)
                              .set_into_module_raw(_m, &increment_token::param_types(), increment_token().into());
                     }
                     #[allow(non_camel_case_types)]
@@ -1509,13 +1509,13 @@ mod generate_tests {
                     #[doc(hidden)]
                     impl increment_token {
                         pub const PARAM_NAMES: &'static [&'static str] = &["x: &mut FLOAT", "()"];
-                        #[inline(always)] pub fn param_types() -> [TypeId; 1usize] { [TypeId::of::<FLOAT>()] }
+                        #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 1usize] { [::core::any::TypeId::of::<FLOAT>()] }
                     }
-                    impl PluginFunc for increment_token {
+                    impl ::rhai::plugin::PluginFunc for increment_token {
                         #[inline(always)]
-                        fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
+                        fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
                             let arg0 = &mut args[0usize].write_lock::<FLOAT>().unwrap();
-                            Ok(Dynamic::from(increment(arg0)))
+                            Ok(::rhai::Dynamic::from(increment(arg0)))
                         }
 
                         #[inline(always)] fn is_method_call(&self) -> bool { true }
@@ -1529,15 +1529,15 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                     if _flatten {
                         self::it_is::rhai_generate_into_module(_m, _flatten);
                     } else {
@@ -1573,16 +1573,16 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("get$square").with_namespace(FnNamespace::Global).with_params_info(int_foo_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("get$square").with_namespace(::rhai::FnNamespace::Global).with_params_info(int_foo_token::PARAM_NAMES)
                          .set_into_module_raw(_m, &int_foo_token::param_types(), int_foo_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -1591,13 +1591,13 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl int_foo_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: &mut u64", "u64"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 1usize] { [TypeId::of::<u64>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 1usize] { [::core::any::TypeId::of::<u64>()] }
                 }
-                impl PluginFunc for int_foo_token {
+                impl ::rhai::plugin::PluginFunc for int_foo_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
                         let arg0 = &mut args[0usize].write_lock::<u64>().unwrap();
-                        Ok(Dynamic::from(int_foo(arg0)))
+                        Ok(::rhai::Dynamic::from(int_foo(arg0)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { true }
@@ -1634,18 +1634,18 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("square").with_params_info(int_foo_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("square").with_params_info(int_foo_token::PARAM_NAMES)
                          .set_into_module_raw(_m, &int_foo_token::param_types(), int_foo_token().into());
-                    FuncRegistration::new("get$square").with_namespace(FnNamespace::Global).with_params_info(int_foo_token::PARAM_NAMES)
+                    ::rhai::FuncRegistration::new("get$square").with_namespace(::rhai::FnNamespace::Global).with_params_info(int_foo_token::PARAM_NAMES)
                          .set_into_module_raw(_m, &int_foo_token::param_types(), int_foo_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -1654,13 +1654,13 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl int_foo_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: &mut u64", "u64"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 1usize] { [TypeId::of::<u64>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 1usize] { [::core::any::TypeId::of::<u64>()] }
                 }
-                impl PluginFunc for int_foo_token {
+                impl ::rhai::plugin::PluginFunc for int_foo_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
                         let arg0 = &mut args[0usize].write_lock::<u64>().unwrap();
-                        Ok(Dynamic::from(int_foo(arg0)))
+                        Ok(::rhai::Dynamic::from(int_foo(arg0)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { true }
@@ -1697,16 +1697,16 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("set$squared").with_namespace(FnNamespace::Global).with_params_info(int_foo_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("set$squared").with_namespace(::rhai::FnNamespace::Global).with_params_info(int_foo_token::PARAM_NAMES)
                          .set_into_module_raw(_m, &int_foo_token::param_types(), int_foo_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -1715,14 +1715,14 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl int_foo_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: &mut u64", "y: u64", "()"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 2usize] { [TypeId::of::<u64>(), TypeId::of::<u64>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 2usize] { [::core::any::TypeId::of::<u64>(), ::core::any::TypeId::of::<u64>()] }
                 }
-                impl PluginFunc for int_foo_token {
+                impl ::rhai::plugin::PluginFunc for int_foo_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg1 = mem::take(args[1usize]).cast::<u64>();
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg1 = ::core::mem::take(args[1usize]).cast::<u64>();
                         let arg0 = &mut args[0usize].write_lock::<u64>().unwrap();
-                        Ok(Dynamic::from(int_foo(arg0, arg1)))
+                        Ok(::rhai::Dynamic::from(int_foo(arg0, arg1)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { true }
@@ -1759,18 +1759,18 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("set_sq").with_params_info(int_foo_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("set_sq").with_params_info(int_foo_token::PARAM_NAMES)
                          .set_into_module_raw(_m, &int_foo_token::param_types(), int_foo_token().into());
-                    FuncRegistration::new("set$squared").with_namespace(FnNamespace::Global).with_params_info(int_foo_token::PARAM_NAMES)
+                    ::rhai::FuncRegistration::new("set$squared").with_namespace(::rhai::FnNamespace::Global).with_params_info(int_foo_token::PARAM_NAMES)
                          .set_into_module_raw(_m, &int_foo_token::param_types(), int_foo_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -1779,14 +1779,14 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl int_foo_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: &mut u64", "y: u64", "()"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 2usize] { [TypeId::of::<u64>(), TypeId::of::<u64>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 2usize] { [::core::any::TypeId::of::<u64>(), ::core::any::TypeId::of::<u64>()] }
                 }
-                impl PluginFunc for int_foo_token {
+                impl ::rhai::plugin::PluginFunc for int_foo_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg1 = mem::take(args[1usize]).cast::<u64>();
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg1 = ::core::mem::take(args[1usize]).cast::<u64>();
                         let arg0 = &mut args[0usize].write_lock::<u64>().unwrap();
-                        Ok(Dynamic::from(int_foo(arg0, arg1)))
+                        Ok(::rhai::Dynamic::from(int_foo(arg0, arg1)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { true }
@@ -1823,16 +1823,16 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("index$get$").with_namespace(FnNamespace::Global).with_params_info(get_by_index_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("index$get$").with_namespace(::rhai::FnNamespace::Global).with_params_info(get_by_index_token::PARAM_NAMES)
                          .set_into_module_raw(_m, &get_by_index_token::param_types(), get_by_index_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -1841,14 +1841,14 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl get_by_index_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: &mut MyCollection", "i: u64", "FLOAT"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 2usize] { [TypeId::of::<MyCollection>(), TypeId::of::<u64>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 2usize] { [::core::any::TypeId::of::<MyCollection>(), ::core::any::TypeId::of::<u64>()] }
                 }
-                impl PluginFunc for get_by_index_token {
+                impl ::rhai::plugin::PluginFunc for get_by_index_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg1 = mem::take(args[1usize]).cast::<u64>();
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg1 = ::core::mem::take(args[1usize]).cast::<u64>();
                         let arg0 = &mut args[0usize].write_lock::<MyCollection>().unwrap();
-                        Ok(Dynamic::from(get_by_index(arg0, arg1)))
+                        Ok(::rhai::Dynamic::from(get_by_index(arg0, arg1)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { true }
@@ -1889,17 +1889,17 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                     #[cfg(hello)]
-                    FuncRegistration::new("index$get$").with_namespace(FnNamespace::Global).with_params_info(get_by_index_token::PARAM_NAMES)
+                    ::rhai::FuncRegistration::new("index$get$").with_namespace(::rhai::FnNamespace::Global).with_params_info(get_by_index_token::PARAM_NAMES)
                          .set_into_module_raw(_m, &get_by_index_token::param_types(), get_by_index_token().into());
                 }
                 #[cfg(hello)]
@@ -1910,15 +1910,15 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl get_by_index_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: &mut MyCollection", "i: u64", "FLOAT"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 2usize] { [TypeId::of::<MyCollection>(), TypeId::of::<u64>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 2usize] { [::core::any::TypeId::of::<MyCollection>(), ::core::any::TypeId::of::<u64>()] }
                 }
                 #[cfg(hello)]
-                impl PluginFunc for get_by_index_token {
+                impl ::rhai::plugin::PluginFunc for get_by_index_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg1 = mem::take(args[1usize]).cast::<u64>();
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg1 = ::core::mem::take(args[1usize]).cast::<u64>();
                         let arg0 = &mut args[0usize].write_lock::<MyCollection>().unwrap();
-                        Ok(Dynamic::from(get_by_index(arg0, arg1)))
+                        Ok(::rhai::Dynamic::from(get_by_index(arg0, arg1)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { true }
@@ -1955,18 +1955,18 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("get").with_params_info(get_by_index_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("get").with_params_info(get_by_index_token::PARAM_NAMES)
                          .set_into_module_raw(_m, &get_by_index_token::param_types(), get_by_index_token().into());
-                    FuncRegistration::new("index$get$").with_namespace(FnNamespace::Global).with_params_info(get_by_index_token::PARAM_NAMES)
+                    ::rhai::FuncRegistration::new("index$get$").with_namespace(::rhai::FnNamespace::Global).with_params_info(get_by_index_token::PARAM_NAMES)
                          .set_into_module_raw(_m, &get_by_index_token::param_types(), get_by_index_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -1975,14 +1975,14 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl get_by_index_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: &mut MyCollection", "i: u64", "FLOAT"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 2usize] { [TypeId::of::<MyCollection>(), TypeId::of::<u64>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 2usize] { [::core::any::TypeId::of::<MyCollection>(), ::core::any::TypeId::of::<u64>()] }
                 }
-                impl PluginFunc for get_by_index_token {
+                impl ::rhai::plugin::PluginFunc for get_by_index_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg1 = mem::take(args[1usize]).cast::<u64>();
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg1 = ::core::mem::take(args[1usize]).cast::<u64>();
                         let arg0 = &mut args[0usize].write_lock::<MyCollection>().unwrap();
-                        Ok(Dynamic::from(get_by_index(arg0, arg1)))
+                        Ok(::rhai::Dynamic::from(get_by_index(arg0, arg1)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { true }
@@ -2019,16 +2019,16 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("index$set$").with_namespace(FnNamespace::Global).with_params_info(set_by_index_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("index$set$").with_namespace(::rhai::FnNamespace::Global).with_params_info(set_by_index_token::PARAM_NAMES)
                          .set_into_module_raw(_m, &set_by_index_token::param_types(), set_by_index_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -2037,15 +2037,15 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl set_by_index_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: &mut MyCollection", "i: u64", "item: FLOAT", "()"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 3usize] { [TypeId::of::<MyCollection>(), TypeId::of::<u64>(), TypeId::of::<FLOAT>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 3usize] { [::core::any::TypeId::of::<MyCollection>(), ::core::any::TypeId::of::<u64>(), ::core::any::TypeId::of::<FLOAT>()] }
                 }
-                impl PluginFunc for set_by_index_token {
+                impl ::rhai::plugin::PluginFunc for set_by_index_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg1 = mem::take(args[1usize]).cast::<u64>();
-                        let arg2 = mem::take(args[2usize]).cast::<FLOAT>();
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg1 = ::core::mem::take(args[1usize]).cast::<u64>();
+                        let arg2 = ::core::mem::take(args[2usize]).cast::<FLOAT>();
                         let arg0 = &mut args[0usize].write_lock::<MyCollection>().unwrap();
-                        Ok(Dynamic::from(set_by_index(arg0, arg1, arg2)))
+                        Ok(::rhai::Dynamic::from(set_by_index(arg0, arg1, arg2)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { true }
@@ -2082,18 +2082,18 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
-                    FuncRegistration::new("set").with_params_info(set_by_index_token::PARAM_NAMES)
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
+                    ::rhai::FuncRegistration::new("set").with_params_info(set_by_index_token::PARAM_NAMES)
                          .set_into_module_raw(_m, &set_by_index_token::param_types(), set_by_index_token().into());
-                    FuncRegistration::new("index$set$").with_namespace(FnNamespace::Global).with_params_info(set_by_index_token::PARAM_NAMES)
+                    ::rhai::FuncRegistration::new("index$set$").with_namespace(::rhai::FnNamespace::Global).with_params_info(set_by_index_token::PARAM_NAMES)
                          .set_into_module_raw(_m, &set_by_index_token::param_types(), set_by_index_token().into());
                 }
                 #[allow(non_camel_case_types)]
@@ -2102,15 +2102,15 @@ mod generate_tests {
                 #[doc(hidden)]
                 impl set_by_index_token {
                     pub const PARAM_NAMES: &'static [&'static str] = &["x: &mut MyCollection", "i: u64", "item: FLOAT", "()"];
-                    #[inline(always)] pub fn param_types() -> [TypeId; 3usize] { [TypeId::of::<MyCollection>(), TypeId::of::<u64>(), TypeId::of::<FLOAT>()] }
+                    #[inline(always)] pub fn param_types() -> [::core::any::TypeId; 3usize] { [::core::any::TypeId::of::<MyCollection>(), ::core::any::TypeId::of::<u64>(), ::core::any::TypeId::of::<FLOAT>()] }
                 }
-                impl PluginFunc for set_by_index_token {
+                impl ::rhai::plugin::PluginFunc for set_by_index_token {
                     #[inline(always)]
-                    fn call(&self, context: Option<NativeCallContext>, args: &mut [&mut Dynamic]) -> RhaiResult {
-                        let arg1 = mem::take(args[1usize]).cast::<u64>();
-                        let arg2 = mem::take(args[2usize]).cast::<FLOAT>();
+                    fn call(&self, context: Option<::rhai::NativeCallContext>, args: &mut [&mut ::rhai::Dynamic]) -> ::rhai::plugin::RhaiResult {
+                        let arg1 = ::core::mem::take(args[1usize]).cast::<u64>();
+                        let arg2 = ::core::mem::take(args[2usize]).cast::<FLOAT>();
                         let arg0 = &mut args[0usize].write_lock::<MyCollection>().unwrap();
-                        Ok(Dynamic::from(set_by_index(arg0, arg1, arg2)))
+                        Ok(::rhai::Dynamic::from(set_by_index(arg0, arg1, arg2)))
                     }
 
                     #[inline(always)] fn is_method_call(&self) -> bool { true }
@@ -2146,15 +2146,15 @@ mod generate_tests {
 
                     #[doc(hidden)]
                     #[inline(always)]
-                    pub fn rhai_module_generate() -> Module {
-                        let mut m = Module::new();
+                    pub fn rhai_module_generate() -> ::rhai::Module {
+                        let mut m = ::rhai::Module::new();
                         rhai_generate_into_module(&mut m, false);
                         m.build_index();
                         m
                     }
                     #[doc(hidden)]
                     #[inline(always)]
-                    pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                    pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                         _m.set_var("MYSTIC_NUMBER", MYSTIC_NUMBER);
                     }
                 }
@@ -2163,15 +2163,15 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                     if _flatten {
                         self::it_is::rhai_generate_into_module(_m, _flatten);
                     } else {
@@ -2210,15 +2210,15 @@ mod generate_tests {
 
                     #[doc(hidden)]
                     #[inline(always)]
-                    pub fn rhai_module_generate() -> Module {
-                        let mut m = Module::new();
+                    pub fn rhai_module_generate() -> ::rhai::Module {
+                        let mut m = ::rhai::Module::new();
                         rhai_generate_into_module(&mut m, false);
                         m.build_index();
                         m
                     }
                     #[doc(hidden)]
                     #[inline(always)]
-                    pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                    pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                         _m.set_var("MYSTIC_NUMBER", MYSTIC_NUMBER);
                     }
                 }
@@ -2231,15 +2231,15 @@ mod generate_tests {
 
                     #[doc(hidden)]
                     #[inline(always)]
-                    pub fn rhai_module_generate() -> Module {
-                        let mut m = Module::new();
+                    pub fn rhai_module_generate() -> ::rhai::Module {
+                        let mut m = ::rhai::Module::new();
                         rhai_generate_into_module(&mut m, false);
                         m.build_index();
                         m
                     }
                     #[doc(hidden)]
                     #[inline(always)]
-                    pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                    pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                         #[cfg(hello)]
                         _m.set_var("SPECIAL_CPU_NUMBER", SPECIAL_CPU_NUMBER);
                     }
@@ -2249,15 +2249,15 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                     if _flatten {
                         self::first_is::rhai_generate_into_module(_m, _flatten);
                         self::second_is::rhai_generate_into_module(_m, _flatten);
@@ -2323,15 +2323,15 @@ mod generate_tests {
 
                             #[doc(hidden)]
                             #[inline(always)]
-                            pub fn rhai_module_generate() -> Module {
-                                let mut m = Module::new();
+                            pub fn rhai_module_generate() -> ::rhai::Module {
+                                let mut m = ::rhai::Module::new();
                                 rhai_generate_into_module(&mut m, false);
                                 m.build_index();
                                 m
                             }
                             #[doc(hidden)]
                             #[inline(always)]
-                            pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                            pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                                 _m.set_var("VALUE", VALUE);
                             }
                         }
@@ -2343,15 +2343,15 @@ mod generate_tests {
 
                             #[doc(hidden)]
                             #[inline(always)]
-                            pub fn rhai_module_generate() -> Module {
-                                let mut m = Module::new();
+                            pub fn rhai_module_generate() -> ::rhai::Module {
+                                let mut m = ::rhai::Module::new();
                                 rhai_generate_into_module(&mut m, false);
                                 m.build_index();
                                 m
                             }
                             #[doc(hidden)]
                             #[inline(always)]
-                            pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                            pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                                 _m.set_var("VALUE", VALUE);
                             }
                         }
@@ -2360,15 +2360,15 @@ mod generate_tests {
 
                         #[doc(hidden)]
                         #[inline(always)]
-                        pub fn rhai_module_generate() -> Module {
-                            let mut m = Module::new();
+                        pub fn rhai_module_generate() -> ::rhai::Module {
+                            let mut m = ::rhai::Module::new();
                             rhai_generate_into_module(&mut m, false);
                             m.build_index();
                             m
                         }
                         #[doc(hidden)]
                         #[inline(always)]
-                        pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                        pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                             _m.set_var("VALUE", VALUE);
 
                             if _flatten {
@@ -2388,15 +2388,15 @@ mod generate_tests {
 
                         #[doc(hidden)]
                         #[inline(always)]
-                        pub fn rhai_module_generate() -> Module {
-                            let mut m = Module::new();
+                        pub fn rhai_module_generate() -> ::rhai::Module {
+                            let mut m = ::rhai::Module::new();
                             rhai_generate_into_module(&mut m, false);
                             m.build_index();
                             m
                         }
                         #[doc(hidden)]
                         #[inline(always)]
-                        pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                        pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                             _m.set_var("VALUE", VALUE);
                         }
                     }
@@ -2405,15 +2405,15 @@ mod generate_tests {
 
                     #[doc(hidden)]
                     #[inline(always)]
-                    pub fn rhai_module_generate() -> Module {
-                        let mut m = Module::new();
+                    pub fn rhai_module_generate() -> ::rhai::Module {
+                        let mut m = ::rhai::Module::new();
                         rhai_generate_into_module(&mut m, false);
                         m.build_index();
                         m
                     }
                     #[doc(hidden)]
                     #[inline(always)]
-                    pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                    pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                         _m.set_var("VALUE", VALUE);
 
                         if _flatten {
@@ -2436,15 +2436,15 @@ mod generate_tests {
 
                         #[doc(hidden)]
                         #[inline(always)]
-                        pub fn rhai_module_generate() -> Module {
-                            let mut m = Module::new();
+                        pub fn rhai_module_generate() -> ::rhai::Module {
+                            let mut m = ::rhai::Module::new();
                             rhai_generate_into_module(&mut m, false);
                             m.build_index();
                             m
                         }
                         #[doc(hidden)]
                         #[inline(always)]
-                        pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                        pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                             _m.set_var("VALUE", VALUE);
                         }
                     }
@@ -2456,15 +2456,15 @@ mod generate_tests {
 
                         #[doc(hidden)]
                         #[inline(always)]
-                        pub fn rhai_module_generate() -> Module {
-                            let mut m = Module::new();
+                        pub fn rhai_module_generate() -> ::rhai::Module {
+                            let mut m = ::rhai::Module::new();
                             rhai_generate_into_module(&mut m, false);
                             m.build_index();
                             m
                         }
                         #[doc(hidden)]
                         #[inline(always)]
-                        pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                        pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                             _m.set_var("VALUE", VALUE);
                         }
                     }
@@ -2473,15 +2473,15 @@ mod generate_tests {
 
                     #[doc(hidden)]
                     #[inline(always)]
-                    pub fn rhai_module_generate() -> Module {
-                        let mut m = Module::new();
+                    pub fn rhai_module_generate() -> ::rhai::Module {
+                        let mut m = ::rhai::Module::new();
                         rhai_generate_into_module(&mut m, false);
                         m.build_index();
                         m
                     }
                     #[doc(hidden)]
                     #[inline(always)]
-                    pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                    pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                         _m.set_var("VALUE", VALUE);
 
                         if _flatten {
@@ -2498,15 +2498,15 @@ mod generate_tests {
 
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_module_generate() -> Module {
-                    let mut m = Module::new();
+                pub fn rhai_module_generate() -> ::rhai::Module {
+                    let mut m = ::rhai::Module::new();
                     rhai_generate_into_module(&mut m, false);
                     m.build_index();
                     m
                 }
                 #[doc(hidden)]
                 #[inline(always)]
-                pub fn rhai_generate_into_module(_m: &mut Module, _flatten: bool) {
+                pub fn rhai_generate_into_module(_m: &mut ::rhai::Module, _flatten: bool) {
                     _m.set_var("VALUE", VALUE);
 
                     if _flatten {

--- a/codegen/tests/custom_root/Cargo.toml
+++ b/codegen/tests/custom_root/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "custom_root"
 version = "0.1.0"
-edition = "2024"
+edition = "2018"
+resolver = "2"
 
 [dev-dependencies]
 oldrhai = { package = "rhai", path = "../../.." }

--- a/codegen/tests/custom_root/Cargo.toml
+++ b/codegen/tests/custom_root/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "custom_root"
+version = "0.1.0"
+edition = "2024"
+
+[dev-dependencies]
+oldrhai = { package = "rhai", path = "../../.." }

--- a/codegen/tests/custom_root/Cargo.toml
+++ b/codegen/tests/custom_root/Cargo.toml
@@ -6,3 +6,6 @@ resolver = "2"
 
 [dev-dependencies]
 oldrhai = { package = "rhai", path = "../../.." }
+
+[features]
+metadata = []

--- a/codegen/tests/custom_root/src/lib.rs
+++ b/codegen/tests/custom_root/src/lib.rs
@@ -48,6 +48,5 @@ fn custom_root_module_test() -> Result<(), Box<oldrhai::EvalAltResult>> {
         engine.eval::<oldrhai::FLOAT>(r#"let m = Math::Advanced::get_mystic_number();m"#)?,
         42.0
     );
-    panic!();
     Ok(())
 }

--- a/codegen/tests/custom_root/src/lib.rs
+++ b/codegen/tests/custom_root/src/lib.rs
@@ -1,0 +1,53 @@
+#[test]
+fn custom_root_test() {
+    #[derive(Clone, oldrhai::CustomType)]
+    #[rhai_type(name = "MyBar", extra = Self::build_extra, root=oldrhai)]
+    pub struct Bar(
+        #[rhai_type(skip)] f32,
+        u32,
+        #[rhai_type(name = "boo", readonly)] String,
+        Vec<u32>,
+    );
+
+    impl Bar {
+        fn build_extra(builder: &mut oldrhai::TypeBuilder<Self>) {
+            builder.with_fn("new_int", || 42);
+        }
+    }
+
+    let mut engine = oldrhai::Engine::new();
+    engine.build_type::<Bar>();
+
+    assert_eq!(
+        engine
+            .eval::<i32>(
+                "
+                        new_int()
+                    "
+            )
+            .unwrap(),
+        42
+    );
+}
+
+#[test]
+fn custom_root_module_test() -> Result<(), Box<oldrhai::EvalAltResult>> {
+    #[oldrhai::plugin::export_module(root = "oldrhai")]
+    pub mod advanced_math {
+        use oldrhai::FLOAT;
+        pub fn get_mystic_number() -> FLOAT {
+            42.0 as FLOAT
+        }
+    }
+
+    let mut engine = oldrhai::Engine::new();
+    let m = oldrhai::exported_module!(advanced_math);
+    engine.register_static_module("Math::Advanced", m.into());
+
+    assert_eq!(
+        engine.eval::<oldrhai::FLOAT>(r#"let m = Math::Advanced::get_mystic_number();m"#)?,
+        42.0
+    );
+    panic!();
+    Ok(())
+}

--- a/codegen/tests/test_custom_type.rs
+++ b/codegen/tests/test_custom_type.rs
@@ -1,4 +1,4 @@
-use rhai::{CustomType, Dynamic, Engine, EvalAltResult, Position, TypeBuilder, INT};
+use rhai::{CustomType, Engine, TypeBuilder, INT};
 
 // Sanity check to make sure everything compiles
 

--- a/codegen/ui_tests/non_clonable.stderr
+++ b/codegen/ui_tests/non_clonable.stderr
@@ -7,13 +7,13 @@ error[E0277]: the trait bound `NonClonable: Clone` is not satisfied
    |                       the trait `Clone` is not implemented for `NonClonable`
    |                       required by a bound introduced by this call
    |
-note: required by a bound in `rhai::Dynamic::cast`
+note: required by a bound in `Dynamic::cast`
   --> $WORKSPACE/src/types/dynamic.rs
    |
    |     pub fn cast<T: Any + Clone>(self) -> T {
    |                          ^^^^^ required by this bound in `Dynamic::cast`
 help: consider annotating `NonClonable` with `#[derive(Clone)]`
    |
-   4 + #[derive(Clone)]
-   5 | struct NonClonable {
-     |
+ 4 + #[derive(Clone)]
+ 5 | struct NonClonable {
+   |

--- a/codegen/ui_tests/non_clonable_second.stderr
+++ b/codegen/ui_tests/non_clonable_second.stderr
@@ -7,13 +7,13 @@ error[E0277]: the trait bound `NonClonable: Clone` is not satisfied
    |                           the trait `Clone` is not implemented for `NonClonable`
    |                           required by a bound introduced by this call
    |
-note: required by a bound in `rhai::Dynamic::cast`
+note: required by a bound in `Dynamic::cast`
   --> $WORKSPACE/src/types/dynamic.rs
    |
    |     pub fn cast<T: Any + Clone>(self) -> T {
    |                          ^^^^^ required by this bound in `Dynamic::cast`
 help: consider annotating `NonClonable` with `#[derive(Clone)]`
    |
-   4 + #[derive(Clone)]
-   5 | struct NonClonable {
-     |
+ 4 + #[derive(Clone)]
+ 5 | struct NonClonable {
+   |

--- a/codegen/ui_tests/rhai_fn_non_clonable_return.stderr
+++ b/codegen/ui_tests/rhai_fn_non_clonable_return.stderr
@@ -1,12 +1,18 @@
 error[E0277]: the trait bound `NonClonable: Clone` is not satisfied
   --> ui_tests/rhai_fn_non_clonable_return.rs:12:31
    |
-11 | #[export_fn]
-   | ------------ in this attribute macro expansion
-12 | pub fn test_fn(input: f32) -> NonClonable {
-   |                               ^^^^^^^^^^^ the trait `Clone` is not implemented for `NonClonable`
+11 |   #[export_fn]
+   |   ------------
+   |   |
+   |  _in this attribute macro expansion
+   | |
+12 | | pub fn test_fn(input: f32) -> NonClonable {
+   | |                               ^^^^^^^^^^-
+   | |_______________________________|_________|
+   |                                 |         required by a bound introduced by this call
+   |                                 the trait `Clone` is not implemented for `NonClonable`
    |
-note: required by a bound in `rhai::Dynamic::from`
+note: required by a bound in `Dynamic::from`
   --> $WORKSPACE/src/types/dynamic.rs
    |
    |     pub fn from<T: Variant + Clone>(value: T) -> Self {
@@ -14,6 +20,6 @@ note: required by a bound in `rhai::Dynamic::from`
    = note: this error originates in the attribute macro `export_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `NonClonable` with `#[derive(Clone)]`
    |
-   4 + #[derive(Clone)]
-   5 | struct NonClonable {
-     |
+ 4 + #[derive(Clone)]
+ 5 | struct NonClonable {
+   |

--- a/codegen/ui_tests/rhai_mod_non_clonable_return.stderr
+++ b/codegen/ui_tests/rhai_mod_non_clonable_return.stderr
@@ -1,13 +1,19 @@
 error[E0277]: the trait bound `NonClonable: Clone` is not satisfied
   --> ui_tests/rhai_mod_non_clonable_return.rs:12:35
    |
-10 | #[export_module]
-   | ---------------- in this attribute macro expansion
-11 | pub mod test_mod {
-12 |     pub fn test_fn(input: f32) -> NonClonable {
-   |                                   ^^^^^^^^^^^ the trait `Clone` is not implemented for `NonClonable`
+10 |   #[export_module]
+   |   ----------------
+   |   |
+   |  _in this attribute macro expansion
+   | |
+11 | | pub mod test_mod {
+12 | |     pub fn test_fn(input: f32) -> NonClonable {
+   | |                                   ^^^^^^^^^^-
+   | |___________________________________|_________|
+   |                                     |         required by a bound introduced by this call
+   |                                     the trait `Clone` is not implemented for `NonClonable`
    |
-note: required by a bound in `rhai::Dynamic::from`
+note: required by a bound in `Dynamic::from`
   --> $WORKSPACE/src/types/dynamic.rs
    |
    |     pub fn from<T: Variant + Clone>(value: T) -> Self {
@@ -15,6 +21,6 @@ note: required by a bound in `rhai::Dynamic::from`
    = note: this error originates in the attribute macro `export_module` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `NonClonable` with `#[derive(Clone)]`
    |
-   3 + #[derive(Clone)]
-   4 | struct NonClonable {
-     |
+ 3 + #[derive(Clone)]
+ 4 | struct NonClonable {
+   |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,9 @@ extern crate no_std_compat as std;
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
 
+// The code emitted by codegen relies on this
+extern crate self as rhai;
+
 // Internal modules
 #[macro_use]
 mod reify;

--- a/src/packages/blob_basic.rs
+++ b/src/packages/blob_basic.rs
@@ -3,12 +3,12 @@
 use crate::eval::{calc_index, calc_offset_len};
 use crate::plugin::*;
 use crate::{
-    def_package, Array, Blob, Dynamic, ExclusiveRange, InclusiveRange, NativeCallContext,
-    RhaiResultOf, INT, INT_BYTES,
+    def_package, Array, Blob, ExclusiveRange, InclusiveRange, NativeCallContext, RhaiResultOf, INT,
+    INT_BYTES,
 };
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
-use std::{any::TypeId, borrow::Cow, convert::TryFrom, mem};
+use std::{borrow::Cow, convert::TryFrom, mem};
 
 #[cfg(not(feature = "no_float"))]
 use crate::{FLOAT, FLOAT_BYTES};

--- a/src/packages/fn_basic.rs
+++ b/src/packages/fn_basic.rs
@@ -1,5 +1,5 @@
 use crate::plugin::*;
-use crate::{def_package, FnPtr, ImmutableString, NativeCallContext};
+use crate::{def_package, FnPtr, ImmutableString};
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
 

--- a/src/packages/iter_basic.rs
+++ b/src/packages/iter_basic.rs
@@ -1,6 +1,5 @@
 use crate::eval::calc_index;
 use crate::plugin::*;
-use crate::FuncRegistration;
 use crate::{def_package, ExclusiveRange, InclusiveRange, RhaiResultOf, ERR, INT, INT_BITS};
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;

--- a/src/packages/map_basic.rs
+++ b/src/packages/map_basic.rs
@@ -2,9 +2,7 @@
 
 use crate::engine::OP_EQUALS;
 use crate::plugin::*;
-use crate::{
-    def_package, Dynamic, FnPtr, ImmutableString, Map, NativeCallContext, RhaiResultOf, INT,
-};
+use crate::{def_package, Dynamic, FnPtr, Map, NativeCallContext, RhaiResultOf, INT};
 use std::convert::TryFrom;
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;

--- a/src/packages/string_more.rs
+++ b/src/packages/string_more.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
-use std::{any::TypeId, convert::TryFrom, mem};
+use std::{convert::TryFrom, mem};
 
 use super::string_basic::{print_with_func, FUNC_TO_STRING};
 

--- a/src/packages/time_basic.rs
+++ b/src/packages/time_basic.rs
@@ -2,7 +2,7 @@
 
 use super::arithmetic::make_err as make_arithmetic_err;
 use crate::plugin::*;
-use crate::{def_package, Dynamic, RhaiResult, RhaiResultOf, INT};
+use crate::{def_package, RhaiResult, RhaiResultOf, INT};
 use std::convert::TryFrom;
 
 #[cfg(not(feature = "no_float"))]

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -504,6 +504,8 @@ fn test_arrays_elvis() {
 #[test]
 #[cfg(feature = "internals")]
 fn test_array_invalid_index_callback() {
+    use std::convert::TryInto;
+
     let mut engine = Engine::new();
 
     engine.on_invalid_array_index(|arr, index, _| match index {
@@ -512,7 +514,7 @@ fn test_array_invalid_index_callback() {
             arr.last_mut().unwrap().try_into()
         }
         100 => Ok(Dynamic::from(100 as INT).into()),
-        _ => Err(EvalAltResult::ErrorArrayBounds(arr.len(), index, Position::NONE).into()),
+        _ => Err(rhai::EvalAltResult::ErrorArrayBounds(arr.len(), index, rhai::Position::NONE).into()),
     });
 
     assert_eq!(

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,6 +1,6 @@
 #![cfg(not(feature = "no_index"))]
-use rhai::{Array, Dynamic, Engine, EvalAltResult, ParseErrorType, Position, INT};
-use std::{convert::TryInto, iter::FromIterator};
+use rhai::{Array, Dynamic, Engine, ParseErrorType, INT};
+use std::iter::FromIterator;
 
 #[test]
 fn test_arrays() {

--- a/tests/build_type.rs
+++ b/tests/build_type.rs
@@ -1,5 +1,5 @@
 #![cfg(not(feature = "no_object"))]
-use rhai::{CustomType, Dynamic, Engine, EvalAltResult, Position, TypeBuilder, INT};
+use rhai::{CustomType, Engine, EvalAltResult, Position, TypeBuilder, INT};
 use std::cmp::Ordering;
 
 #[test]

--- a/tests/maps.rs
+++ b/tests/maps.rs
@@ -259,6 +259,8 @@ fn test_map_oop() {
 #[test]
 #[cfg(feature = "internals")]
 fn test_map_missing_property_callback() {
+    use std::convert::TryInto;
+
     let mut engine = Engine::new();
 
     engine.on_map_missing_property(|map, prop, _| match prop {
@@ -266,8 +268,8 @@ fn test_map_missing_property_callback() {
             map.insert("y".into(), (42 as INT).into());
             map.get_mut("y").unwrap().try_into()
         }
-        "z" => Ok(Dynamic::from(100 as INT).into()),
-        _ => Err(EvalAltResult::ErrorPropertyNotFound(prop.to_string(), Position::NONE).into()),
+        "z" => Ok(rhai::Dynamic::from(100 as INT).into()),
+        _ => Err(rhai::EvalAltResult::ErrorPropertyNotFound(prop.to_string(), rhai::Position::NONE).into()),
     });
 
     assert_eq!(

--- a/tests/maps.rs
+++ b/tests/maps.rs
@@ -1,6 +1,5 @@
 #![cfg(not(feature = "no_object"))]
-use rhai::{Dynamic, Engine, EvalAltResult, Map, ParseErrorType, Position, Scope, INT};
-use std::convert::TryInto;
+use rhai::{Engine, EvalAltResult, Map, ParseErrorType, Scope, INT};
 
 #[test]
 fn test_map_indexing() {

--- a/tests/optimizer.rs
+++ b/tests/optimizer.rs
@@ -1,5 +1,5 @@
 #![cfg(not(feature = "no_optimize"))]
-use rhai::{Engine, FuncRegistration, Module, OptimizationLevel, Scope, INT};
+use rhai::{Engine, FuncRegistration, OptimizationLevel, Scope, INT};
 
 #[test]
 fn test_optimizer() {

--- a/tests/optimizer.rs
+++ b/tests/optimizer.rs
@@ -91,7 +91,7 @@ fn test_optimizer_parse() {
 
     assert_eq!(format!("{ast:?}"), r#"AST { source: None, doc: "", resolver: None, body: [Expr(Variable(NUMBER) @ 1:1)] }"#);
 
-    let mut module = Module::new();
+    let mut module = rhai::Module::new();
     module.set_var("NUMBER", 42 as INT);
 
     engine.register_global_module(module.into());

--- a/tests/parse_json.rs
+++ b/tests/parse_json.rs
@@ -1,22 +1,15 @@
-use rhai::{Dynamic, Engine, EvalAltResult, LexError, ParseErrorType, Position, Scope, INT};
-
-#[cfg(not(feature = "no_object"))]
-use rhai::Map;
-
 #[cfg(not(feature = "metadata"))]
 mod without_metadata {
-    use super::*;
-
     #[test]
     #[cfg(not(feature = "no_function"))]
     #[cfg(not(feature = "no_index"))]
     #[cfg(not(feature = "no_object"))]
     fn test_parse_json() {
-        let engine = Engine::new();
-        let mut scope = Scope::new();
+        let engine = rhai::Engine::new();
+        let mut scope = rhai::Scope::new();
 
         let map = engine
-            .eval_with_scope::<Map>(
+            .eval_with_scope::<rhai::Map>(
                 &mut scope,
                 r#"
                 parse_json("{\
@@ -50,11 +43,11 @@ mod without_metadata {
     #[cfg(not(feature = "no_object"))]
     #[cfg(not(feature = "no_float"))]
     fn test_parse_json_scientific_notation() {
-        let engine = Engine::new();
-        let mut scope = Scope::new();
+        let engine = rhai::Engine::new();
+        let mut scope = rhai::Scope::new();
 
         let map = engine
-            .eval_with_scope::<Map>(
+            .eval_with_scope::<rhai::Map>(
                 &mut scope,
                 r#"
                 parse_json("{\
@@ -81,11 +74,11 @@ mod without_metadata {
     #[cfg(not(feature = "no_object"))]
     #[cfg(not(feature = "no_function"))]
     fn test_parse_json_err_no_index() {
-        let engine = Engine::new();
-        let mut scope = Scope::new();
+        let engine = rhai::Engine::new();
+        let mut scope = rhai::Scope::new();
 
         let err = engine
-            .eval_with_scope::<Dynamic>(
+            .eval_with_scope::<rhai::Dynamic>(
                 &mut scope,
                 r#"
                 parse_json("{\
@@ -98,20 +91,20 @@ mod without_metadata {
             )
             .unwrap_err();
 
-        assert!(matches!(err.as_ref(), EvalAltResult::ErrorParsing(
-            ParseErrorType::BadInput(LexError::UnexpectedInput(token)), pos)
-                if token == "[" && *pos == Position::new(1, 7)));
+        assert!(matches!(err.as_ref(), rhai::EvalAltResult::ErrorParsing(
+            rhai::ParseErrorType::BadInput(rhai::LexError::UnexpectedInput(token)), pos)
+                if token == "[" && *pos == rhai::Position::new(1, 7)));
     }
 
     #[test]
     #[cfg(feature = "no_object")]
     #[cfg(not(feature = "no_function"))]
     fn test_parse_json_err_no_object() {
-        let engine = Engine::new();
-        let mut scope = Scope::new();
+        let engine = rhai::Engine::new();
+        let mut scope = rhai::Scope::new();
 
         let err = engine
-            .eval_with_scope::<Dynamic>(
+            .eval_with_scope::<rhai::Dynamic>(
                 &mut scope,
                 r#"
                 parse_json("{\
@@ -124,8 +117,8 @@ mod without_metadata {
             )
             .unwrap_err();
 
-        assert!(matches!(err.as_ref(), EvalAltResult::ErrorFunctionNotFound(msg, pos)
-            if msg == "parse_json (&str | ImmutableString | String)" && *pos == Position::new(2, 13)));
+        assert!(matches!(err.as_ref(), rhai::EvalAltResult::ErrorFunctionNotFound(msg, pos)
+            if msg == "parse_json (&str | ImmutableString | String)" && *pos == rhai::Position::new(2, 13)));
     }
 }
 
@@ -138,11 +131,11 @@ mod with_metadata {
     #[cfg(not(feature = "no_index"))]
     #[cfg(not(feature = "no_object"))]
     fn test_parse_json() {
-        let engine = Engine::new();
-        let mut scope = Scope::new();
+        let engine = rhai::Engine::new();
+        let mut scope = rhai::Scope::new();
 
         let map = engine
-            .eval_with_scope::<Map>(
+            .eval_with_scope::<rhai::Map>(
                 &mut scope,
                 r#"
                 parse_json("{\
@@ -176,11 +169,11 @@ mod with_metadata {
     #[cfg(not(feature = "no_object"))]
     #[cfg(not(feature = "no_float"))]
     fn test_parse_json_scientific_notation() {
-        let engine = Engine::new();
-        let mut scope = Scope::new();
+        let engine = rhai::Engine::new();
+        let mut scope = rhai::Scope::new();
 
         let map = engine
-            .eval_with_scope::<Map>(
+            .eval_with_scope::<rhai::Map>(
                 &mut scope,
                 r#"
                 parse_json("{\
@@ -207,11 +200,11 @@ mod with_metadata {
     #[cfg(not(feature = "no_object"))]
     #[cfg(not(feature = "no_function"))]
     fn test_parse_json_err_no_index() {
-        let engine = Engine::new();
-        let mut scope = Scope::new();
+        let engine = rhai::Engine::new();
+        let mut scope = rhai::Scope::new();
 
         let err = engine
-            .eval_with_scope::<Dynamic>(
+            .eval_with_scope::<rhai::Dynamic>(
                 &mut scope,
                 r#"
                 parse_json("{\
@@ -224,19 +217,19 @@ mod with_metadata {
             )
             .unwrap_err();
 
-        assert!(matches!(err.as_ref(), EvalAltResult::ErrorRuntime(msg, pos)
-                if msg.is_string() && *pos == Position::new(2, 17)));
+        assert!(matches!(err.as_ref(), rhai::EvalAltResult::ErrorRuntime(msg, pos)
+                if msg.is_string() && *pos == rhai::Position::new(2, 17)));
     }
 
     #[test]
     #[cfg(feature = "no_object")]
     #[cfg(not(feature = "no_function"))]
     fn test_parse_json_err_no_object() {
-        let engine = Engine::new();
-        let mut scope = Scope::new();
+        let engine = rhai::Engine::new();
+        let mut scope = rhai::Scope::new();
 
         let err = engine
-            .eval_with_scope::<Dynamic>(
+            .eval_with_scope::<rhai::Dynamic>(
                 &mut scope,
                 r#"
                 parse_json("{\
@@ -249,7 +242,7 @@ mod with_metadata {
             )
             .unwrap_err();
 
-        assert!(matches!(err.as_ref(), EvalAltResult::ErrorFunctionNotFound(msg, pos)
-            if msg == "parse_json (&str | ImmutableString | String)" && *pos == Position::new(2, 17)));
+        assert!(matches!(err.as_ref(), rhai::EvalAltResult::ErrorFunctionNotFound(msg, pos)
+            if msg == "parse_json (&str | ImmutableString | String)" && *pos == rhai::Position::new(2, 17)));
     }
 }


### PR DESCRIPTION
This should make it easier for users of the library, because they don't have to add random `use` statements for all the things the macros need.