### PR TITLE
Fix compact_script dropping $raw$ custom-syntax bodies

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -2701,6 +2701,21 @@ impl Iterator for TokenIterator<'_> {
                     '\n' => self.pos.new_line(),
                     _ => self.pos.advance(),
                 }
+                // Compacting support for `$raw$` custom syntax: append the
+                // consumed raw character verbatim to the compressed buffer.
+                // Raw characters are not produced by `get_next_token` and
+                // carry no `last_token`, so the normal token-compression
+                // path at the tail of this function never sees them.
+                // Appending verbatim preserves the raw body exactly as the
+                // plugin authored it — which is correct, because raw
+                // content is opaque to Rhai (that is the whole point of
+                // `$raw$`).
+                if compress_script {
+                    let control = &mut *self.state.tokenizer_control.borrow_mut();
+                    if let Some(ref mut compressed) = control.compressed {
+                        compressed.push(ch);
+                    }
+                }
                 return Some((Token::UnprocessedRawChar(ch), pos));
             }
         }

--- a/tests/custom_syntax.rs
+++ b/tests/custom_syntax.rs
@@ -508,3 +508,77 @@ fn test_custom_syntax_raw_interpolation() {
         "SELECT  *   FROM   //table//  WHERE  id=? AND   value <= ?\n123\n42"
     );
 }
+
+/// Regression test: `Engine::compact_script` must preserve the body of custom
+/// syntax that uses `$raw$` character capture. Previously the raw-char path in
+/// `TokenIterator::next` returned early before the compression buffer was
+/// updated, silently dropping every character inside the raw capture.
+#[test]
+fn test_compact_script_preserves_raw_custom_syntax_body() {
+    use rhai::{Map, ParseError};
+
+    let mut engine = Engine::new();
+
+    // Register a trivial `$raw$` syntax: `grab { BODY }`. Parses by tracking
+    // brace depth over raw characters, stops at the matching `}`. Execution
+    // is a no-op — we only care about parsing and compaction.
+    engine.register_custom_syntax_without_look_ahead_raw(
+        "grab",
+        |symbols, state| {
+            if state.is_unit() {
+                *state = Dynamic::from(Map::new());
+            }
+            let mut map = state.write_lock::<Map>().unwrap();
+
+            let in_raw = map.get("in_raw").and_then(|v| v.as_bool().ok()).unwrap_or(false);
+
+            if in_raw {
+                let ch = symbols.last().and_then(|s| s.chars().next()).unwrap_or('\0');
+                let mut depth = map.get("depth").and_then(|v| v.as_int().ok()).unwrap_or(0);
+                match ch {
+                    '{' => {
+                        depth += 1;
+                        map.insert("depth".into(), Dynamic::from_int(depth));
+                    }
+                    '}' => {
+                        if depth == 0 {
+                            map.insert("in_raw".into(), Dynamic::from_bool(false));
+                            return Ok(None);
+                        }
+                        depth -= 1;
+                        map.insert("depth".into(), Dynamic::from_int(depth));
+                    }
+                    _ => {}
+                }
+                return Ok(Some("$raw$".into()));
+            }
+
+            match symbols.len() {
+                1 => Ok(Some("{".into())),
+                2 => {
+                    map.insert("in_raw".into(), Dynamic::from_bool(true));
+                    map.insert("depth".into(), Dynamic::from_int(0));
+                    Ok(Some("$raw$".into()))
+                }
+                n => Err(ParseError(Box::new(ParseErrorType::BadInput(LexError::UnexpectedInput(format!("unexpected len={}", n)))), Position::NONE)),
+            }
+        },
+        false,
+        |_ctx, _inputs, _state| Ok(Dynamic::UNIT),
+    );
+
+    let source = "grab { let x = 1; let y = 2; print(x + y); }";
+
+    // Sanity: the script compiles as-is.
+    engine.compile(source).unwrap();
+
+    // Compact it. The output must still contain the body tokens.
+    let compacted = engine.compact_script(source).unwrap();
+
+    assert!(compacted.contains("let x"), "compacted lost `let x`: {:?}", compacted);
+    assert!(compacted.contains("let y"), "compacted lost `let y`: {:?}", compacted);
+    assert!(compacted.contains("print"), "compacted lost `print`: {:?}", compacted);
+
+    // The compacted form must also compile back (round-trip).
+    engine.compile(&compacted).expect("compacted script must compile");
+}

--- a/tests/custom_syntax.rs
+++ b/tests/custom_syntax.rs
@@ -513,6 +513,7 @@ fn test_custom_syntax_raw_interpolation() {
 /// syntax that uses `$raw$` character capture. Previously the raw-char path in
 /// `TokenIterator::next` returned early before the compression buffer was
 /// updated, silently dropping every character inside the raw capture.
+#[cfg(not(feature = "no_object"))]
 #[test]
 fn test_compact_script_preserves_raw_custom_syntax_body() {
     use rhai::{Map, ParseError};


### PR DESCRIPTION
## Summary

`Engine::compact_script` silently drops every character captured by custom syntax that uses the `$raw$` marker (registered via `register_custom_syntax_with_state_raw` or `register_custom_syntax_without_look_ahead_raw`). The compacted output contains the custom-syntax keyword and surrounding non-raw tokens, but the raw body is gone.

For example, a `grab { let x = 1; let y = 2; print(x + y); }` script compacts to `grab{` — body and closing brace both stripped. The compacted script then either fails to parse back or, worse, parses as a truncated no-op and only surfaces the corruption at a later recompile.

`$block$`, `$expr$`, `$ident$`, `$symbol$`, and `$token$` are all unaffected — only `$raw$` is broken. The plain `register_custom_syntax` API explicitly rejects `$raw$` (`src/api/custom_syntax.rs:254`), so this only affects the raw-variant registration APIs.

## Root cause

The `_char_mode` branch in `TokenIterator::next` (`src/tokenizer.rs`) pulls one character at a time via `self.stream.get_next()` and returns `Token::UnprocessedRawChar(ch)` early, **before** the normal token-compression block at the tail of `next()` runs. Raw characters therefore never reach the `compressed` buffer.

## Fix

Inside the `_char_mode` branch, before returning the raw char, append it verbatim to `control.compressed` when compression is active. Appending verbatim (rather than going through the normal identifier-boundary spacing path) is correct because raw content is opaque to Rhai — there is no grammar to strip whitespace from, and the plugin's parse function may be counting characters in its state machine. The surrounding non-raw tokens are still compacted normally, so the output remains smaller than the input.

Fix is ~10 lines in `src/tokenizer.rs`. No change to public API.

## Test plan

- [x] Added `test_compact_script_preserves_raw_custom_syntax_body` to `tests/custom_syntax.rs` — registers a minimal `grab { BODY }` raw syntax, compacts a script, and asserts that the body tokens still appear in the compacted form and that the compacted script round-trips through `compile`.
- [x] Full `cargo test --features internals` passes — 0 failures across all test binaries, including the existing `$raw$` tests (`test_custom_syntax_raw`, `test_custom_syntax_raw2`, `test_custom_syntax_raw_interpolation`).
- [x] Standalone minimal reproducer flips from exit 2 (bug) to exit 0 (fixed) with this patch applied.

## Background

Discovered while using a `timer NAME { BODY }` custom syntax in a downstream project (home-automation store server). The `timer` keyword uses `$raw$` to capture the body, and every stored script had its timer body dropped at validation time. The corruption only surfaced at cold load when the broken compact form failed to recompile, producing confusing "unexpected token" errors on scripts that had parsed cleanly moments earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)