### PR TITLE
chore(ci): refresh codegen UI-test stderr for current stable rustc

### DIFF
--- a/codegen/ui_tests/rhai_mod_unknown_type_return.stderr
+++ b/codegen/ui_tests/rhai_mod_unknown_type_return.stderr
@@ -2,10 +2,4 @@ error[E0425]: cannot find type `boool` in this scope
   --> ui_tests/rhai_mod_unknown_type_return.rs:12:37
    |
 12 |     pub fn test_fn(input: Point) -> boool {
-   |                                     ^^^^^
-   |
-help: a builtin type with a similar name exists
-   |
-12 -     pub fn test_fn(input: Point) -> boool {
-12 +     pub fn test_fn(input: Point) -> bool {
-   |
+   |                                     ^^^^^ help: a builtin type with a similar name exists: `bool`


### PR DESCRIPTION
Refresh the trybuild stderr snapshot for `codegen/ui_tests/rhai_mod_unknown_type_return` to match current stable rustc's rendering of the "builtin type with similar name" suggestion (the multi-line help block is now collapsed into a single `help: …` suffix).

The UI test failure on `upstream/main` pre-dates #1083 — verified on `c3202b62`, before the cache-isolation feature commit. Split out of #1083 per @schungx's request so the feature PR is feature-only.

No behaviour change; snapshot update only.