### PR TITLE
fix: array.index_of(string) misdispatches to deprecated fn-name overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Bug fixes
 
 * `Engine::compact_script` now properly compacts scripts with custom syntax that uses `$raw$` (thanks [`@yuvalrakavy`](https://github.com/yuvalrakavy) [`#1079`](https://github.com/rhaiscript/rhai/pull/1079)).
 * The string methods `split`, `split_rev` and their variants are now marked pure so they can be called on `const` strings ([`#1081`](https://github.com/rhaiscript/rhai/issues/1081)).
+* `array.index_of` now falls back to value comparison for string argument when no script function of that name is registered ([`#795`](https://github.com/rhaiscript/rhai/issues/795)).
 
 New features
 ------------

--- a/src/api/deprecated.rs
+++ b/src/api/deprecated.rs
@@ -848,6 +848,7 @@ use crate::plugin::*;
 #[export_module]
 pub mod deprecated_array_functions {
     use crate::packages::array_basic::array_functions::*;
+    use crate::packages::array_basic::index_of_start_inner;
     use crate::{Array, INT};
 
     /// Iterate through all the elements in the array, applying a function named by `mapper` to each
@@ -963,7 +964,25 @@ pub mod deprecated_array_functions {
         array: &mut Array,
         filter: &str,
     ) -> RhaiResultOf<INT> {
-        index_of_filter(ctx, array, FnPtr::new(filter)?)
+        if array.is_empty() {
+            return Ok(-1);
+        }
+        if let Ok(fp) = FnPtr::new(filter) {
+            match index_of_start_inner(&ctx, array, fp, 0) {
+                Ok(found) => return Ok(found),
+                Err(err) => match *err {
+                    EvalAltResult::ErrorFunctionNotFound(ref sig, ..)
+                        if sig.starts_with(filter) => {}
+                    EvalAltResult::ErrorInFunctionCall(_, _, ref inner, _) => match **inner {
+                        EvalAltResult::ErrorFunctionNotFound(ref sig, ..)
+                            if sig.starts_with(filter) => {}
+                        _ => return Err(err),
+                    },
+                    _ => return Err(err),
+                },
+            }
+        }
+        index_of_starting_from(ctx, array, filter.into(), 0)
     }
     /// Iterate through all the elements in the array, starting from a particular `start` position,
     /// applying a function named by `filter` to each element in turn, and return the index of the
@@ -1015,7 +1034,26 @@ pub mod deprecated_array_functions {
         filter: &str,
         start: INT,
     ) -> RhaiResultOf<INT> {
-        index_of_filter_starting_from(ctx, array, FnPtr::new(filter)?, start)
+        if array.is_empty() {
+            return Ok(-1);
+        }
+
+        if let Ok(fp) = FnPtr::new(filter) {
+            match index_of_start_inner(&ctx, array, fp, start) {
+                Ok(found) => return Ok(found),
+                Err(err) => match *err {
+                    EvalAltResult::ErrorFunctionNotFound(ref sig, ..)
+                        if sig.starts_with(filter) => {}
+                    EvalAltResult::ErrorInFunctionCall(_, _, ref inner, _) => match **inner {
+                        EvalAltResult::ErrorFunctionNotFound(ref sig, ..)
+                            if sig.starts_with(filter) => {}
+                        _ => return Err(err),
+                    },
+                    _ => return Err(err),
+                },
+            }
+        }
+        index_of_starting_from(ctx, array, filter.into(), start)
     }
     /// Return `true` if any element in the array that returns `true` when applied a function named
     /// by `filter`.

--- a/src/packages/array_basic.rs
+++ b/src/packages/array_basic.rs
@@ -26,6 +26,31 @@ def_package! {
     }
 }
 
+pub(crate) fn index_of_start_inner(
+    ctx: &NativeCallContext,
+    array: &mut Array,
+    filter: FnPtr,
+    start: INT,
+) -> RhaiResultOf<INT> {
+    if array.is_empty() {
+        return Ok(-1);
+    }
+    let (start, ..) = calc_offset_len(array.len(), start, 0);
+    for (i, item) in array.iter_mut().enumerate().skip(start) {
+        let ex = [INT::try_from(i).unwrap_or(INT::MAX).into()];
+
+        if filter
+            .call_raw_with_extra_args("index_of", &ctx, Some(item), [], ex, Some(0))?
+            .as_bool()
+            .unwrap_or(false)
+        {
+            return Ok(INT::try_from(i).unwrap_or(INT::MAX));
+        }
+    }
+
+    Ok(-1 as INT)
+}
+
 #[export_module]
 pub mod array_functions {
     /// Number of elements in the array.
@@ -974,21 +999,7 @@ pub mod array_functions {
             return Ok(-1);
         }
 
-        let (start, ..) = calc_offset_len(array.len(), start, 0);
-
-        for (i, item) in array.iter_mut().enumerate().skip(start) {
-            let ex = [INT::try_from(i).unwrap_or(INT::MAX).into()];
-
-            if filter
-                .call_raw_with_extra_args("index_of", &ctx, Some(item), [], ex, Some(0))?
-                .as_bool()
-                .unwrap_or(false)
-            {
-                return Ok(INT::try_from(i).unwrap_or(INT::MAX));
-            }
-        }
-
-        Ok(-1 as INT)
+        index_of_start_inner(&ctx, array, filter, start)
     }
     /// Iterate through all the elements in the array, applying a `filter` function to each element
     /// in turn, and return a copy of the first element that returns `true`. If no element returns

--- a/src/packages/array_basic.rs
+++ b/src/packages/array_basic.rs
@@ -26,6 +26,8 @@ def_package! {
     }
 }
 
+/// Temporary helper function supporting deprecated `index_of_by_fn_name*` functions.
+/// Can be removed in the next major version
 pub(crate) fn index_of_start_inner(
     ctx: &NativeCallContext,
     array: &mut Array,

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -502,6 +502,53 @@ fn test_arrays_elvis() {
 }
 
 #[test]
+fn test_arrays_index_of() {
+    let engine = Engine::new();
+    // INT array
+    assert_eq!(engine.eval::<INT>("[1, 2, 3].index_of(2)").unwrap(), 1);
+    // String array
+    assert_eq!(engine.eval::<INT>(r#"["hi", "hello", "world"].index_of("hello")"#).unwrap(), 1);
+    assert_eq!(engine.eval::<INT>(r#"["a","b","c","b"].index_of("b", 2)"#).unwrap(), 3);
+    assert_eq!(engine.eval::<INT>(r#"["a","b"].index_of("missing")"#).unwrap(), -1);
+
+    // Cross-type behavior
+    assert_eq!(engine.eval::<INT>(r#"[1,2,3].index_of("foo")"#).unwrap(), -1);
+    assert_eq!(
+        engine
+            .eval::<INT>(
+                r#"
+             fn is_two(x) { x == 2 }
+             [1,2,3,2].index_of("is_two")
+         "#
+            )
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        engine
+            .eval::<INT>(
+                r#"
+             fn is_two(x) { x == 2 }
+             [1,2,3,2].index_of("is_two", 2)
+         "#
+            )
+            .unwrap(),
+        3
+    );
+    assert_eq!(
+        engine
+            .eval::<INT>(
+                r#"                                                                                    
+                 fn is_two(x) { x == 2 }                                                                               
+                 [1,2,3,2].index_of("is_two", 2)                                                                       
+             "#
+            )
+            .unwrap(),
+        3
+    );
+}
+
+#[test]
 #[cfg(feature = "internals")]
 fn test_array_invalid_index_callback() {
     use std::convert::TryInto;

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -505,14 +505,21 @@ fn test_arrays_elvis() {
 fn test_arrays_index_of() {
     let engine = Engine::new();
     // INT array
-    assert_eq!(engine.eval::<INT>("[1, 2, 3].index_of(2)").unwrap(), 1);
+    assert_eq!(engine.eval::<INT>("index_of([1, 2, 3], 2)").unwrap(), 1);
     // String array
-    assert_eq!(engine.eval::<INT>(r#"["hi", "hello", "world"].index_of("hello")"#).unwrap(), 1);
-    assert_eq!(engine.eval::<INT>(r#"["a","b","c","b"].index_of("b", 2)"#).unwrap(), 3);
-    assert_eq!(engine.eval::<INT>(r#"["a","b"].index_of("missing")"#).unwrap(), -1);
+    assert_eq!(engine.eval::<INT>(r#"index_of(["hi", "hello", "world"], "hello")"#).unwrap(), 1);
+    assert_eq!(engine.eval::<INT>(r#"index_of(["a","b","c","b"], "b", 2)"#).unwrap(), 3);
+    assert_eq!(engine.eval::<INT>(r#"index_of(["a","b"], "missing")"#).unwrap(), -1);
 
     // Cross-type behavior
-    assert_eq!(engine.eval::<INT>(r#"[1,2,3].index_of("foo")"#).unwrap(), -1);
+    assert_eq!(engine.eval::<INT>(r#"index_of([1,2,3], "foo")"#).unwrap(), -1);
+}
+
+#[test]
+#[cfg(not(feature = "no_object"))]
+#[cfg(not(feature = "no_function"))]
+fn test_arrays_index_of_with_named_fn() {
+    let engine = Engine::new();
     assert_eq!(
         engine
             .eval::<INT>(
@@ -535,19 +542,7 @@ fn test_arrays_index_of() {
             .unwrap(),
         3
     );
-    assert_eq!(
-        engine
-            .eval::<INT>(
-                r#"                                                                                    
-                 fn is_two(x) { x == 2 }                                                                               
-                 [1,2,3,2].index_of("is_two", 2)                                                                       
-             "#
-            )
-            .unwrap(),
-        3
-    );
 }
-
 #[test]
 #[cfg(feature = "internals")]
 fn test_array_invalid_index_callback() {


### PR DESCRIPTION
This PR added a value-comparison fallback for `array.index_of` when given a string argument and no script function of that name is registered.

Fixes #795