### PR TITLE
feat: support `$$` escape in string interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Enhancements
 * Procedural macros such as `#[export_module]` and `#[derive(CustomType)]` no longer require importing standard Rhai types (thanks [`@timokoesters`](https://github.com/timokoesters) [`#1071`](https://github.com/rhaiscript/rhai/pull/1071)).
 * `FnPtr::call_fn_as_method` and `FnPtr::call_as_method_within_context` are added (when not under `no_object`) to accept a `this` pointer for calling the function pointer as a method call (thanks [`@yunfengzh`](https://github.com/yunfengzh) for the request [`#1080`](https://github.com/rhaiscript/rhai/pull/1080)).
 * `NativeCallContext::call_method` and `NativeCallContext::call_native_method` are added (when not under `no_object`) to accept a `this` pointer for method calls (thanks [`@yunfengzh`](https://github.com/yunfengzh) for the idea [`#1080`](https://github.com/rhaiscript/rhai/pull/1080)).
+* `$$` is added as the escape sequence for backtick string interpolation which emits single `$` - so `$${` produces a single `${` without triggering string interpolation. 
 
 
 Version 1.24.0

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1431,8 +1431,20 @@ pub fn parse_string_literal(
             last.push(next_char);
         }
 
-        // String interpolation?
+        // `$$` escape sequence - emit a single `$`
+        // `$${` emit `${` without string interpolation
         if allow_interpolation
+            && next_char == '$'
+            && escape.is_empty()
+            && stream.peek_next() == Some('$')
+        {
+            stream.eat_next_and_advance(pos);
+            if let Some(ref mut last) = state.last_token {
+                last.push('$');
+            }
+        }
+        // String interpolation?
+        else if allow_interpolation
             && next_char == '$'
             && escape.is_empty()
             && stream.peek_next() == Some('{')

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -348,15 +348,9 @@ fn test_string_interpolated() {
         "hello 42 worlds!"
     );
 
-    assert_eq!(
-        engine.eval::<String>(r"`hello $${world}`").unwrap(),
-        "hello ${world}"
-    );
+    assert_eq!(engine.eval::<String>(r"`hello $${world}`").unwrap(), "hello ${world}");
 
-    assert_eq!(
-        engine.eval::<String>(r"`price: $$5`").unwrap(),
-        "price: $5"
-    );
+    assert_eq!(engine.eval::<String>(r"`price: $$5`").unwrap(), "price: $5");
 
     assert_eq!(
         engine
@@ -370,20 +364,10 @@ fn test_string_interpolated() {
         "literal ${a} value 7"
     );
 
-    assert_eq!(
-        engine.eval::<String>(r"`$$$x`").unwrap(),
-        "$$x"
-    );
-    assert_eq!(
-        engine.eval::<String>(r"`trailing$`").unwrap(),
-        "trailing$"
-    );
+    assert_eq!(engine.eval::<String>(r"`$$$x`").unwrap(), "$$x");
+    assert_eq!(engine.eval::<String>(r"`trailing$`").unwrap(), "trailing$");
 
-    assert_eq!(
-        engine.eval::<String>(r"`trailing$$`").unwrap(),
-        "trailing$"
-    );
-
+    assert_eq!(engine.eval::<String>(r"`trailing$$`").unwrap(), "trailing$");
 
     assert_eq!(engine.eval::<String>("`hello ${}world!`").unwrap(), "hello world!");
 

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -348,6 +348,43 @@ fn test_string_interpolated() {
         "hello 42 worlds!"
     );
 
+    assert_eq!(
+        engine.eval::<String>(r"`hello $${world}`").unwrap(),
+        "hello ${world}"
+    );
+
+    assert_eq!(
+        engine.eval::<String>(r"`price: $$5`").unwrap(),
+        "price: $5"
+    );
+
+    assert_eq!(
+        engine
+            .eval::<String>(
+                r#"
+                  let x = 7;
+                  `literal $${a} value ${x}`
+              "#
+            )
+            .unwrap(),
+        "literal ${a} value 7"
+    );
+
+    assert_eq!(
+        engine.eval::<String>(r"`$$$x`").unwrap(),
+        "$$x"
+    );
+    assert_eq!(
+        engine.eval::<String>(r"`trailing$`").unwrap(),
+        "trailing$"
+    );
+
+    assert_eq!(
+        engine.eval::<String>(r"`trailing$$`").unwrap(),
+        "trailing$"
+    );
+
+
     assert_eq!(engine.eval::<String>("`hello ${}world!`").unwrap(), "hello world!");
 
     assert_eq!(


### PR DESCRIPTION
This PR added `$$` as an escape sequence inside backtick-string interpolation that emits a literal `$`.
For example, `$${...}` produces a literal `${...}` instead of triggering interpolation.

Fixes https://github.com/rhaiscript/rhai/issues/694