### PR TITLE
Reintroduce re-exports in `rhai::plugin`

### DIFF
--- a/src/func/plugin.rs
+++ b/src/func/plugin.rs
@@ -1,14 +1,24 @@
 //! Module defining macros for developing _plugins_.
 
 use super::FnCallArgs;
-use crate::NativeCallContext;
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
+
 
 /// Result of a Rhai function.
 pub type RhaiResult = crate::RhaiResult;
 
 pub use rhai_codegen::*;
+
+// Removing these re-exports would be a breaking change,
+// despite there are other import paths that can be used.
+// https://github.com/rhaiscript/rhai/issues/1098
+pub use super::RhaiFunc;
+pub use crate::{
+    Dynamic, Engine, EvalAltResult, FnAccess, FnNamespace, FuncRegistration, ImmutableString,
+    Module, NativeCallContext, Position,
+};
+pub use std::{any::TypeId, mem};
 
 /// Trait implemented by a _plugin function_.
 ///

--- a/src/func/plugin.rs
+++ b/src/func/plugin.rs
@@ -4,7 +4,6 @@ use super::FnCallArgs;
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
 
-
 /// Result of a Rhai function.
 pub type RhaiResult = crate::RhaiResult;
 


### PR DESCRIPTION
This PR re-introduce some re-exports that were [removed from `rhai::plugin` in 1.25.0](https://github.com/rhaiscript/rhai/commit/475d45ee294aa4cf95c7e07bdca2934dca10e20b#r186669870).

This removal was an unintended breaking change despite the items still being available, since dependent crates may have used this import path. In-fact, this did break [`apollo-router`](https://github.com/apollographql/router/issues/9528) when used as a library.

Fixes #1098