### PR TITLE
Expose more internal items and allow unvalidated `Fn` creation 

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -9,7 +9,7 @@ use crate::func::native::{
 use crate::packages::{Package, StandardPackage};
 use crate::tokenizer::Token;
 use crate::types::StringsInterner;
-use crate::{Dynamic, Identifier, ImmutableString, Locked, SharedModule};
+use crate::{expose_under_internals, Dynamic, Identifier, ImmutableString, Locked, SharedModule};
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
 use std::{collections::BTreeSet, fmt, num::NonZeroU8};
@@ -37,8 +37,10 @@ pub const KEYWORD_GLOBAL: &str = "global";
 pub const FN_GET: &str = "get$";
 #[cfg(not(feature = "no_object"))]
 pub const FN_SET: &str = "set$";
+/// The name a custom index getter is registered under.
 #[cfg(any(not(feature = "no_index"), not(feature = "no_object")))]
 pub const FN_IDX_GET: &str = "index$get$";
+/// The name a custom index setter is registered under.
 #[cfg(any(not(feature = "no_index"), not(feature = "no_object")))]
 pub const FN_IDX_SET: &str = "index$set$";
 #[cfg(not(feature = "no_function"))]
@@ -406,5 +408,35 @@ impl Engine {
     #[must_use]
     pub(crate) const fn is_debugger_registered(&self) -> bool {
         self.debugger_interface.is_some()
+    }
+
+    /// _(internals)_ The variable resolver registered with [`Engine::on_var`],
+    /// if any.
+    /// Exported under the `internals` feature only.
+    #[expose_under_internals]
+    #[inline(always)]
+    #[must_use]
+    fn variable_resolver(&self) -> Option<&OnVarCallback> {
+        self.resolve_var.as_deref()
+    }
+
+    /// _(internals)_ The modules loaded into the global namespace.
+    /// Exported under the `internals` feature only.
+    #[expose_under_internals]
+    #[inline(always)]
+    #[must_use]
+    fn global_modules(&self) -> &[SharedModule] {
+        &self.global_modules
+    }
+
+    /// _(internals)_ The sub-modules registered with
+    /// [`Engine::register_static_module`], keyed by name.
+    /// Exported under the `internals` feature only.
+    #[cfg(not(feature = "no_module"))]
+    #[expose_under_internals]
+    #[inline(always)]
+    #[must_use]
+    fn global_sub_modules(&self) -> &std::collections::BTreeMap<Identifier, SharedModule> {
+        &self.global_sub_modules
     }
 }

--- a/src/eval/chaining.rs
+++ b/src/eval/chaining.rs
@@ -6,8 +6,8 @@ use crate::ast::{ASTFlags, BinaryExpr, Expr, OpAssignment};
 use crate::engine::{FN_IDX_GET, FN_IDX_SET};
 use crate::types::dynamic::Union;
 use crate::{
-    calc_fn_hash, Dynamic, Engine, ExclusiveRange, FnArgsVec, InclusiveRange, OnceCell, Position,
-    RhaiResult, RhaiResultOf, Scope, ERR,
+    calc_fn_hash, expose_under_internals, Dynamic, Engine, ExclusiveRange, FnArgsVec,
+    InclusiveRange, OnceCell, Position, RhaiResult, RhaiResultOf, Scope, ERR,
 };
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
@@ -101,13 +101,16 @@ impl Engine {
         )
     }
 
-    /// Get the value at the indexed position of a base type.
+    /// _(internals)_ Get the value at the indexed position of a base type.
     ///
     /// # Panics
     ///
     /// Panics if the target object is shared.
     ///
     /// Shared objects should be handled (dereferenced) before calling this method.
+    ///
+    /// Exported under the `internals` feature only.
+    #[expose_under_internals]
     fn get_indexed_mut<'t>(
         &self,
         global: &mut GlobalRuntimeState,

--- a/src/eval/data_check.rs
+++ b/src/eval/data_check.rs
@@ -3,7 +3,7 @@
 
 use super::GlobalRuntimeState;
 use crate::types::dynamic::Union;
-use crate::{Dynamic, Engine, Position, RhaiResultOf, ERR};
+use crate::{expose_under_internals, Dynamic, Engine, Position, RhaiResultOf, ERR};
 use std::borrow::Borrow;
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
@@ -120,12 +120,15 @@ pub fn calc_data_sizes(value: &Dynamic, _top: bool) -> (usize, usize, usize) {
 }
 
 impl Engine {
-    /// Raise an error if any data size exceeds limit.
+    /// _(internals)_ Raise an error if any data size exceeds limit.
     ///
     /// [`Position`] in [`EvalAltResult`][crate::EvalAltResult] is always [`NONE`][Position::NONE]
     /// and should be set afterwards.
+    ///
+    /// Exported under the `internals` feature only.
     #[cfg(not(feature = "unchecked"))]
-    pub(crate) fn throw_on_size(&self, (_arr, _map, s): (usize, usize, usize)) -> RhaiResultOf<()> {
+    #[expose_under_internals]
+    fn throw_on_size(&self, (_arr, _map, s): (usize, usize, usize)) -> RhaiResultOf<()> {
         if self.limits.string_len.map_or(false, |max| s > max.get()) {
             return Err(
                 ERR::ErrorDataTooLarge("Length of string".to_string(), Position::NONE).into(),
@@ -179,13 +182,11 @@ impl Engine {
         self.check_data_size(value, Position::NONE).map(|_| ())
     }
 
-    /// Check if the number of operations stay within limit.
+    /// _(internals)_ Check if the number of operations stay within limit.
+    /// Exported under the `internals` feature only.
+    #[expose_under_internals]
     #[inline(always)]
-    pub(crate) fn track_operation(
-        &self,
-        global: &mut GlobalRuntimeState,
-        pos: Position,
-    ) -> RhaiResultOf<()> {
+    fn track_operation(&self, global: &mut GlobalRuntimeState, pos: Position) -> RhaiResultOf<()> {
         global.num_operations += 1;
 
         // Guard against too many operations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,9 +362,49 @@ pub use ast::Namespace;
 #[cfg(feature = "internals")]
 pub use eval::{Caches, FnResolutionCache, FnResolutionCacheEntry, GlobalRuntimeState, Target};
 
+/// _(internals)_ Measure a value against the configured data-size limits.
+/// Exported under the `internals` feature only.
+#[cfg(feature = "internals")]
+#[cfg(not(feature = "unchecked"))]
+#[cfg(any(not(feature = "no_index"), not(feature = "no_object")))]
+pub use eval::calc_data_sizes;
+
 #[cfg(feature = "internals")]
 #[allow(deprecated)]
 pub use func::{locked_read, locked_write, NativeCallContextStore, RhaiFunc};
+
+/// _(internals)_ The built-in operator implementations the evaluator itself
+/// short-circuits to under fast-operators mode.
+/// Exported under the `internals` feature only.
+#[cfg(feature = "internals")]
+pub use func::{get_builtin_binary_op_fn, get_builtin_op_assignment_fn};
+
+/// _(internals)_ The hasher `switch` matches cases with.
+/// Exported under the `internals` feature only.
+#[cfg(feature = "internals")]
+pub use func::hashing::get_hasher;
+
+/// _(internals)_ Return type of the built-in operator lookups.
+/// Exported under the `internals` feature only.
+#[cfg(feature = "internals")]
+pub use func::native::FnBuiltin;
+
+/// _(internals)_ The function a registered type iterator is stored as.
+/// Exported under the `internals` feature only.
+#[cfg(feature = "internals")]
+pub use func::native::FnIterator;
+
+/// _(internals)_ Render a value the way `print`, `debug` and string
+/// interpolation do.
+/// Exported under the `internals` feature only.
+#[cfg(feature = "internals")]
+pub use packages::string_basic::print_with_func;
+
+/// _(internals)_ The names a custom indexer is registered under.
+/// Exported under the `internals` feature only.
+#[cfg(feature = "internals")]
+#[cfg(any(not(feature = "no_index"), not(feature = "no_object")))]
+pub use engine::{FN_IDX_GET, FN_IDX_SET};
 
 #[cfg(feature = "internals")]
 #[cfg(feature = "metadata")]

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -373,10 +373,10 @@ impl FuncRegistration {
     ///
     /// # Parameter Examples
     ///
-    /// `"foo: &str"`   <- parameter name = `foo`, type = `&str`  
-    /// `"bar"`         <- parameter name = `bar`, type unknown  
-    /// `"_: i64"`      <- parameter name unknown, type = `i64`  
-    /// `"MyType"`      <- parameter name unknown, type = `MyType`  
+    /// `"foo: &str"`   <- parameter name = `foo`, type = `&str`
+    /// `"bar"`         <- parameter name = `bar`, type unknown
+    /// `"_: i64"`      <- parameter name unknown, type = `i64`
+    /// `"MyType"`      <- parameter name unknown, type = `MyType`
     #[cfg(feature = "metadata")]
     #[must_use]
     pub fn with_params_info<S: AsRef<str>>(mut self, params: impl IntoIterator<Item = S>) -> Self {
@@ -2678,18 +2678,24 @@ impl Module {
         })
     }
 
-    /// Get the specified type iterator.
+    /// _(internals)_ Get the specified type iterator, including those of
+    /// sub-modules.
+    /// Exported under the `internals` feature only.
     #[cfg(not(feature = "no_module"))]
+    #[expose_under_internals]
     #[inline]
     #[must_use]
-    pub(crate) fn get_qualified_iter(&self, id: TypeId) -> Option<&FnIterator> {
+    fn get_qualified_iter(&self, id: TypeId) -> Option<&FnIterator> {
         self.all_type_iterators.get(&id).map(|f| &**f)
     }
 
-    /// Get the specified type iterator.
+    /// _(internals)_ Get the specified type iterator.
+    /// Exported under the `internals` feature only.
+    ///
+    #[expose_under_internals]
     #[inline]
     #[must_use]
-    pub(crate) fn get_iter(&self, id: TypeId) -> Option<&FnIterator> {
+    fn get_iter(&self, id: TypeId) -> Option<&FnIterator> {
         self.type_iterators.get(&id).map(|f| &**f)
     }
 }

--- a/src/types/dynamic.rs
+++ b/src/types/dynamic.rs
@@ -1,6 +1,6 @@
 //! Helper module which defines the [`Dynamic`] data type.
 
-use crate::{ExclusiveRange, FnPtr, ImmutableString, InclusiveRange, INT};
+use crate::{expose_under_internals, ExclusiveRange, FnPtr, ImmutableString, InclusiveRange, INT};
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
 use std::{
@@ -1185,7 +1185,7 @@ impl Dynamic {
             ReadOnly => true,
         }
     }
-    /// Can this [`Dynamic`] be hashed?
+    /// _(internals)_ Can this [`Dynamic`] be hashed?
     ///
     /// # Shared Value
     ///
@@ -1198,8 +1198,11 @@ impl Dynamic {
     /// Under these circumstances, `false` is returned.
     ///
     /// These normally shouldn't occur since most operations in Rhai are single-threaded.
+    ///
+    /// Exported under the `internals` feature only.
+    #[expose_under_internals]
     #[must_use]
-    pub(crate) fn is_hashable(&self) -> bool {
+    fn is_hashable(&self) -> bool {
         match self.0 {
             Union::Unit(..)
             | Union::Bool(..)

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -3,6 +3,8 @@
 use crate::{Dynamic, ParseErrorType, Position, INT};
 #[cfg(feature = "no_std")]
 use core_error::Error;
+#[cfg(not(feature = "no_object"))]
+use rhai_codegen::expose_under_internals;
 #[cfg(not(feature = "no_std"))]
 use std::error::Error;
 use std::fmt;
@@ -380,11 +382,13 @@ impl EvalAltResult {
                 | Self::ErrorTerminated(..)
         )
     }
-    /// Get the [position][Position] of this error.
+    /// _(internals)_ Get the [position][Position] of this error.
+    /// Exported under the `internals` feature only.
     #[cfg(not(feature = "no_object"))]
+    #[expose_under_internals]
     #[cold]
     #[inline(never)]
-    pub(crate) fn dump_fields(&self, map: &mut crate::Map) {
+    fn dump_fields(&self, map: &mut crate::Map) {
         map.insert(
             "error".into(),
             format!("{self:?}")

--- a/src/types/fn_ptr.rs
+++ b/src/types/fn_ptr.rs
@@ -99,6 +99,21 @@ impl FnPtr {
     pub fn new(name: impl Into<ImmutableString>) -> RhaiResultOf<Self> {
         name.into().try_into()
     }
+    /// _(internals)_ Create a new function pointer to a name, without
+    /// checking that the name is one a script could have written.
+    /// Exported under the `internals` feature only.
+    #[expose_under_internals]
+    #[inline(always)]
+    #[must_use]
+    fn new_unchecked(name: impl Into<ImmutableString>) -> Self {
+        Self {
+            name: name.into(),
+            curry: ThinVec::new(),
+            #[cfg(not(feature = "no_function"))]
+            env: None,
+            typ: FnPtrType::Normal,
+        }
+    }
     /// Create a new function pointer from a native Rust function.
     ///
     /// # Errors

--- a/src/types/fn_ptr.rs
+++ b/src/types/fn_ptr.rs
@@ -105,7 +105,7 @@ impl FnPtr {
     #[expose_under_internals]
     #[inline(always)]
     #[must_use]
-    fn new_unchecked(name: impl Into<ImmutableString>) -> Self {
+    fn new_unvalidated(name: impl Into<ImmutableString>) -> Self {
         Self {
             name: name.into(),
             curry: ThinVec::new(),

--- a/src/types/scope.rs
+++ b/src/types/scope.rs
@@ -1,7 +1,7 @@
 //! Module that defines the [`Scope`] type representing a function call-stack scope.
 
 use super::dynamic::{AccessMode, Variant};
-use crate::{Dynamic, Identifier, ImmutableString, StaticVec, ThinVec};
+use crate::{expose_under_internals, Dynamic, Identifier, ImmutableString, StaticVec, ThinVec};
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
 use std::{
@@ -795,13 +795,17 @@ impl Scope<'_> {
                 AccessMode::ReadOnly => None,
             })
     }
-    /// Get a mutable reference to the value of an entry in the [`Scope`] based on the index.
+    /// _(internals)_ Get a mutable reference to the value of an entry in the
+    /// [`Scope`] based on the index.
     ///
     /// # Panics
     ///
     /// Panics if the index is out of bounds.
+    ///
+    /// Exported under the `internals` feature only.
+    #[expose_under_internals]
     #[inline(always)]
-    pub(crate) fn get_mut_by_index(&mut self, index: usize) -> &mut Dynamic {
+    fn get_mut_by_index(&mut self, index: usize) -> &mut Dynamic {
         &mut self.values[index]
     }
     /// Add an alias to an entry in the [`Scope`].


### PR DESCRIPTION
I am working on a stack-based VM for Rhai called [`rhaigrain`](https://github.com/ImTheSquid/rhaigrain) that needs access to some of the internals of Rhai that aren't currently exposed. rhaigrain is already working on a fork of Rhai, so I'd like to upstream. This PR adds some more exports under the `internals` feature and allows for unvalidated `FnPtr` creation. Adding these under `internals` reduces the maintenance burden, since `internals` functions have no compatibility guarantees (as referenced in the book).