### PR TITLE
Fix switch bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Bug fixes
 ---------
 
 * Fixes bug in `Engine::compact_script` that generates invalid compacted scripts due to missing spaces between ambiguous operators (thanks [`@yuvalrakavy`](https://github.com/yuvalrakavy) [`#1106`](https://github.com/rhaiscript/rhai/pull/1106)).
+* Fixes bug in `switch` statement that fails to try ranges when all conditions of exact matches fail ([`#1117`](https://github.com/rhaiscript/rhai/pull/1118))
 
 New features
 ------------

--- a/src/eval/stmt.rs
+++ b/src/eval/stmt.rs
@@ -541,7 +541,9 @@ impl Engine {
                                 break;
                             }
                         }
-                    } else if !ranges.is_empty() {
+                    }
+                    // Then check ranges
+                    if !result.is_some() && !ranges.is_empty() {
                         // Then check integer ranges
                         for r in ranges.iter().filter(|r| r.contains(&value)) {
                             let BinaryExpr { lhs, rhs } = &expressions[r.index()];

--- a/src/packages/arithmetic.rs
+++ b/src/packages/arithmetic.rs
@@ -13,9 +13,7 @@ pub fn make_err(msg: impl Into<String>) -> RhaiError {
     ERR::ErrorArithmetic(msg.into(), Position::NONE).into()
 }
 
-#[cfg(not(feature = "only_i32"))]
-#[cfg(not(feature = "only_i64"))]
-#[cfg(not(feature = "unchecked"))]
+#[allow(unused_macros)]
 macro_rules! gen_arithmetic_functions {
     ($root:ident => $($arg_type:ident),+) => {
         #[allow(non_snake_case)]

--- a/src/packages/arithmetic.rs
+++ b/src/packages/arithmetic.rs
@@ -13,6 +13,9 @@ pub fn make_err(msg: impl Into<String>) -> RhaiError {
     ERR::ErrorArithmetic(msg.into(), Position::NONE).into()
 }
 
+#[cfg(not(feature = "only_i32"))]
+#[cfg(not(feature = "only_i64"))]
+#[cfg(not(feature = "unchecked"))]
 macro_rules! gen_arithmetic_functions {
     ($root:ident => $($arg_type:ident),+) => {
         #[allow(non_snake_case)]

--- a/tests/grain/corpus/mod.rs
+++ b/tests/grain/corpus/mod.rs
@@ -394,7 +394,10 @@ pub const CASES: &[Case] = &[
     // whose guard declined goes to the *default*, never on to the ranges
     // (eval/stmt.rs:544). Without the range arm here the two are the same
     // answer and the case proves nothing.
-    case("switch_declined_case_skips_ranges", "let f = false; let x = 1; switch x { 1 if f => \"guarded\", 0..=5 => \"range\", _ => \"default\" }"),
+    //
+    // This bug is fixed by [#1118](https://github.com/rhaiscript/rhai/pull/1118).
+    // Commenting out this case for now, before the VM is modified to reflect the fix.
+    //case("switch_declined_case_skips_ranges", "let f = false; let x = 1; switch x { 1 if f => \"guarded\", 0..=5 => \"range\", _ => \"default\" }"),
     // No `_` arm at all, so the miss has to produce unit from nowhere.
     case("switch_no_default", "let x = 9; switch x { 1 => \"a\" }"),
     case("switch_string", "let s = \"b\"; switch s { \"a\" => 1, \"b\" => 2, _ => 0 }"),

--- a/tests/switch.rs
+++ b/tests/switch.rs
@@ -18,6 +18,22 @@ fn test_switch() {
     let _: () = engine.eval_with_scope::<()>(&mut scope, "switch x { 1 => 123, 2 => 'a' }").unwrap();
 
     assert_eq!(engine.eval_with_scope::<INT>(&mut scope, "switch x { 1 | 2 | 3 | 5..50 | 'x' | true => 123, 'z' => 'a' }").unwrap(), 123);
+    assert_eq!(
+        engine
+            .eval_with_scope::<INT>(
+                &mut scope,
+                "
+                    let foo = false;
+                    switch x {
+                        42 if foo => 0,
+                        0..100 => 123,
+                        _ => 999
+                    }
+                "
+            )
+            .unwrap(),
+        123
+    );
     assert_eq!(engine.eval_with_scope::<INT>(&mut scope, "switch x { 424242 => 123, _ => 42 }").unwrap(), 42);
     assert_eq!(engine.eval_with_scope::<INT>(&mut scope, "switch x { 1 => 123, 42 => { x / 2 }, _ => 999 }").unwrap(), 21);
     #[cfg(not(feature = "no_index"))]


### PR DESCRIPTION
Closes #1117.

The Rhai Grain test `switch_declined_case_skips_ranges` is commented out temporarily until the VM can be modified to reflect the fix.
