### PR TITLE
VM: Speed up Rust native function calls by using FnArgsVec (smallvec)

### DIFF
--- a/examples/grain_bench.rs
+++ b/examples/grain_bench.rs
@@ -83,7 +83,14 @@ const CASES: &[Case] = &[
         callbacks: false,
         floor: 1.55,
     },
-    // The VM scans its case hashes; rhai probes a hash map. Two sizes,
+    Case {
+        name: "recursive fibonacci",
+        source: "fn fib(n) { if n < 2 { n } else { fib(n-1) + fib(n-2) }} fib(28)",
+        iterations: 1,
+        callbacks: false,
+        floor: 1.50,
+    },
+    // The VM scans its case hashes; Rhai probes a hash map. Two sizes,
     // because which of those wins is a question about how many arms there
     // are, and a `switch` nobody would write is the only place the scan can
     // lose.
@@ -116,6 +123,13 @@ const CASES: &[Case] = &[
         callbacks: false,
         floor: 1.45,
     },
+    Case {
+        name: "native function calls",
+        source: "let a = 42; for i in 0..20000 { a = abs(abs(abs(abs(a)))); } a",
+        iterations: 5,
+        callbacks: true,
+        floor: 1.50,
+    },
     // The one case the VM is expected to lose. Every element is a boundary out
     // of the VM, through rhai's dispatch and back into a second `Vm` with an
     // empty resolution cache — where the walker stays inside itself and reaches
@@ -131,6 +145,35 @@ const CASES: &[Case] = &[
         iterations: 20,
         callbacks: true,
         floor: 0.64,
+    },
+    Case {
+        name: "primes",
+        source: r#"
+            const SIZE = 1_000_000;
+
+            let prime_mask = [];
+            prime_mask.pad(SIZE + 1, true);
+
+            prime_mask[0] = false;
+            prime_mask[1] = false;
+
+            let total_primes_found = 0;
+
+            for p in 2..=SIZE {
+                if !prime_mask[p] { continue; }
+
+                total_primes_found += 1;
+
+                for i in range(2 * p, SIZE + 1, p) {
+                    prime_mask[i] = false;
+                }
+            }
+
+            total_primes_found
+        "#,
+        iterations: 1,
+        callbacks: false,
+        floor: 1.55,
     },
 ];
 

--- a/src/grain/compile/mod.rs
+++ b/src/grain/compile/mod.rs
@@ -1813,16 +1813,24 @@ impl Lowering {
     /// captures the enclosing scope is closure construction, and a qualified
     /// name resolves against imported modules; neither is a plain call.
     fn is_lowerable_call(&self, call: &FnCallExpr) -> bool {
+        use crate::engine::{
+            KEYWORD_EVAL, KEYWORD_FN_PTR, KEYWORD_FN_PTR_CALL, KEYWORD_FN_PTR_CURRY,
+            KEYWORD_IS_DEF_FN, KEYWORD_IS_DEF_VAR, KEYWORD_IS_SHARED,
+        };
+
         // `is_shared` belongs here for a sharper reason than the rest: rhai
         // answers it syntactically in both call positions (`func/call.rs:1240`
         // and `:929`) and registers no function for it anywhere, so a lowered
         // call raises `ErrorFunctionNotFound` where the walker returns a bool.
-        const SYNTACTIC: &[&str] = &["eval", "is_def_var", "is_def_fn"];
+        const SYNTACTIC: &[&str] = &[KEYWORD_EVAL, KEYWORD_IS_DEF_VAR, KEYWORD_IS_DEF_FN];
 
         // These are handled by `fn_ptr_call` above, but only at the arities
         // rhai treats syntactically — at any other arity it falls through to
         // ordinary dispatch, and so must this.
-        if matches!(call.name.as_str(), "Fn" | "call" | "curry" | "is_shared") {
+        if matches!(
+            call.name.as_str(),
+            KEYWORD_FN_PTR | KEYWORD_FN_PTR_CALL | KEYWORD_FN_PTR_CURRY | KEYWORD_IS_SHARED
+        ) {
             return false;
         }
 

--- a/src/grain/compile/mod.rs
+++ b/src/grain/compile/mod.rs
@@ -1813,24 +1813,29 @@ impl Lowering {
     /// captures the enclosing scope is closure construction, and a qualified
     /// name resolves against imported modules; neither is a plain call.
     fn is_lowerable_call(&self, call: &FnCallExpr) -> bool {
-        use crate::engine::{
-            KEYWORD_EVAL, KEYWORD_FN_PTR, KEYWORD_FN_PTR_CALL, KEYWORD_FN_PTR_CURRY,
-            KEYWORD_IS_DEF_FN, KEYWORD_IS_DEF_VAR, KEYWORD_IS_SHARED,
-        };
+        const SYNTACTIC: &[&str] = &[
+            crate::engine::KEYWORD_EVAL,
+            crate::engine::KEYWORD_IS_DEF_VAR,
+            #[cfg(not(feature = "no_function"))]
+            crate::engine::KEYWORD_IS_DEF_FN,
+        ];
 
         // `is_shared` belongs here for a sharper reason than the rest: rhai
         // answers it syntactically in both call positions (`func/call.rs:1240`
         // and `:929`) and registers no function for it anywhere, so a lowered
         // call raises `ErrorFunctionNotFound` where the walker returns a bool.
-        const SYNTACTIC: &[&str] = &[KEYWORD_EVAL, KEYWORD_IS_DEF_VAR, KEYWORD_IS_DEF_FN];
+        const FN_CALL: &[&str] = &[
+            crate::engine::KEYWORD_FN_PTR,
+            crate::engine::KEYWORD_FN_PTR_CALL,
+            crate::engine::KEYWORD_FN_PTR_CURRY,
+            #[cfg(not(feature = "no_closure"))]
+            crate::engine::KEYWORD_IS_SHARED,
+        ];
 
         // These are handled by `fn_ptr_call` above, but only at the arities
         // rhai treats syntactically — at any other arity it falls through to
         // ordinary dispatch, and so must this.
-        if matches!(
-            call.name.as_str(),
-            KEYWORD_FN_PTR | KEYWORD_FN_PTR_CALL | KEYWORD_FN_PTR_CURRY | KEYWORD_IS_SHARED
-        ) {
+        if FN_CALL.contains(&call.name.as_str()) {
             return false;
         }
 

--- a/src/grain/vm/callback.rs
+++ b/src/grain/vm/callback.rs
@@ -40,7 +40,8 @@ use core::mem;
 use std::prelude::v1::*;
 
 use crate::{
-    func::RhaiFunc, Dynamic, FuncRegistration, ImmutableString, Module, NativeCallContext, Shared,
+    func::RhaiFunc, Dynamic, FnArgsVec, FuncRegistration, ImmutableString, Module,
+    NativeCallContext, Shared,
 };
 
 use super::{malformed, Vm, VmResult};
@@ -131,7 +132,7 @@ fn invoke(
     // Taken rather than cloned, as every registered function does: the
     // arguments are the caller's to give away, and it has already copied
     // anything it still needs.
-    let values: Vec<Dynamic> = args.iter_mut().map(|arg| mem::take(*arg)).collect();
+    let values: FnArgsVec<Dynamic> = args.iter_mut().map(|arg| mem::take(*arg)).collect();
 
     Vm::reentrant(context).call_function(
         program,

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -28,11 +28,10 @@ use crate::CallFnOptions;
 #[cfg(not(feature = "no_object"))]
 use crate::Map;
 use crate::{
-    eval::Caches, eval::GlobalRuntimeState, Dynamic, Engine, EvalAltResult, EvalContext, Scope,
+    eval::Caches, eval::GlobalRuntimeState, Dynamic, Engine, EvalAltResult, EvalContext, FnArgsVec,
+    Scope,
 };
-use crate::{
-    FnArgsVec, FnPtr, ImmutableString, NativeCallContext, Position, ThinVec, FUNC_TO_STRING, INT,
-};
+use crate::{FnPtr, ImmutableString, NativeCallContext, Position, ThinVec, FUNC_TO_STRING, INT};
 
 mod callback;
 
@@ -486,7 +485,7 @@ impl<'e> Vm<'e> {
         &mut self,
         program: &Program,
         name: &str,
-        args: Vec<Dynamic>,
+        args: FnArgsVec<Dynamic>,
         level: usize,
         pos: Position,
     ) -> VmResult {
@@ -502,7 +501,7 @@ impl<'e> Vm<'e> {
         &mut self,
         program: &Program,
         name: &str,
-        args: Vec<Dynamic>,
+        args: FnArgsVec<Dynamic>,
         level: usize,
         pos: Position,
         this: Option<Dynamic>,
@@ -591,7 +590,7 @@ impl<'e> Vm<'e> {
     ) -> Result<T, Box<EvalAltResult>> {
         let name = name.as_ref();
 
-        let mut arg_values = Vec::new();
+        let mut arg_values = FnArgsVec::new();
         args.parse(&mut arg_values);
 
         let orig_scope_len = scope.len();
@@ -1839,7 +1838,7 @@ impl<'e> Vm<'e> {
         } else {
             // Anything else is rhai's: a native function, a name registered
             // elsewhere, or a pointer it built itself.
-            let mut args: Vec<Dynamic> = self.stack.drain(at + 1..).collect();
+            let mut args: FnArgsVec<Dynamic> = self.stack.drain(at + 1..).collect();
             let context = native_context(self.engine, pointer.fn_name(), None, &self.global, pos);
             pointer
                 .call_raw(&context, bound.as_mut(), &mut args)
@@ -2050,7 +2049,7 @@ impl<'e> Vm<'e> {
         // which is exactly the shape rhai's ABI wants (`func/call.rs:36`). It
         // consumes them, replacing each with unit, so the caller truncates
         // afterwards rather than reusing them.
-        let mut args: Vec<&mut Dynamic> = self.stack[first..].iter_mut().collect();
+        let mut args: FnArgsVec<&mut Dynamic> = self.stack[first..].iter_mut().collect();
 
         // A scope of the callee's own, because the scope an `EvalContext`
         // carries is the one a *script* function's body runs in
@@ -2180,7 +2179,7 @@ impl<'e> Vm<'e> {
                     first + 1,
                 ),
             };
-            let mut args: Vec<&mut Dynamic> = core::iter::once(entry)
+            let mut args: FnArgsVec<&mut Dynamic> = core::iter::once(entry)
                 .chain(self.stack[rest..].iter_mut())
                 .collect();
             // The scope a dispatched script function runs in, which is never
@@ -2253,7 +2252,7 @@ impl<'e> Vm<'e> {
                 .ok_or_else(|| malformed("`this` stopped being bound".to_string()))?;
             // Argument zero is the snapshot, dead now that there is a register
             // to reach through.
-            let mut args: Vec<&mut Dynamic> = core::iter::once(entry)
+            let mut args: FnArgsVec<&mut Dynamic> = core::iter::once(entry)
                 .chain(self.stack[first + 1..].iter_mut())
                 .collect();
             // A scope of the callee's own, for [`Vm::call_stacked`]'s reason.

--- a/tests/grain/scope.rs
+++ b/tests/grain/scope.rs
@@ -648,26 +648,28 @@ fn a_closure_pointer_is_late_bound() {
 #[test]
 #[cfg(not(feature = "no_function"))]
 fn a_compiled_function_can_be_called_by_name() {
+    use smallvec::smallvec;
+
     let engine = corpus::engine();
     let ast = engine.compile("fn add(a, b) { a + b } fn boom() { throw 7; } 0").expect("must compile");
     let program = Compiler::new().compile(&ast);
 
     let mut vm = Vm::new(&engine);
-    let value = vm.call_function(&program, "add", vec![lit(2), lit(3)], 0, rhai::Position::NONE).expect("must call");
+    let value = vm.call_function(&program, "add", smallvec![lit(2), lit(3)], 0, rhai::Position::NONE).expect("must call");
     assert_eq!(value.as_int().unwrap(), 5);
 
     // Wrong arity is a miss, not a crash — the table is keyed on both.
     let err = vm
-        .call_function(&program, "add", vec![lit(1)], 0, rhai::Position::NONE)
+        .call_function(&program, "add", smallvec![lit(1)], 0, rhai::Position::NONE)
         .expect_err("one argument is a different function");
     assert!(matches!(*err, rhai::EvalAltResult::ErrorFunctionNotFound(..)));
 
     // And what the function raises comes back, wrapped as rhai wraps it.
-    let err = vm.call_function(&program, "boom", Vec::new(), 0, rhai::Position::NONE).expect_err("must propagate");
+    let err = vm.call_function(&program, "boom", smallvec![], 0, rhai::Position::NONE).expect_err("must propagate");
     assert!(matches!(*err, rhai::EvalAltResult::ErrorInFunctionCall(..)), "got {err:?}",);
 
     // The operand stack is where it started, so a caller can keep using it.
-    let value = vm.call_function(&program, "add", vec![lit(10), lit(1)], 0, rhai::Position::NONE).expect("must call again");
+    let value = vm.call_function(&program, "add", smallvec![lit(10), lit(1)], 0, rhai::Position::NONE).expect("must call again");
     assert_eq!(value.as_int().unwrap(), 11);
 }
 


### PR DESCRIPTION
## Use `FnArgsVec` to avoid allocations

This PR reduces `Vec` allocations during Rust native function calls by using `FnArgsVec` (which is a typedef to `smallvec`) instead to hold arguments.  This generates a 50% speed-up for function calls.
