### PR TITLE
Reduce error handling if unchecked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,22 @@ This is a work-in-progress and is not yet fully integrated into the main `Engine
 
 It is gated under the `grain` feature flag.
 
+Rhai Grain VM
+-------------
+
+* Add the experimental Rhai Grain bytecodes compiler and VM (requires the `grain` feature) for fast evaluation of scripts (thanks [`@ImTheSquid`](https://github.com/ImTheSquid) [`#1109`](https://github.com/rhaiscript/rhai/pull/1109)).
+
+### Bugs found in the process
+
+Since the Rhai Grain VM must run a script exactly the same as the standard AST interpreter, a number of bugs have been uncovered that are now fixed.
+
+* Fixes bug in `switch` statement that fails to try ranges when all conditions of exact matches fail ([`#1117`](https://github.com/rhaiscript/rhai/pull/1118))
+* Fixes bug in `switch` statement that fails to match shared values ([`#1120`](https://github.com/rhaiscript/rhai/pull/1120))
+
 Bug fixes
 ---------
 
 * Fixes bug in `Engine::compact_script` that generates invalid compacted scripts due to missing spaces between ambiguous operators (thanks [`@yuvalrakavy`](https://github.com/yuvalrakavy) [`#1106`](https://github.com/rhaiscript/rhai/pull/1106)).
-* Fixes bug in `switch` statement that fails to try ranges when all conditions of exact matches fail ([`#1117`](https://github.com/rhaiscript/rhai/pull/1118))
-
-New features
-------------
-
-* Added the experimental Rhai Grain bytecodes compiler and VM (under the `grain` feature) for fast evaluation of scripts (thanks [`@ImTheSquid`](https://github.com/ImTheSquid) [`#1109`](https://github.com/rhaiscript/rhai/pull/1109)).
 
 Enhancements
 ------------

--- a/src/eval/stmt.rs
+++ b/src/eval/stmt.rs
@@ -544,6 +544,8 @@ impl Engine {
                     }
                     // Then check ranges
                     if !result.is_some() && !ranges.is_empty() {
+                        let value = value.flatten();
+
                         // Then check integer ranges
                         for r in ranges.iter().filter(|r| r.contains(&value)) {
                             let BinaryExpr { lhs, rhs } = &expressions[r.index()];

--- a/src/grain/bytecode/code.rs
+++ b/src/grain/bytecode/code.rs
@@ -274,22 +274,68 @@ pub fn width(code: &[u8], at: usize) -> Option<usize> {
     (at + size <= code.len()).then_some(size)
 }
 
+/// How many bytes the instruction at `at` occupies.
+///
+/// # Panics
+///
+/// Panics if the offsets are out of bounds or the tag is unknown.
+///
+/// This is intended for use cases where the inputs are precisely known.
+/// Use [`width`] instead to handle potential errors.
+#[must_use]
+#[inline(always)]
+pub fn width_unchecked(code: &[u8], at: usize) -> usize {
+    WIDTHS[code[at] as usize] as usize
+}
+
 /// Read a `u16` operand at `at`.
 ///
-/// Returns `None` past the end rather than panicking. The verifier makes that
-/// unreachable for any program the VM will run, but the check is a load's worth
-/// of cost and it means nothing has to be trusted.
+/// Returns `None` past the end rather than panicking.
+///
+/// The verifier makes that unreachable for any program the VM will run,
+/// but the check is a load's worth of cost and it means nothing has to be trusted.
+///
+/// Under `unchecked` it by-passes these checks for raw performance,
+/// so it may panic if the slice is too short.
 #[must_use]
-#[inline]
+#[inline(always)]
 pub fn u16_at(code: &[u8], at: usize) -> Option<u16> {
-    Some(u16::from_le_bytes(code.get(at..at + 2)?.try_into().ok()?))
+    // The checked version which returns `None` if the slice is too short.
+    #[cfg(not(feature = "unchecked"))]
+    return Some(u16::from_le_bytes(code.get(at..at + 2)?.try_into().ok()?));
+
+    // The unchecked version which does a straight slice copy.
+    #[cfg(feature = "unchecked")]
+    {
+        let mut buf = [0_u8; 2];
+        buf.copy_from_slice(&code[at..at + 2]);
+        return Some(u16::from_le_bytes(buf));
+    }
 }
 
 /// Read a `u32` operand at `at`.
+///
+/// Returns `None` past the end rather than panicking.
+///
+/// The verifier makes that unreachable for any program the VM will run,
+/// but the check is a load's worth of cost and it means nothing has to be trusted.
+///
+/// Under `unchecked` it by-passes these checks for raw performance,
+/// so it may panic if the slice is too short.
 #[must_use]
-#[inline]
+#[inline(always)]
 pub fn u32_at(code: &[u8], at: usize) -> Option<u32> {
-    Some(u32::from_le_bytes(code.get(at..at + 4)?.try_into().ok()?))
+    // The checked version which returns `None` if the slice is too short.
+    #[cfg(not(feature = "unchecked"))]
+    return Some(u32::from_le_bytes(code.get(at..at + 4)?.try_into().ok()?));
+
+    // The unchecked version which does a straight slice copy.
+    #[cfg(feature = "unchecked")]
+    {
+        let mut buf = [0_u8; 4];
+        buf.copy_from_slice(&code[at..at + 4]);
+        return Some(u32::from_le_bytes(buf));
+    }
 }
 
 /// Why a lowering could not be turned into bytes.

--- a/src/grain/program.rs
+++ b/src/grain/program.rs
@@ -526,8 +526,27 @@ impl<'a> Program<'a> {
             .unwrap_or(0);
     }
 
+    /// Get the constant at `index`, or `None` if the index is out of bounds.
+    ///
+    /// Returns `None` past the end rather than panicking.
+    ///
+    /// The verifier makes that unreachable for any program the VM will run,
+    /// but the check is a load's worth of cost and it means nothing has to be trusted.
+    ///
+    /// # Panics
+    ///
+    /// Under `unchecked` it by-passes these checks for raw performance,
+    /// so it panics if the slice is too short.
+    #[inline(always)]
+    #[must_use]
     pub(crate) fn constant(&self, index: u32) -> Option<&Dynamic> {
-        self.consts.get(index as usize)
+        // The checked version which returns `None` if the slice is too short.
+        #[cfg(not(feature = "unchecked"))]
+        return self.consts.get(index as usize);
+
+        // The unchecked version which may panic if the index is out of bounds.
+        #[cfg(feature = "unchecked")]
+        return Some(&self.consts[index as usize]);
     }
 
     /// A name, borrowed from the artifact. Never allocates.
@@ -535,27 +554,105 @@ impl<'a> Program<'a> {
         self.names.get(index)
     }
 
+    /// Get the token at `index`, or `None` if the index is out of bounds.
+    ///
+    /// Returns `None` past the end rather than panicking.
+    ///
+    /// The verifier makes that unreachable for any program the VM will run,
+    /// but the check is a load's worth of cost and it means nothing has to be trusted.
+    ///
+    /// # Panics
+    ///
+    /// Under `unchecked` it by-passes these checks for raw performance,
+    /// so it panics if the slice is too short.
+    #[inline(always)]
+    #[must_use]
     pub(crate) fn token(&self, index: u32) -> Option<&Token> {
-        self.tokens.get(index as usize)
+        // The checked version which returns `None` if the slice is too short.
+        #[cfg(not(feature = "unchecked"))]
+        return self.tokens.get(index as usize);
+
+        // The unchecked version which may panic if the index is out of bounds.
+        #[cfg(feature = "unchecked")]
+        return Some(&self.tokens[index as usize]);
     }
 
+    /// Get the `assign_op` at `index`, or `None` if the index is out of bounds.
+    ///
+    /// Returns `None` past the end rather than panicking.
+    ///
+    /// The verifier makes that unreachable for any program the VM will run,
+    /// but the check is a load's worth of cost and it means nothing has to be trusted.
+    ///
+    /// # Panics
+    ///
+    /// Under `unchecked` it by-passes these checks for raw performance,
+    /// so it panics if the slice is too short.
+    #[inline(always)]
+    #[must_use]
     pub(crate) fn assign_op(&self, index: u32) -> Option<&AssignOp> {
-        self.assign_ops.get(index as usize)
+        // The checked version which returns `None` if the slice is too short.
+        #[cfg(not(feature = "unchecked"))]
+        return self.assign_ops.get(index as usize);
+
+        // The unchecked version which may panic if the index is out of bounds.
+        #[cfg(feature = "unchecked")]
+        return Some(&self.assign_ops[index as usize]);
     }
 
+    /// Get the `chain` at `index`, or `None` if the index is out of bounds.
+    ///
+    /// Returns `None` past the end rather than panicking.
+    ///
+    /// The verifier makes that unreachable for any program the VM will run,
+    /// but the check is a load's worth of cost and it means nothing has to be trusted.
+    ///
+    /// # Panics
+    ///
+    /// Under `unchecked` it by-passes these checks for raw performance,
+    /// so it panics if the slice is too short.
+    #[inline(always)]
+    #[must_use]
     pub(crate) fn chain(&self, index: u32) -> Option<&Chain> {
-        self.chains.get(index as usize)
+        // The checked version which returns `None` if the slice is too short.
+        #[cfg(not(feature = "unchecked"))]
+        return self.chains.get(index as usize);
+
+        // The unchecked version which may panic if the index is out of bounds.
+        #[cfg(feature = "unchecked")]
+        return Some(&self.chains[index as usize]);
     }
 
+    #[must_use]
     pub(crate) fn chains(&self) -> &[Chain] {
         &self.chains
     }
 
+    /// Get the [`Op::Switch`](crate::grain::bytecode::Op::Switch) at `index`,
+    /// or `None` if the index is out of bounds.
+    ///
+    /// Returns `None` past the end rather than panicking.
+    ///
+    /// The verifier makes that unreachable for any program the VM will run,
+    /// but the check is a load's worth of cost and it means nothing has to be trusted.
+    ///
+    /// # Panics
+    ///
+    /// Under `unchecked` it by-passes these checks for raw performance,
+    /// so it panics if the slice is too short.
+    #[inline(always)]
+    #[must_use]
     pub(crate) fn switch(&self, index: u32) -> Option<&Switch> {
-        self.switches.get(index as usize)
+        // The checked version which returns `None` if the slice is too short.
+        #[cfg(not(feature = "unchecked"))]
+        return self.switches.get(index as usize);
+
+        // The unchecked version which may panic if the index is out of bounds.
+        #[cfg(feature = "unchecked")]
+        return Some(&self.switches[index as usize]);
     }
 
-    /// The dispatch tables [`Op::Switch`](crate::grain::bytecode::Op::Switch) indexes.
+    /// The dispatch table's [`Op::Switch`](crate::grain::bytecode::Op::Switch) indexes.
     ///
     /// Public because a disassembly that leaves them out is misleading: a
     /// switch's arms are reached only from its table, so without it they read
@@ -653,8 +750,27 @@ impl<'a> Program<'a> {
         nodes
     }
 
+    /// Get the AST nodes still inside fragments at `index`,
+    /// or `None` if the index is out of bounds.
+    ///
+    /// Returns `None` past the end rather than panicking.
+    ///
+    /// The verifier makes that unreachable for any program the VM will run,
+    /// but the check is a load's worth of cost and it means nothing has to be trusted.
+    ///
+    /// # Panics
+    ///
+    /// Under `unchecked` it by-passes these checks for raw performance,
+    /// so it panics if the slice is too short.
+    #[inline(always)]
+    #[must_use]
     pub(crate) fn residual(&self, index: u32) -> Option<&Expr> {
-        self.residuals.get(index as usize)
+        // The checked version which returns `None` if the slice is too short.
+        return self.residuals.get(index as usize);
+
+        // The unchecked version which may panic if the index is out of bounds.
+        #[cfg(feature = "unchecked")]
+        return Some(&self.residuals[index as usize]);
     }
 
     /// The construct that stopped this program being written, and where.

--- a/src/grain/program.rs
+++ b/src/grain/program.rs
@@ -536,11 +536,11 @@ impl<'a> Program<'a> {
     /// # Panics
     ///
     /// Under `unchecked` it by-passes these checks for raw performance,
-    /// so it panics if the slice is too short.
+    /// so it panics if the index is out of bounds.
     #[inline(always)]
     #[must_use]
     pub(crate) fn constant(&self, index: u32) -> Option<&Dynamic> {
-        // The checked version which returns `None` if the slice is too short.
+        // The checked version which returns `None` if the index is out of bounds.
         #[cfg(not(feature = "unchecked"))]
         return self.consts.get(index as usize);
 
@@ -564,11 +564,11 @@ impl<'a> Program<'a> {
     /// # Panics
     ///
     /// Under `unchecked` it by-passes these checks for raw performance,
-    /// so it panics if the slice is too short.
+    /// so it panics if the index is out of bounds.
     #[inline(always)]
     #[must_use]
     pub(crate) fn token(&self, index: u32) -> Option<&Token> {
-        // The checked version which returns `None` if the slice is too short.
+        // The checked version which returns `None` if the index is out of bounds.
         #[cfg(not(feature = "unchecked"))]
         return self.tokens.get(index as usize);
 
@@ -587,11 +587,11 @@ impl<'a> Program<'a> {
     /// # Panics
     ///
     /// Under `unchecked` it by-passes these checks for raw performance,
-    /// so it panics if the slice is too short.
+    /// so it panics if the index is out of bounds.
     #[inline(always)]
     #[must_use]
     pub(crate) fn assign_op(&self, index: u32) -> Option<&AssignOp> {
-        // The checked version which returns `None` if the slice is too short.
+        // The checked version which returns `None` if the index is out of bounds.
         #[cfg(not(feature = "unchecked"))]
         return self.assign_ops.get(index as usize);
 
@@ -610,11 +610,11 @@ impl<'a> Program<'a> {
     /// # Panics
     ///
     /// Under `unchecked` it by-passes these checks for raw performance,
-    /// so it panics if the slice is too short.
+    /// so it panics if the index is out of bounds.
     #[inline(always)]
     #[must_use]
     pub(crate) fn chain(&self, index: u32) -> Option<&Chain> {
-        // The checked version which returns `None` if the slice is too short.
+        // The checked version which returns `None` if the index is out of bounds.
         #[cfg(not(feature = "unchecked"))]
         return self.chains.get(index as usize);
 
@@ -639,11 +639,11 @@ impl<'a> Program<'a> {
     /// # Panics
     ///
     /// Under `unchecked` it by-passes these checks for raw performance,
-    /// so it panics if the slice is too short.
+    /// so it panics if the index is out of bounds.
     #[inline(always)]
     #[must_use]
     pub(crate) fn switch(&self, index: u32) -> Option<&Switch> {
-        // The checked version which returns `None` if the slice is too short.
+        // The checked version which returns `None` if the index is out of bounds.
         #[cfg(not(feature = "unchecked"))]
         return self.switches.get(index as usize);
 
@@ -761,11 +761,12 @@ impl<'a> Program<'a> {
     /// # Panics
     ///
     /// Under `unchecked` it by-passes these checks for raw performance,
-    /// so it panics if the slice is too short.
+    /// so it panics if the index is out of bounds.
     #[inline(always)]
     #[must_use]
     pub(crate) fn residual(&self, index: u32) -> Option<&Expr> {
-        // The checked version which returns `None` if the slice is too short.
+        // The checked version which returns `None` if the index is out of bounds.
+        #[cfg(not(feature = "unchecked"))]
         return self.residuals.get(index as usize);
 
         // The unchecked version which may panic if the index is out of bounds.

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -794,10 +794,16 @@ impl<'e> Vm<'e> {
         result
     }
 
+    #[inline(always)]
+    #[must_use]
     fn pop(&mut self) -> Result<Dynamic, Box<EvalAltResult>> {
-        self.stack
+        #[cfg(not(feature = "unchecked"))]
+        return self
+            .stack
             .pop()
-            .ok_or_else(|| malformed("operand stack underflow".to_string()))
+            .ok_or_else(|| malformed("operand stack underflow".to_string()));
+        #[cfg(feature = "unchecked")]
+        return Ok(self.stack.pop().expect("operand stack underflow"));
     }
 
     /// `reached` tracks the instruction being executed, so a failure can be
@@ -2770,8 +2776,12 @@ impl<'e> Vm<'e> {
             // and nothing allocated. The bounds checks are what let this run
             // straight off an artifact without trusting it; the verifier has
             // already made them unreachable for anything that loaded.
+            #[cfg(not(feature = "unchecked"))]
             let width = code::width(code, pc)
                 .ok_or_else(|| malformed(format!("undecodable instruction at {pc}")))?;
+            #[cfg(feature = "unchecked")]
+            let width = code::width_unchecked(code, pc);
+
             let small = |offset: usize| {
                 code::u16_at(code, pc + offset)
                     .ok_or_else(|| malformed(format!("truncated operand at {pc}")))

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -852,11 +852,14 @@ impl<'e> Vm<'e> {
     ) -> VmResult {
         // Step operands were pushed first, then the root if it is one that has
         // to be evaluated, then the value being assigned.
+        #[cfg(not(feature = "unchecked"))]
         let operands_at = self
             .stack
             .len()
             .checked_sub(chain.consumes())
             .ok_or_else(|| malformed("chain with too few operands".to_string()))?;
+        #[cfg(feature = "unchecked")]
+        let operands_at = self.stack.len() - chain.consumes();
 
         let ChainRoot {
             value: mut root,
@@ -1777,11 +1780,15 @@ impl<'e> Vm<'e> {
         frame_base: usize,
         pos: Position,
     ) -> VmResult {
+        #[cfg(not(feature = "unchecked"))]
         let base = self
             .stack
             .len()
             .checked_sub(argc + 1)
             .ok_or_else(|| malformed("function pointer call is missing its target".into()))?;
+        #[cfg(feature = "unchecked")]
+        let base = self.stack.len() - argc - 1;
+
         let mut at = base;
 
         // In method position a target that is not a pointer means the *first
@@ -2132,11 +2139,15 @@ impl<'e> Vm<'e> {
             }
             Receiver::This => unreachable!("taken above"),
         };
+
+        #[cfg(not(feature = "unchecked"))]
         let first = self
             .stack
             .len()
             .checked_sub(on_stack)
             .ok_or_else(|| malformed("call with too few arguments".to_string()))?;
+        #[cfg(feature = "unchecked")]
+        let first = self.stack.len() - on_stack;
 
         let place = match at {
             Site::Slot(index) => Some(scope.get_mut_by_index(index)),
@@ -2230,11 +2241,14 @@ impl<'e> Vm<'e> {
         argc: usize,
         pos: Position,
     ) -> VmResult {
+        #[cfg(not(feature = "unchecked"))]
         let first = self
             .stack
             .len()
             .checked_sub(argc)
             .ok_or_else(|| malformed("call with too few arguments".to_string()))?;
+        #[cfg(feature = "unchecked")]
+        let first = self.stack.len() - argc;
 
         // Rhai turns `f(this, ..)` into `this.f(..)` for a receiver that is not
         // shared, and read-only is *not* part of that test — unlike the variable
@@ -3131,11 +3145,14 @@ impl<'e> Vm<'e> {
                         None
                     };
 
+                    #[cfg(not(feature = "unchecked"))]
                     let first = self
                         .stack
                         .len()
                         .checked_sub(argc)
                         .ok_or_else(|| malformed("call with too few arguments".to_string()))?;
+                    #[cfg(feature = "unchecked")]
+                    let first = self.stack.len() - argc;
 
                     // Reach the same built-in the walker reaches. Gated on
                     // rhai's own `fast_operators()` rather than a guard of our
@@ -3198,14 +3215,22 @@ impl<'e> Vm<'e> {
 
                 code::tag::ROTATE => {
                     let under = code[pc + 1] as usize;
+                    #[cfg(not(feature = "unchecked"))]
                     let top = self
                         .stack
                         .len()
                         .checked_sub(1)
                         .ok_or_else(|| malformed("rotate on an empty stack".to_string()))?;
+                    #[cfg(feature = "unchecked")]
+                    let top = self.stack.len() - 1;
+
+                    #[cfg(not(feature = "unchecked"))]
                     let to = top
                         .checked_sub(under)
                         .ok_or_else(|| malformed("rotate past the bottom".to_string()))?;
+                    #[cfg(feature = "unchecked")]
+                    let to = top - under;
+
                     self.stack[to..].rotate_right(1);
                 }
 
@@ -3214,11 +3239,15 @@ impl<'e> Vm<'e> {
                 #[cfg(not(feature = "no_index"))]
                 code::tag::MAKE_ARRAY => {
                     let len = small(1)? as usize;
+
+                    #[cfg(not(feature = "unchecked"))]
                     let first = self
                         .stack
                         .len()
                         .checked_sub(len)
                         .ok_or_else(|| malformed("array with too few elements".to_string()))?;
+                    #[cfg(feature = "unchecked")]
+                    let first = self.stack.len() - len;
 
                     // The running total belongs to this literal and goes with
                     // it. `Op::CheckSize` is what filled it in, one element at
@@ -3241,11 +3270,16 @@ impl<'e> Vm<'e> {
                 #[cfg(not(feature = "no_object"))]
                 code::tag::MAKE_MAP => {
                     let len = small(1)? as usize;
+
+                    #[cfg(not(feature = "unchecked"))]
                     let first = self
                         .stack
                         .len()
                         .checked_sub(2 * len + 1)
                         .ok_or_else(|| malformed("map with too few operands".to_string()))?;
+                    #[cfg(feature = "unchecked")]
+                    let first = self.stack.len() - (2 * len + 1);
+
                     // As for `MakeArray`: nothing was pushed for a literal
                     // with no computed entries, so nothing may be popped.
                     if len > 0 {
@@ -3254,9 +3288,14 @@ impl<'e> Vm<'e> {
 
                     let mut parts = self.stack.drain(first..);
                     let template = parts.next().expect("checked above");
+
+                    #[cfg(not(feature = "unchecked"))]
                     let mut map = template
                         .try_cast::<Map>()
                         .ok_or_else(|| malformed("map literal without a template".to_string()))?;
+                    #[cfg(feature = "unchecked")]
+                    let mut map = template.cast::<Map>();
+
                     while let Some(key) = parts.next() {
                         let value = parts.next().expect("pairs, checked above");
                         let key = key.into_immutable_string().map_err(|actual| {
@@ -3389,15 +3428,24 @@ impl<'e> Vm<'e> {
 
                 code::tag::CURRY => {
                     let argc = code[pc + 1] as usize;
+
+                    #[cfg(not(feature = "unchecked"))]
                     let at = self
                         .stack
                         .len()
                         .checked_sub(argc + 1)
                         .ok_or_else(|| malformed("curry is missing its target".into()))?;
+                    #[cfg(feature = "unchecked")]
+                    let at = self.stack.len() - (argc + 1);
+
+                    #[cfg(not(feature = "unchecked"))]
                     let mut pointer = self.stack[at]
                         .clone()
                         .try_cast::<FnPtr>()
                         .ok_or_else(|| self.mismatch::<FnPtr>(self.stack[at].type_name(), pos()))?;
+                    #[cfg(feature = "unchecked")]
+                    let mut pointer = self.stack[at].clone().cast::<FnPtr>();
+
                     for value in self.stack.drain(at + 1..) {
                         pointer.add_curry(value);
                     }
@@ -3517,12 +3565,20 @@ impl<'e> Vm<'e> {
                     // Counted before the item is unwrapped, as rhai does, so a
                     // loop long enough to wrap the counter is an error rather
                     // than a wrap.
-                    iteration.count = iteration.count.checked_add(1).ok_or_else(|| {
-                        Box::new(EvalAltResult::ErrorArithmetic(
-                            format!("for-loop counter overflow: {}", iteration.count),
-                            pos(),
-                        ))
-                    })?;
+                    #[cfg(not(feature = "unchecked"))]
+                    {
+                        iteration.count = iteration.count.checked_add(1).ok_or_else(|| {
+                            Box::new(EvalAltResult::ErrorArithmetic(
+                                format!("for-loop counter overflow: {}", iteration.count),
+                                pos(),
+                            ))
+                        })?;
+                    }
+                    #[cfg(feature = "unchecked")]
+                    {
+                        iteration.count += 1;
+                    }
+
                     let count = iteration.count;
 
                     // A fallible iterator's error is positioned at the

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -3438,13 +3438,10 @@ impl<'e> Vm<'e> {
                     #[cfg(feature = "unchecked")]
                     let at = self.stack.len() - (argc + 1);
 
-                    #[cfg(not(feature = "unchecked"))]
                     let mut pointer = self.stack[at]
                         .clone()
                         .try_cast::<FnPtr>()
                         .ok_or_else(|| self.mismatch::<FnPtr>(self.stack[at].type_name(), pos()))?;
-                    #[cfg(feature = "unchecked")]
-                    let mut pointer = self.stack[at].clone().cast::<FnPtr>();
 
                     for value in self.stack.drain(at + 1..) {
                         pointer.add_curry(value);

--- a/src/packages/iter_basic.rs
+++ b/src/packages/iter_basic.rs
@@ -42,7 +42,7 @@ where
 }
 
 // Range iterator with step
-#[derive(Clone, Hash, Eq, PartialEq)]
+#[derive(Clone, Hash)]
 pub struct StepRange<T> {
     /// Start of the range.
     pub from: T,

--- a/src/types/dynamic.rs
+++ b/src/types/dynamic.rs
@@ -388,6 +388,14 @@ impl Hash for Dynamic {
     ///
     /// Panics if the [`Dynamic`] value contains an unrecognized trait object.
     fn hash<H: Hasher>(&self, state: &mut H) {
+        #[cfg(not(feature = "no_closure"))]
+        match self.0 {
+            Union::Shared(ref cell, ..) => {
+                return (*crate::func::locked_read(cell).unwrap()).hash(state)
+            }
+            _ => (),
+        }
+
         mem::discriminant(&self.0).hash(state);
 
         match self.0 {
@@ -416,7 +424,7 @@ impl Hash for Dynamic {
             }
 
             #[cfg(not(feature = "no_closure"))]
-            Union::Shared(ref cell, ..) => (*crate::func::locked_read(cell).unwrap()).hash(state),
+            Union::Shared(..) => unreachable!(),
 
             Union::Variant(ref v, ..) => {
                 let _value_any = (***v).as_any();
@@ -1696,7 +1704,8 @@ impl Dynamic {
     /// Under the `sync` feature, a _shared_ value may deadlock.
     /// Otherwise, the data may currently be borrowed for write (so its type cannot be determined).
     ///
-    /// Under these circumstances, the _shared_ value is simply cloned.
+    /// Under these circumstances, the _shared_ value is simply cloned, meaning that the result
+    /// value will also be _shared_.
     ///
     /// These normally shouldn't occur since most operations in Rhai are single-threaded.
     #[inline]


### PR DESCRIPTION
## Description

This is a draft PR to speed up certain lookups during the VM running stage when the bytecodes are known to be well-formed.

All such are gated only under the `unchecked` feature.

Essentially, some of the lookup functions (e.g. `Program::constant`) would use the original code without the `unchecked` feature, but will use more optimized direct lookup code under `unchecked` (which can panic if there is a bug in the VM).

In both scenarios, the one uncompromising premise is that malicious _user_ inputs can never cause a panic.  Therefore, panics can only happen if there is a bug in the core system code.

## Performance

Although the checks are still performed under the faster path, they panic instead of returning `None`.  Thus, returning a constant `Some` value and turning on inlining allows the compiler to remove the subsequent checks for `None` at the call site, as well as the error handling return.

Thus `program.constant(index).ok_or_else(|| malformed(format!("no constant {index}")))?` will hopefully be optimized into a single `&program.constants[index]`, which can potentially enable further follow-on optimizations.

Benchmarked this and it looks like another 10-20% speed gain on average.
