### PR TITLE
Use a strings interner to reduce allocation for Dynamic string constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Rhai Grain VM
 Since the Rhai Grain VM must run a script exactly the same as the standard AST interpreter, a number of bugs have been uncovered that are now fixed.
 
 * Fixes bug in `switch` statement that fails to try ranges when all conditions of exact matches fail ([`#1117`](https://github.com/rhaiscript/rhai/pull/1118))
-* Fixes bug in `switch` statement that fails to match shared values ([`#1120`](https://github.com/rhaiscript/rhai/pull/1120))
+* Fixes bug in `switch` statement that fails to match shared values ([`#1123`](https://github.com/rhaiscript/rhai/pull/1123))
 
 Bug fixes
 ---------

--- a/src/grain/format/read.rs
+++ b/src/grain/format/read.rs
@@ -1,4 +1,4 @@
-use crate::{tokenizer::Token, Dynamic, ImmutableString};
+use crate::{tokenizer::Token, types::StringsInterner, Dynamic};
 use core::convert::{TryFrom, TryInto};
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
@@ -114,6 +114,11 @@ impl core::fmt::Display for ReadError {
 }
 
 pub(super) fn read(bytes: &[u8]) -> Result<Program<'_>, ReadError> {
+    // Use a strings interner to avoid allocating string constants (as `Dynamic`) multiple times.
+    // Notice that this is not used for other strings, which are all borrowed from the byte stream.
+    // Therefore, a small number of interned strings should be enough for most programs.
+    let mut strings_interner = StringsInterner::new(64);
+
     let mut cursor = Cursor::new(bytes);
 
     if cursor.take(MAGIC.len())? != MAGIC {
@@ -140,7 +145,7 @@ pub(super) fn read(bytes: &[u8]) -> Result<Program<'_>, ReadError> {
     }
 
     let source = cursor.str()?;
-    let source = (!source.is_empty()).then(|| ImmutableString::from(source));
+    let source = (!source.is_empty()).then(|| strings_interner.get(source));
 
     // Borrowed: the spans are read, the blob is sliced, and nothing per-name
     // is allocated.
@@ -155,7 +160,7 @@ pub(super) fn read(bytes: &[u8]) -> Result<Program<'_>, ReadError> {
 
     let mut consts = Vec::new();
     for _ in 0..cursor.uvarint()? {
-        consts.push(get_constant(&mut cursor, 0)?);
+        consts.push(get_constant(&mut cursor, &mut strings_interner, 0)?);
     }
 
     let mut tokens = Vec::new();
@@ -411,7 +416,11 @@ fn get_token(cursor: &mut Cursor) -> Result<Token, ReadError> {
     })
 }
 
-fn get_constant(cursor: &mut Cursor, depth: usize) -> Result<Dynamic, ReadError> {
+fn get_constant(
+    cursor: &mut Cursor,
+    strings_interner: &mut StringsInterner,
+    depth: usize,
+) -> Result<Dynamic, ReadError> {
     if depth > MAX_CONSTANT_DEPTH {
         return Err(ReadError::ConstantTooDeep);
     }
@@ -440,7 +449,7 @@ fn get_constant(cursor: &mut Cursor, depth: usize) -> Result<Dynamic, ReadError>
             Dynamic::from(char::from_u32(code).ok_or(ReadError::MalformedVarint)?)
         }
 
-        constant::STRING => Dynamic::from(ImmutableString::from(cursor.str()?)),
+        constant::STRING => Dynamic::from(strings_interner.get(cursor.str()?)),
 
         // A build with no type for one cannot decode it into anything; the tag
         // falls through to the unknown-tag arm, which is the truthful answer.
@@ -451,7 +460,7 @@ fn get_constant(cursor: &mut Cursor, depth: usize) -> Result<Dynamic, ReadError>
             let count = cursor.uvarint()?;
             let mut array = rhai::Array::new();
             for _ in 0..count {
-                array.push(get_constant(cursor, depth + 1)?);
+                array.push(get_constant(cursor, strings_interner, depth + 1)?);
             }
             Dynamic::from(array)
         }
@@ -462,7 +471,7 @@ fn get_constant(cursor: &mut Cursor, depth: usize) -> Result<Dynamic, ReadError>
             let mut map = rhai::Map::new();
             for _ in 0..count {
                 let key = cursor.str()?.into();
-                map.insert(key, get_constant(cursor, depth + 1)?);
+                map.insert(key, get_constant(cursor, strings_interner, depth + 1)?);
             }
             Dynamic::from(map)
         }

--- a/src/grain/vm/callback.rs
+++ b/src/grain/vm/callback.rs
@@ -40,8 +40,8 @@ use core::mem;
 use std::prelude::v1::*;
 
 use crate::{
-    func::RhaiFunc, Dynamic, FnArgsVec, FuncRegistration, ImmutableString, Module,
-    NativeCallContext, Shared,
+    func::RhaiFunc, Dynamic, FnArgsVec, FuncRegistration, Module, NativeCallContext, Shared,
+    SmartString,
 };
 
 use super::{malformed, Vm, VmResult};
@@ -92,7 +92,7 @@ pub(super) fn wrappers(program: &SharedProgram) -> Module {
         };
 
         let owner = program.clone();
-        let called: ImmutableString = name.into();
+        let called: SmartString = name.into();
 
         // One closure for every arity, rather than the fixed-arity shapes
         // `Module::set_native_fn` generates. `Dynamic` parameters throughout


### PR DESCRIPTION
String constants (e.g. used in string literals) in a bytecodes stream must be converted into `Dynamic` values for the program to run.

If multiple copies of the same string literal appear throughout the script, this may result in over allocation of the same string.

Use Rhai's standard strings interner to reuse copies of the same string.
