### PR TITLE
Fix very serious optimizer bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Since the Rhai Grain VM must run a script exactly the same as the standard AST i
 
 * Fixes bug in `switch` statement that fails to try ranges when all conditions of exact matches fail ([`#1117`](https://github.com/rhaiscript/rhai/pull/1118))
 * Fixes bug in `switch` statement that fails to match shared values ([`#1123`](https://github.com/rhaiscript/rhai/pull/1123))
+* Fixes a very serious bug in optimizer that erroneously removes statements involving variable access which should be considered side effects.
 
 Bug fixes
 ---------

--- a/fuzz/fuzz_targets/generated.rs
+++ b/fuzz/fuzz_targets/generated.rs
@@ -120,27 +120,6 @@ fn compare(engine: &Engine, source: &str) -> Option<(String, String)> {
     Some((outcome(&vm_scope, ours)?, expected))
 }
 
-/// Whether a divergence is rhai's optimizer losing a local rather than a bug of
-/// ours — see `rhai_drops_a_local_its_optimizer_still_refers_to` in
-/// `tests/fuzz.rs`.
-///
-/// The optimizer can delete a `let` whose variable is still read, leaving the
-/// read pointing at whatever now sits at that scope index. Rhai answers with
-/// another variable's value; we resolve by name and report it missing. There is
-/// no agreeing with an AST that refers to a local it does not declare.
-///
-/// Turning the optimizer off is what tells the two apart, and it runs only on a
-/// divergence that already looks like this one — a fuzzer that quietly stopped
-/// comparing would be worse than one that stops.
-fn optimizer_lost_a_local(source: &str, ours: &str) -> bool {
-    if !ours.contains("ErrorVariableNotFound") {
-        return false;
-    }
-    let mut plain = engine();
-    plain.set_optimization_level(rhai::OptimizationLevel::None);
-    compare(&plain, source).is_some_and(|(ours, expected)| ours == expected)
-}
-
 fuzz_target!(|data: &[u8]| {
     // Too few bytes to steer with, and the PRNG fallback would make every such
     // input the same script.
@@ -152,7 +131,7 @@ fuzz_target!(|data: &[u8]| {
     let Some((ours, expected)) = compare(&engine(), &source) else {
         return;
     };
-    if ours == expected || optimizer_lost_a_local(&source, &ours) {
+    if ours == expected {
         return;
     }
 

--- a/fuzz/fuzz_targets/roundtrip.rs
+++ b/fuzz/fuzz_targets/roundtrip.rs
@@ -81,34 +81,6 @@ fn outcome(run: impl FnOnce(&mut Scope) -> Result<Dynamic, Box<rhai::EvalAltResu
     }
 }
 
-/// Whether a divergence is rhai's optimizer losing a local rather than a bug of
-/// ours — see `rhai_drops_a_local_its_optimizer_still_refers_to` in
-/// `tests/fuzz.rs`.
-///
-/// The optimizer can delete a `let` whose variable is still read, leaving the
-/// read pointing at whatever now sits at that scope index. Rhai answers with
-/// another variable's value; we resolve by name and report it missing. There is
-/// no agreeing with an AST that refers to a local it does not declare.
-///
-/// Turning the optimizer off is what tells the two apart, and it runs only on a
-/// divergence that already looks like this one — a fuzzer that quietly stopped
-/// comparing would be worse than one that stops.
-fn optimizer_lost_a_local(source: &str, direct: &str) -> bool {
-    if !direct.contains("ErrorVariableNotFound") {
-        return false;
-    }
-    let mut plain = engine();
-    plain.set_optimization_level(rhai::OptimizationLevel::None);
-    let Ok(ast) = plain.compile(source) else {
-        return false;
-    };
-    let program = Compiler::new().compile(&ast);
-
-    let expected = outcome(|scope| plain.eval_ast_with_scope::<Dynamic>(scope, &ast));
-    let ours = outcome(|scope| Vm::new(&plain).eval_with_scope(scope, &program));
-    ours == expected
-}
-
 fuzz_target!(|source: String| {
     let engine = engine();
     let Ok(ast) = engine.compile(&source) else {
@@ -132,7 +104,7 @@ fuzz_target!(|source: String| {
     if expected == "budget" || direct == "budget" {
         return;
     }
-    if direct != expected && optimizer_lost_a_local(&source, &direct) {
+    if direct != expected {
         return;
     }
     assert_eq!(

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -769,7 +769,8 @@ impl Expr {
 
             Self::Stmt(x) => x.iter().all(Stmt::is_pure),
 
-            Self::Variable(..) => true,
+            // Variable access is never pure because it involves a variable lookup which is a side effect.
+            Self::Variable(..) => false,
 
             _ => self.is_constant(),
         }

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -168,7 +168,7 @@ fn optimize_stmt_block(
 
     let mut is_dirty = state.is_dirty();
 
-    let is_pure = if is_internal {
+    let is_pure_for_this_block = if is_internal {
         Stmt::is_internally_pure
     } else {
         Stmt::is_pure
@@ -217,7 +217,8 @@ fn optimize_stmt_block(
         });
 
         // Optimize each statement in the block
-        statements.iter_mut().for_each(|stmt| {
+        let len = statements.len();
+        statements.iter_mut().enumerate().for_each(|(index, stmt)| {
             match stmt {
                 Stmt::Var(x, options, ..) => {
                     optimize_expr(&mut x.1, state, false);
@@ -231,42 +232,43 @@ fn optimize_stmt_block(
                     };
                     state.push_var(x.0.name.clone(), value);
                 }
-                // Optimize the statement
-                _ => optimize_stmt(stmt, state, preserve_result),
+                // Optimize the statement, preserve result if necessary only for the last one
+                _ => optimize_stmt(stmt, state, preserve_result && (index >= len - 1)),
             }
         });
 
         // Remove all pure statements except the last one
         let mut index = 0;
-        let mut first_non_constant = statements
+        let mut last_non_pure = statements
             .iter()
             .rev()
-            .position(|stmt| match stmt {
-                stmt if !is_pure(stmt) => true,
-
-                Stmt::Var(x, ..) if x.1.is_constant() => true,
-                Stmt::Expr(e) if !e.is_constant() => true,
-
-                #[cfg(not(feature = "no_module"))]
-                Stmt::Import(x, ..) if !x.0.is_constant() => true,
-
-                _ => false,
-            })
+            .position(|stmt| !is_pure_for_this_block(stmt))
             .map_or(0, |n| statements.len() - n - 1);
 
         while index < statements.len() {
             if preserve_result && index >= statements.len() - 1 {
                 break;
             }
-            match statements[index] {
-                ref stmt if is_pure(stmt) && index >= first_non_constant => {
+            match &statements[index] {
+                // Pure/internally-pure statements beyond the last non-pure one can be removed
+                stmt if is_pure_for_this_block(stmt) && index >= last_non_pure => {
                     state.set_dirty();
                     statements.remove(index);
                 }
-                ref stmt if stmt.is_pure() => {
+                // A variable access is normally non-pure, but if it is a statement by itself,
+                // it has no side effects in this block and can be removed
+                Stmt::Expr(expr) if matches!(expr.as_ref(), Expr::Variable(..)) => {
                     state.set_dirty();
-                    if index < first_non_constant {
-                        first_non_constant -= 1;
+                    if index < last_non_pure {
+                        last_non_pure -= 1;
+                    }
+                    statements.remove(index);
+                }
+                // Pure statements can always be removed
+                stmt if stmt.is_pure() => {
+                    state.set_dirty();
+                    if index < last_non_pure {
+                        last_non_pure -= 1;
                     }
                     statements.remove(index);
                 }
@@ -286,7 +288,7 @@ fn optimize_stmt_block(
                         state.set_dirty();
                         statements.clear();
                     }
-                    [ref stmt] if !stmt.returns_value() && is_pure(stmt) => {
+                    [ref stmt] if !stmt.returns_value() && is_pure_for_this_block(stmt) => {
                         state.set_dirty();
                         statements.clear();
                     }
@@ -317,7 +319,7 @@ fn optimize_stmt_block(
                     // { ...; stmt_that_returns; pure_non_value_stmt } -> { ...; stmt_that_returns; noop }
                     // { ...; stmt; pure_non_value_stmt } -> { ...; stmt }
                     [.., ref second_last_stmt, ref last_stmt]
-                        if !last_stmt.returns_value() && is_pure(last_stmt) =>
+                        if !last_stmt.returns_value() && is_pure_for_this_block(last_stmt) =>
                     {
                         state.set_dirty();
                         if second_last_stmt.returns_value() {
@@ -332,7 +334,7 @@ fn optimize_stmt_block(
         } else {
             loop {
                 match statements[..] {
-                    [ref stmt] if is_pure(stmt) => {
+                    [ref stmt] if is_pure_for_this_block(stmt) => {
                         state.set_dirty();
                         statements.clear();
                     }
@@ -352,7 +354,7 @@ fn optimize_stmt_block(
                         state.set_dirty();
                         statements.pop().unwrap();
                     }
-                    [.., ref last_stmt] if is_pure(last_stmt) => {
+                    [.., ref last_stmt] if is_pure_for_this_block(last_stmt) => {
                         state.set_dirty();
                         statements.pop().unwrap();
                     }

--- a/tests/grain/corpus/mod.rs
+++ b/tests/grain/corpus/mod.rs
@@ -785,4 +785,8 @@ pub const CASES: &[Case] = &[
     case("type_of_a_host_type", "let w = widget(1); type_of(w)"),
     case("type_of_method_style", "let s = \"a\"; s.type_of()"),
     case("type_of_a_pointer", "let r = \"\"; { let f = |x| x; r = type_of(f); } r"),
+    // Optimizer tests
+    case("optimizer_folding_switch", "let a = 1; { let b = 99; switch b { _ => b } }"),
+    case("optimizer_folding_variables_access", "let a = 1; { let b = 99; b; b; b; b }"),
+    case("optimizer_folding_internal_variables_access", "let a = 1; { let b = 99; b; b; b; b } a"),
 ];

--- a/tests/grain/fuzz.rs
+++ b/tests/grain/fuzz.rs
@@ -213,102 +213,6 @@ fn quietly<T>(body: impl FnOnce() -> T) -> Option<T> {
     out
 }
 
-/// A rhai bug, not one of ours, found by `cargo fuzz run generated`.
-///
-/// A `switch` as the last statement of a block makes rhai's optimizer delete a
-/// `let` in that block and flatten what is left into the enclosing statement
-/// list — while the reads of that local keep the scope index the parser gave
-/// them. The index is counted back from the end of the scope, so it now names
-/// whatever moved into its place.
-///
-/// Two symptoms, and the quiet one is the dangerous one:
-///
-/// * with something else at that index, rhai answers with **another variable's
-///   value** and reports nothing at all;
-/// * with nothing there, `scope.len() - index` underflows (`eval/expr.rs:131`)
-///   — a panic in a debug build and a wild index in a release one.
-///
-/// Both are three lines of ordinary rhai with none of this involved. We resolve
-/// locals by name, so we say the variable is missing, which is the closest
-/// thing to right available: there is no agreeing with an AST that refers to a
-/// local it does not declare.
-///
-/// Pinned because `generated_scripts_agree_with_the_walker` and both `cargo
-/// fuzz` targets have to skip these, and every one of those skips should go the
-/// day this test starts failing.
-///
-/// The bug is the optimizer's, so `no_optimize` is the one build without it.
-#[test]
-#[cfg(not(feature = "no_optimize"))]
-fn rhai_drops_a_local_its_optimizer_still_refers_to() {
-    // The read lands on `a`, so rhai answers 1 where the script says 99.
-    const WRONG: &str = "let a = 1; { let b = 99; switch b { _ => b } }";
-    // The same shape with nothing left at that index.
-    const PANIC: &str = "{ let b = 99; switch b { _ => b } }";
-
-    let engine = corpus::engine();
-    let mut plain = corpus::engine();
-    plain.set_optimization_level(rhai::OptimizationLevel::None);
-
-    let ast = engine.compile(WRONG).expect("it parses");
-    let value = engine.eval_ast::<Dynamic>(&ast).expect("rhai runs it, which is the problem");
-    assert_eq!(
-        value.as_int().ok(),
-        Some(1),
-        "rhai no longer reads the wrong variable — delete the optimizer skips \
-         in the fuzzers and this test with them",
-    );
-
-    let ast = engine.compile(PANIC).expect("it parses");
-    assert!(
-        quietly(|| engine.eval_ast::<Dynamic>(&ast)).is_none(),
-        "rhai no longer underflows here — delete the walker skip in \
-         `generated_scripts_agree_with_the_walker`",
-    );
-
-    // The same scripts with the optimizer out of the way, which is what says
-    // the fault is in the optimizer rather than in them.
-    for source in [WRONG, PANIC] {
-        let ast = plain.compile(source).expect("it parses either way");
-        let value = quietly(|| plain.eval_ast::<Dynamic>(&ast))
-            .expect("with the optimizer off it should run")
-            .expect("and it should not fail");
-        assert_eq!(value.as_int().ok(), Some(99), "{source:?}");
-    }
-}
-
-/// Whether the two sides agree once rhai's optimizer is out of the way.
-///
-/// The optimizer is what makes a dropped local reachable, so agreeing without
-/// it and disagreeing with it says the AST is at fault rather than the
-/// lowering. Only ever asked about a divergence that already looks like one.
-fn agree_unoptimised(source: &str) -> bool {
-    #[allow(unused_mut)]
-    let mut plain = corpus::engine();
-    // `no_optimize` builds one that way to begin with.
-    #[cfg(not(feature = "no_optimize"))]
-    plain.set_optimization_level(rhai::OptimizationLevel::None);
-    let Ok(ast) = plain.compile(source) else {
-        return false;
-    };
-
-    let mut walker_scope = Scope::new();
-    let Some(walked) = quietly(|| plain.eval_ast_with_scope::<Dynamic>(&mut walker_scope, &ast)) else {
-        return false;
-    };
-
-    let program = Compiler::new().compile(&ast);
-    let mut vm_scope = Scope::new();
-    let ours = if program.makes_fn_pointers() {
-        let program = program.into_shared();
-        Vm::new(&plain).eval_with_callbacks(&mut vm_scope, &program)
-    } else {
-        Vm::new(&plain).eval_with_scope(&mut vm_scope, &program)
-    };
-
-    snapshot(&walker_scope, walked) == snapshot(&vm_scope, ours)
-}
-
 /// The claim the corpus makes, over scripts nobody wrote.
 ///
 /// `tests/differential.rs` pins the constructs someone thought of. This is the
@@ -346,7 +250,6 @@ fn generated_scripts_agree_with_the_walker() {
     let mut skipped = 0usize;
     let mut walker_panics = 0usize;
     let mut too_deep = 0usize;
-    let mut lost_a_local = 0usize;
     let mut unparsed: Vec<String> = Vec::new();
     let mut failures = Vec::new();
 
@@ -409,13 +312,6 @@ fn generated_scripts_agree_with_the_walker() {
         if walked == ours {
             continue;
         }
-        // Not every disagreement is one to have: rhai's optimizer can delete a
-        // `let` whose variable is still read, and then there is no agreeing
-        // with it. See `rhai_drops_a_local_its_optimizer_still_refers_to`.
-        if format!("{ours:?}").contains("ErrorVariableNotFound") && agree_unoptimised(&source) {
-            lost_a_local += 1;
-            continue;
-        }
 
         if failures.len() < 5 {
             failures.push(format!("\n=== script {n} (seed {:#x}) ===\n  {source}\n  rhai: {walked:?}\n  vm:   {ours:?}", SEED ^ n as u64,));
@@ -426,8 +322,7 @@ fn generated_scripts_agree_with_the_walker() {
         "{parsed} of {SCRIPTS} generated scripts parsed, {ran} compared, \
          {valued} produced a value, {skipped} hit a limit, \
          {walker_panics} panicked the walker, \
-         {too_deep} were too complex to parse, \
-         {lost_a_local} lost a local to rhai's optimizer",
+         {too_deep} were too complex to parse",
     );
 
     // The walker panicking is upstream's problem, but it is also a hole in this


### PR DESCRIPTION
## How this was found

The Rhai Grain VM, during its fuzzing, found errors when handling this case, clearly labeling it as a "Rhai bug" which needs to be routed around.

The fuzzer actually has to get around this bug by detecting this condition.

## How it happened

The optimizer has a serious bug related to how it determines whether an expression is _pure_ or not.

A pure expression has no side effects.  Rhai erroneously considered a simple variable access to be pure, which is not correct.  A variable access depends on the variable existing, and that is a side effect.  Without considering this, the variable declaration may be removed in error, creating a serious soundness bug.

The script that flagged this was found by Rhai Grain's fuzzer:
```rust
let a = 1;
{
    let b = 99;
    switch b { _ => b }
}
```

Previously, access to the variable `b` in the `switch` statement was considered pure, so the statement was pure.  Therefore, the variable declaration of `b` was removed by the optimizer because it no longer had any impure statements following it.

However, the `switch` statement was not removed by the optimizer because the result of the script depends on the value from this statement.  Thus the script was optimized to:

```rust
let a = 1;
switch b { _ => b }
```

which would have created a `variable not found` error, had it not been that the variable `b` was actually trying to read the scope slot for `a`, causing the script to return the value 1 instead of 99.

## Conclusion

The bug has been fixed and the special detection code in the VM's fuzzer is removed.
