### PR TITLE
VM: support decimal numbers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
         toolchain: [stable]
         experimental: [false]
         include:
-          # smoketests for different toolchains
+          # smoke-tests for different toolchains
           - {toolchain: stable, os: windows-latest, experimental: false, flags: ""}
           - {toolchain: stable, os: macos-latest, experimental: false, flags: ""}
           - {toolchain: beta, os: ubuntu-latest, experimental: false, flags: "--features unstable"}

--- a/src/grain/compile/poolable.rs
+++ b/src/grain/compile/poolable.rs
@@ -5,6 +5,8 @@ use rhai::Map;
 #[cfg(not(feature = "no_index"))]
 use rhai::{Array, Blob};
 use rhai::{Dynamic, INT};
+#[cfg(feature = "decimal")]
+use rust_decimal::Decimal;
 
 /// Whether a constant can live in the artifact's constant pool.
 ///
@@ -54,6 +56,12 @@ pub(crate) fn is_poolable(value: &Dynamic) -> bool {
     #[cfg(not(feature = "no_index"))]
     if value.is_blob() {
         return value.read_lock::<Blob>().is_some();
+    }
+
+    // Decimals are enabled by `decimal`.
+    #[cfg(feature = "decimal")]
+    if value.is_decimal() {
+        return value.read_lock::<Decimal>().is_some();
     }
 
     // A range is a host type by representation but not by nature: Rhai builds

--- a/src/grain/format/mod.rs
+++ b/src/grain/format/mod.rs
@@ -108,6 +108,7 @@ mod constant {
     pub const BLOB: u8 = 0x09;
     pub const RANGE: u8 = 0x0a;
     pub const RANGE_INCLUSIVE: u8 = 0x0b;
+    pub const DECIMAL: u8 = 0x0c;
 }
 
 /// Everything a stripped artifact left behind.

--- a/src/grain/format/read.rs
+++ b/src/grain/format/read.rs
@@ -437,16 +437,36 @@ fn get_constant(
 
         constant::INT => {
             let value = cursor.ivarint()?;
-            Dynamic::from(rhai::INT::try_from(value).map_err(|_| ReadError::MalformedVarint)?)
+            Dynamic::from_int(rhai::INT::try_from(value).map_err(|_| ReadError::MalformedVarint)?)
         }
 
         #[cfg(not(feature = "no_float"))]
         constant::FLOAT => {
             let width = core::mem::size_of::<rhai::FLOAT>();
             let bits = cursor.take(width)?;
-            Dynamic::from(rhai::FLOAT::from_le_bytes(
+            Dynamic::from_float(rhai::FLOAT::from_le_bytes(
                 bits.try_into().expect("width matches the fingerprint"),
             ))
+        }
+
+        #[cfg(feature = "decimal")]
+        constant::DECIMAL => {
+            let width = core::mem::size_of::<i128>() + core::mem::size_of::<u32>();
+            let bits = cursor.take(width)?;
+            let value = i128::from_le_bytes(
+                bits[0..core::mem::size_of::<i128>()]
+                    .try_into()
+                    .expect("width matches the fingerprint"),
+            );
+            let scale = u32::from_le_bytes(
+                bits[core::mem::size_of::<i128>()..]
+                    .try_into()
+                    .expect("width matches the fingerprint"),
+            );
+            Dynamic::from_decimal(
+                rust_decimal::Decimal::try_from_i128_with_scale(value, scale)
+                    .map_err(|_| ReadError::MalformedVarint)?,
+            )
         }
 
         constant::CHAR => {

--- a/src/grain/format/write.rs
+++ b/src/grain/format/write.rs
@@ -391,6 +391,17 @@ fn put_constant(out: &mut Vec<u8>, value: &Dynamic) -> Result<(), String> {
         out.extend_from_slice(&number.to_le_bytes());
         return Ok(());
     }
+    #[cfg(feature = "decimal")]
+    if let Ok(number) = value.as_decimal() {
+        out.push(constant::DECIMAL);
+        let value = number.mantissa();
+        let scale = number.scale();
+        let mut buf = [0u8; core::mem::size_of::<i128>() + core::mem::size_of::<u32>()];
+        buf[0..core::mem::size_of::<i128>()].copy_from_slice(&value.to_le_bytes());
+        buf[core::mem::size_of::<i128>()..].copy_from_slice(&scale.to_le_bytes());
+        out.extend_from_slice(&buf);
+        return Ok(());
+    }
     if let Ok(character) = value.as_char() {
         out.push(constant::CHAR);
         put_uvarint(out, u32::from(character).into());

--- a/src/packages/map_basic.rs
+++ b/src/packages/map_basic.rs
@@ -5,7 +5,7 @@ use crate::plugin::*;
 use crate::{def_package, Dynamic, FnPtr, Map, NativeCallContext, RhaiResultOf, INT};
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
-use std::{collections::BTreeMap, convert::TryFrom, mem};
+use std::{convert::TryFrom, mem};
 
 #[cfg(not(feature = "no_index"))]
 use crate::Array;
@@ -536,7 +536,7 @@ mod map_functions {
         return serde_json::to_string(
             &map.iter()
                 .map(|(k, v)| (k.as_str(), v))
-                .collect::<BTreeMap<_, _>>(),
+                .collect::<std::collections::BTreeMap<_, _>>(),
         )
         .unwrap_or_else(|_| "ERROR".into());
         #[cfg(not(feature = "metadata"))]

--- a/tests/grain/corpus/mod.rs
+++ b/tests/grain/corpus/mod.rs
@@ -141,6 +141,11 @@ pub fn applies_to_this_build(name: &str) -> bool {
     ) {
         return false;
     }
+    // No `decimal` does not have support for `Decimal`.
+    #[cfg(not(feature = "decimal"))]
+    if matches!(name, "decimal_numbers" | "decimal_arithmetic") {
+        return false;
+    }
     // `no_function` removes `fn` and the anonymous form with it, so a case that
     // declares one, points at one, or has a `this` to be a method of does not
     // parse. The prefixes carry the families; the rest reach for a function
@@ -320,6 +325,8 @@ pub const CASES: &[Case] = &[
     case("int_arithmetic", "let a = 7; let b = 3; a * b - a / b + a % b"),
     case("float_arithmetic", "let a = 7.5; let b = 0.5; a * b + a / b"),
     case("mixed_numeric", "1 + 2.5"),
+    case("decimal_numbers", "let a = parse_decimal(\"42\")"),
+    case("decimal_arithmetic", "let a = parse_decimal(\"42\"); let b = 1; a + b"),
     case("comparison_chain", "let a = 5; a > 1 && a < 10 || a == 5"),
     case("bitwise", "let a = 0b1010; (a & 0b0110) | (a ^ 0b1111) << 2"),
     case("string_ops", r#"let s = "hello"; s + " " + "world" + s.len"#),


### PR DESCRIPTION
Support for `Decimal` constants are added for builds with the `decimal` feature flag.

This requires adding `constant::DECIMAL` to the ABI and the read/write methods to handle them.

No need to bump artifact version because previous artifacts simply would not have decimals written.
