### PR TITLE
Fix function currying behavior on native functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Bug fixes
 ---------
 
 * Fixes bug in `Engine::compact_script` that generates invalid compacted scripts due to missing spaces between ambiguous operators (thanks [`@yuvalrakavy`](https://github.com/yuvalrakavy) [`#1106`](https://github.com/rhaiscript/rhai/pull/1106)).
+* Fixes bug where a curried function pointer passed to a native iteration function (e.g. `map`, `filter`, `reduce`) received the element _before_ the curried arguments, the reverse of what `FnPtr::call` does.
 
 Enhancements
 ------------

--- a/src/grain/vm/callback.rs
+++ b/src/grain/vm/callback.rs
@@ -13,25 +13,14 @@
 //! # What being a native costs
 //!
 //! Rhai reaches its own closures through a `Fn*` pointer carrying the body, and
-//! that shortcut is what these wrappers cannot have. Two consequences, both
-//! measured rather than assumed:
+//! that shortcut is what these wrappers cannot have. The cost is speed and call
+//! budget, measured rather than assumed: Rhai resolves a wrapper by name and
+//! type on every element, from a cache it builds fresh per crossing, where its
+//! own pointer skips resolution entirely. `native callbacks` in
+//! `examples/bench.rs` measures 0.34x — the one case the VM loses — and the two
+//! extra dispatch layers cost 5 call levels per crossing against the walker's 2.
 //!
-//! * **Argument order, for a capturing closure called by a native that binds
-//!   `this`.** A capture is a curried value, and `_call_with_extra_args`
-//!   (`types/fn_ptr.rs:573`) tries `[this] ++ curry ++ args` first for anything
-//!   that is not a `Fn*` pointer. That shape is never right, and it is what a
-//!   wrapper answers to. Stock Rhai does the same thing to its own name-only
-//!   pointers — `stock_rhai_does_the_same_to_its_own_native_pointers` in
-//!   `tests/callback.rs` reproduces it with none of this involved — so the fix
-//!   is not here; it is upstream, or in not currying captures at all.
-//! * **Speed, and call budget.** Rhai resolves a wrapper by name and type on
-//!   every element, from a cache it builds fresh per crossing, where its own
-//!   pointer skips resolution entirely. `native callbacks` in
-//!   `examples/bench.rs` measures 0.34x — the one case the VM loses — and the
-//!   two extra dispatch layers cost 5 call levels per crossing against the
-//!   walker's 2.
-//!
-//! Neither touches a pointer called directly from compiled code, which is
+//! None of it touches a pointer called directly from compiled code, which is
 //! `Op::CallFnPtr` and never comes through here.
 
 use core::any::TypeId;

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -832,9 +832,8 @@ impl<'e> Vm<'e> {
     /// does not get it still runs — the pointer simply fails to resolve, as
     /// `ErrorFunctionNotFound`, at the point the native tries to call it.
     ///
-    /// Read the `callback` module before relying on it: a crossing is slower than the
-    /// walker, and a *capturing* closure handed to a native that binds `this`
-    /// arrives with its arguments rotated.
+    /// Read the `callback` module before relying on it: a crossing is slower
+    /// than the walker.
     ///
     /// Named `eval_` rather than `run_` because it yields the program's value;
     /// Rhai has no `Engine` method to mirror here, so the crate's own rule is

--- a/src/types/fn_ptr.rs
+++ b/src/types/fn_ptr.rs
@@ -566,10 +566,27 @@ impl FnPtr {
             _ => (),
         }
 
-        self.call_raw(ctx, this_ptr.as_deref_mut(), args.clone())
+        // Curried arguments bind to the front of the parameter list, so `this` cannot be passed as
+        // the object -- that would place it ahead of them and reverse the argument order relative
+        // to a direct `call`. Move it into the argument list at the designated position instead.
+        let this_ptr_is_curried_arg = MOVE_PTR && self.is_curried() && this_ptr.is_some();
+
+        let result = if this_ptr_is_curried_arg {
+            let mut args2 = FnArgsVec::with_capacity(args.len() + 1);
+            args2.extend(args.clone());
+            args2.insert(move_this_ptr_to_args, this_ptr.as_deref().unwrap().clone());
+            self.call_raw(ctx, None, args2)
+        } else {
+            self.call_raw(ctx, this_ptr.as_deref_mut(), args.clone())
+        };
+
+        result
             .or_else(|err| match *err {
                 ERR::ErrorFunctionNotFound(sig, ..)
-                    if MOVE_PTR && this_ptr.is_some() && sig.starts_with(self.fn_name()) =>
+                    if MOVE_PTR
+                        && !this_ptr_is_curried_arg
+                        && this_ptr.is_some()
+                        && sig.starts_with(self.fn_name()) =>
                 {
                     let mut args2 = FnArgsVec::with_capacity(args.len() + 1);
                     if move_this_ptr_to_args == 0 {

--- a/tests/fn_ptr.rs
+++ b/tests/fn_ptr.rs
@@ -136,6 +136,45 @@ fn test_fn_ptr_curry() {
     );
 }
 
+/// A curried argument comes first no matter who does the calling - a direct `call` or a
+/// native iteration function such as `map`.
+#[test]
+#[cfg(not(feature = "no_object"))]
+#[cfg(not(feature = "no_index"))]
+fn test_fn_ptr_curry_arg_order() {
+    let mut engine = Engine::new();
+
+    engine.register_fn("subtract", |a: INT, b: INT| a - b);
+
+    assert_eq!(engine.eval::<INT>(r#"Fn("subtract").curry(10).call(1)"#).unwrap(), 9);
+
+    assert_eq!(
+        engine
+            .eval::<rhai::Array>(r#"[1, 2, 3].map(Fn("subtract").curry(10))"#)
+            .unwrap()
+            .into_iter()
+            .map(|v| v.as_int().unwrap())
+            .collect::<Vec<_>>(),
+        [9, 8, 7]
+    );
+
+    #[cfg(not(feature = "no_function"))]
+    assert_eq!(
+        engine
+            .eval::<rhai::Array>(
+                r#"
+                    fn sub(a, b) { a - b }
+                    [1, 2, 3].map(Fn("sub").curry(10))
+                "#
+            )
+            .unwrap()
+            .into_iter()
+            .map(|v| v.as_int().unwrap())
+            .collect::<Vec<_>>(),
+        [9, 8, 7]
+    );
+}
+
 #[test]
 #[cfg(not(feature = "no_function"))]
 fn test_fn_ptr_call() {

--- a/tests/grain/callback.rs
+++ b/tests/grain/callback.rs
@@ -76,8 +76,8 @@ fn a_bare_function_name_is_a_pointer() {
 /// A capture arrives, and has the right value.
 ///
 /// Multiplication commutes, so this says nothing about which *position* it
-/// arrives in — see `a_capturing_closure_reaches_a_native_with_its_arguments_rotated`
-/// for that, which is where the answer is unwelcome.
+/// arrives in — see `a_capturing_closure_reaches_a_native_with_its_arguments_in_order`
+/// for that.
 #[test]
 #[cfg(not(feature = "no_closure"))]
 fn a_capturing_closure_resolves_and_sees_its_capture() {
@@ -86,49 +86,38 @@ fn a_capturing_closure_resolves_and_sees_its_capture() {
 }
 
 /// A capturing closure handed to a native that binds `this` gets its captured
-/// values *after* the element instead of before.
+/// values *before* the element, which is where currying puts them.
 ///
-/// Not our arithmetic: it is which shape Rhai tries first. A capture is a
-/// curried value, and `_call_with_extra_args` (`types/fn_ptr.rs:573`) opens
-/// with `[this] ++ curry ++ args` — the one order that is never right. Rhai's
-/// own closures escape it because they are `Fn*` pointers with the body
-/// attached, which is caught two branches earlier at `:538` and rearranged
-/// into `curry ++ [this] ++ args`.
+/// A capture is a curried value, and ours are `Fn` pointers resolved by name,
+/// so Rhai reaches them as natives rather than as `Fn*` pointers with the body
+/// attached. Both routes now build `curry ++ [this] ++ args`.
 ///
-/// Ours are `Fn` pointers resolved by name, so Rhai reaches them as *natives*
-/// and takes the first shape. The proof that this is Rhai's behaviour rather
-/// than ours is `stock_rhai_does_the_same_to_its_own_native_pointers` below,
-/// which reproduces it with no Rhai Grain in the picture at all.
-///
-/// So: safe for a closure that captures nothing, and for one whose parameters
-/// commute. Wrong, silently, otherwise. Non-commutative on purpose here —
-/// `n - x` and `x - n` are the same two values in the other order, and only
-/// arithmetic that cares can tell them apart.
+/// Non-commutative on purpose — `n - x` and `x - n` are the same two values in
+/// the other order, and only arithmetic that cares can tell them apart.
 #[test]
 #[cfg(not(feature = "no_closure"))]
-fn a_capturing_closure_reaches_a_native_with_its_arguments_rotated() {
+fn a_capturing_closure_reaches_a_native_with_its_arguments_in_order() {
     let engine = corpus::engine();
     let source = "let n = 10; let a = [1, 2, 3]; a.map(|x| n - x)";
 
     assert_eq!(walk(&engine, source), Ok("[9, 8, 7]".to_string()));
-    assert_eq!(run(&engine, source), Ok("[-9, -8, -7]".to_string()));
+    assert_eq!(run(&engine, source), Ok("[9, 8, 7]".to_string()));
 }
 
-/// The same rotation, with nothing of ours involved.
+/// The same ordering, with nothing of ours involved.
 ///
 /// `Fn(s)` on a computed name is the one spelling that gets a name-only
 /// pointer out of stock Rhai, which is what every pointer we make is. Curry it,
-/// point it at a native, and hand it to `map`: Rhai passes the element first
-/// and the curried value second, while `f.call(1)` on the very same pointer
-/// passes them the other way round.
+/// point it at a native, and hand it to `map`: the curried value leads, exactly
+/// as `f.call(1)` on the very same pointer passes it.
 #[test]
-fn stock_rhai_does_the_same_to_its_own_native_pointers() {
+fn stock_rhai_orders_its_own_native_pointers_the_same_way() {
     let mut engine = corpus::engine();
     engine.register_fn("subtract", |a: rhai::INT, b: rhai::INT| a - b);
 
     let curried = "let s = \"sub\" + \"tract\"; let f = Fn(s).curry(10);";
-    assert_eq!(walk(&engine, &format!("{curried} [1, 2, 3].map(f)")), Ok("[-9, -8, -7]".to_string()), "rhai puts the element before the curried value",);
-    assert_eq!(walk(&engine, &format!("{curried} f.call(1)")), Ok("9".to_string()), "and the curried value first when there is no element",);
+    assert_eq!(walk(&engine, &format!("{curried} [1, 2, 3].map(f)")), Ok("[9, 8, 7]".to_string()), "the curried value leads the element",);
+    assert_eq!(walk(&engine, &format!("{curried} f.call(1)")), Ok("9".to_string()), "and leads on its own when there is no element",);
 }
 
 #[test]


### PR DESCRIPTION
Rhai had a bug where if you curried a function that was passed into a native function, the curried argument would be added *after* the other arguments, not before (like the normal behavior). This PR fixes that.

Old behavior:
```rs
engine.register_fn("subtract", |a: INT, b: INT| a - b);

assert_eq!(engine.eval::<INT>(r#"Fn("subtract").curry(10).call(1)"#).unwrap(), 9);

assert_eq!(
    engine
        .eval::<rhai::Array>(r#"[1, 2, 3].map(Fn("subtract").curry(10))"#)
        .unwrap()
        .into_iter()
        .map(|v| v.as_int().unwrap())
        .collect::<Vec<_>>(),
    [-9, -8, -7]
);
```

New behavior:
```rs
engine.register_fn("subtract", |a: INT, b: INT| a - b);

assert_eq!(engine.eval::<INT>(r#"Fn("subtract").curry(10).call(1)"#).unwrap(), 9);

assert_eq!(
    engine
        .eval::<rhai::Array>(r#"[1, 2, 3].map(Fn("subtract").curry(10))"#)
        .unwrap()
        .into_iter()
        .map(|v| v.as_int().unwrap())
        .collect::<Vec<_>>(),
    [9, 8, 7]
);
```