### PR TITLE
VM: Allow passing Position values instead of `Position::NONE` into Rhai calls

### DIFF
--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -25,6 +25,7 @@ pub use debugger::{
     BreakPoint, Debugger, DebuggerCommand, DebuggerEvent, DebuggerStatus, OnDebuggerCallback,
     OnDebuggingInit,
 };
+#[cfg(feature = "grain")]
 pub(crate) use eval_context::_call_fn_raw;
 pub use eval_context::{EvalContext, EvalContextFrameGuard};
 


### PR DESCRIPTION
Functions such as `debug` can print out the current position in a script.

The VM relies on `context::call_fn_raw` which automatically sets position to `Position::NONE`.

This PR exposes a lower-level private version, which accepts the current position such that `debug` can print out line numbers.
