### PR TITLE
VM: Allow shared values coming back from var resolver

### DIFF
--- a/src/eval/eval_context.rs
+++ b/src/eval/eval_context.rs
@@ -262,6 +262,7 @@ impl<'a, 's, 'ps, 'g, 'c, 't> EvalContext<'a, 's, 'ps, 'g, 'c, 't> {
             false,
             is_ref_mut,
             false,
+            Position::NONE,
         )
         .and_then(|result| {
             result.try_cast_result().map_err(|r| {
@@ -308,6 +309,7 @@ impl<'a, 's, 'ps, 'g, 'c, 't> EvalContext<'a, 's, 'ps, 'g, 'c, 't> {
             true,
             is_ref_mut,
             false,
+            Position::NONE,
         )
         .and_then(|result| {
             result.try_cast_result().map_err(|r| {
@@ -363,6 +365,7 @@ impl<'a, 's, 'ps, 'g, 'c, 't> EvalContext<'a, 's, 'ps, 'g, 'c, 't> {
             native_only,
             is_ref_mut,
             is_method_call,
+            Position::NONE,
         )
     }
     /// Call a registered native Rust function inside the [evaluation context][`EvalContext`].
@@ -402,6 +405,7 @@ impl<'a, 's, 'ps, 'g, 'c, 't> EvalContext<'a, 's, 'ps, 'g, 'c, 't> {
             true,
             is_ref_mut,
             false,
+            Position::NONE,
         )
     }
 
@@ -470,7 +474,7 @@ impl<'a, 's, 'ps, 'g, 'c, 't> EvalContext<'a, 's, 'ps, 'g, 'c, 't> {
 }
 
 /// Call a function (native Rust or scripted) inside the [evaluation context][`EvalContext`].
-fn _call_fn_raw(
+pub(crate) fn _call_fn_raw(
     engine: &Engine,
     global: &mut GlobalRuntimeState,
     caches: &mut Caches,
@@ -480,6 +484,7 @@ fn _call_fn_raw(
     native_only: bool,
     is_ref_mut: bool,
     is_method_call: bool,
+    pos: Position,
 ) -> RhaiResult {
     defer! { let orig_level = global.level; global.level += 1 }
 
@@ -487,7 +492,6 @@ fn _call_fn_raw(
     let op_token = Token::lookup_symbol_from_syntax(fn_name);
     let op_token = op_token.as_ref();
     let args_len = args.len();
-    let pos = Position::NONE;
 
     if native_only {
         if let Some(result) = engine.exec_syntactic_fn_call(global, caches, fn_name, args, pos)? {

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -25,6 +25,7 @@ pub use debugger::{
     BreakPoint, Debugger, DebuggerCommand, DebuggerEvent, DebuggerStatus, OnDebuggerCallback,
     OnDebuggingInit,
 };
+pub(crate) use eval_context::_call_fn_raw;
 pub use eval_context::{EvalContext, EvalContextFrameGuard};
 
 pub use global_state::GlobalRuntimeState;

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -1193,7 +1193,7 @@ impl<'e> Vm<'e> {
                 // what makes writing through it an error.
                 if let Some(value) = self.resolve_var(name, scope, var_pos)? {
                     return Ok(ChainRoot {
-                        value: RootValue::Detached(value.into_read_only()),
+                        value: RootValue::Detached(value),
                         pos: var_pos,
                     });
                 }
@@ -1844,7 +1844,7 @@ impl<'e> Vm<'e> {
         // A resolver hands back a value, not a place, so it is read-only —
         // which is what makes assigning to one an error.
         if let Some(value) = self.resolve_var(name, scope, pos)? {
-            return Ok(value.into_read_only());
+            return Ok(value);
         }
 
         if let Some(value) = scope.get(name) {
@@ -1900,12 +1900,11 @@ impl<'e> Vm<'e> {
             self.global.always_search_scope = true;
         }
 
-        resolved.map_err(|err| {
-            if err.position().is_none() {
-                return reposition(err, pos);
-            }
-            err
-        })
+        match resolved {
+            Ok(Some(value)) => Ok(Some(value.into_read_only())),
+            Ok(None) => Ok(None),
+            Err(err) => Err(positioned(err, pos)),
+        }
     }
 
     /// Assign to a variable no slot names.
@@ -1931,38 +1930,38 @@ impl<'e> Vm<'e> {
             ))
         };
 
-        if self.resolve_var(name, scope, pos)?.is_some() {
-            return Err(constant());
+        // Try the variable resolver first.
+        if let Some(mut value) = self.resolve_var(name, scope, pos)? {
+            if value.is_read_only() {
+                return Err(constant());
+            }
+            let mut target = place(&mut value, name, pos)?;
+            return self.store(program, op, &mut target, rhs, pos);
         }
 
-        match scope.is_constant(name) {
-            Some(true) => return Err(constant()),
-            Some(false) => {}
+        // Search the scope.
+        match scope.get_mut_raw(name) {
+            Some(None) => Err(constant()),
+            Some(Some(entry)) => {
+                let mut target = place(entry, name, pos)?;
+                self.store(program, op, &mut target, rhs, pos)
+            }
             // Not a variable at all. A module's is a value rather than a
             // place, so writing to one is the same refusal as writing to a
             // `const`.
-            None => {
-                return Err(
-                    if self
-                        .engine
-                        .global_modules
-                        .iter()
-                        .any(|module| module.get_var(name).is_some())
-                    {
-                        constant()
-                    } else {
-                        missing(name, pos)
-                    },
-                )
-            }
+            None => Err(
+                if self
+                    .engine
+                    .global_modules
+                    .iter()
+                    .any(|module| module.get_var(name).is_some())
+                {
+                    constant()
+                } else {
+                    missing(name, pos)
+                },
+            ),
         }
-
-        let entry = scope
-            .get_mut(name)
-            .ok_or_else(|| malformed(format!("`{name}` is in scope but not writable")))?;
-        let mut target = place(entry, name, pos)?;
-
-        self.store(program, op, &mut target, rhs, pos)
     }
 
     /// Call a function pointer, preferring a chunk we compiled.

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -83,6 +83,36 @@ fn native_context<'a>(
     NativeCallContext::from((engine, fn_name, source, global, pos))
 }
 
+#[inline(always)]
+fn call_engine(
+    engine: &Engine,
+    global: &mut GlobalRuntimeState,
+    caches: &mut Caches,
+    scope: &mut Scope,
+    fn_name: &str,
+    args: &mut [&mut Dynamic],
+    is_ref_mut: bool,
+    is_method_call: bool,
+    pos: Position,
+) -> VmResult {
+    let native_only = !crate::tokenizer::is_valid_function_name(fn_name);
+    #[cfg(not(feature = "no_function"))]
+    let native_only = native_only && !crate::parser::is_anonymous_fn(fn_name);
+
+    crate::eval::_call_fn_raw(
+        engine,
+        global,
+        caches,
+        scope,
+        fn_name,
+        args,
+        native_only,
+        is_ref_mut,
+        is_method_call,
+        pos,
+    )
+}
+
 /// Stamp the call site on an error that passes through a function boundary
 /// unwrapped, as Rhai does for exits and system exceptions
 /// (`func/script.rs:134`).
@@ -1358,17 +1388,17 @@ impl<'e> Vm<'e> {
                     let mut call_args: FnArgsVec<&mut Dynamic> = core::iter::once(&mut *target)
                         .chain(args.iter_mut())
                         .collect();
-                    let mut detached = Scope::new();
-                    let mut context = EvalContext::new(
+                    call_engine(
                         self.engine,
                         &mut self.global,
                         &mut self.caches,
-                        &mut detached,
-                        None,
-                    );
-                    context
-                        .call_fn_raw(name, true, true, &mut call_args)
-                        .map_err(|err| dispatch_failure(err, step_pos))?
+                        &mut Scope::new(),
+                        name,
+                        &mut call_args,
+                        true,
+                        true,
+                        step_pos,
+                    )?
                 };
 
                 if last {
@@ -1513,6 +1543,7 @@ impl<'e> Vm<'e> {
 
     /// Call the index getter, which unlike the setter is allowed to fail.
     #[cfg(not(all(feature = "no_index", feature = "no_object")))]
+    #[inline(always)]
     fn call_indexer(
         &mut self,
         name: &str,
@@ -1520,22 +1551,17 @@ impl<'e> Vm<'e> {
         index: &mut Dynamic,
         pos: Position,
     ) -> VmResult {
-        let mut detached = Scope::new();
-        let mut context = EvalContext::new(
+        call_engine(
             self.engine,
             &mut self.global,
             &mut self.caches,
-            &mut detached,
-            None,
-        );
-        context
-            .call_fn_raw(name, true, false, &mut [target, index])
-            .map_err(|mut err| {
-                if err.position().is_none() {
-                    err.set_position(pos);
-                }
-                err
-            })
+            &mut Scope::new(),
+            name,
+            &mut [target, index],
+            true,
+            false,
+            pos,
+        )
     }
 
     /// Put an element back into a container that had no reference to give.
@@ -1544,6 +1570,7 @@ impl<'e> Vm<'e> {
     /// temporary; this is the replay Rhai does at `eval/chaining.rs:744`,
     /// including swallowing "this type cannot be indexed" the way it does.
     #[cfg(not(all(feature = "no_index", feature = "no_object")))]
+    #[inline(always)]
     fn call_indexer_set(
         &mut self,
         target: &mut Dynamic,
@@ -1551,16 +1578,18 @@ impl<'e> Vm<'e> {
         value: &mut Dynamic,
         pos: Position,
     ) -> Result<(), Box<EvalAltResult>> {
-        let mut detached = Scope::new();
-        let mut context = EvalContext::new(
+        let result = call_engine(
             self.engine,
             &mut self.global,
             &mut self.caches,
-            &mut detached,
-            None,
+            &mut Scope::new(),
+            FN_IDX_SET,
+            &mut [target, index, value],
+            true,
+            false,
+            pos,
         );
-
-        match context.call_fn_raw(FN_IDX_SET, true, false, &mut [target, index, value]) {
+        match result {
             Ok(_) => Ok(()),
             Err(err) if matches!(*err, EvalAltResult::ErrorIndexingType(..)) => Ok(()),
             Err(mut err) => {
@@ -1648,17 +1677,17 @@ impl<'e> Vm<'e> {
             let fn_name = program
                 .name(fn_name)
                 .ok_or_else(|| malformed(format!("no name {fn_name}")))?;
-            let mut detached = Scope::new();
-            let mut context = EvalContext::new(
+            call_engine(
                 vm.engine,
                 &mut vm.global,
                 &mut vm.caches,
-                &mut detached,
-                None,
-            );
-            context
-                .call_fn_raw(fn_name, true, true, args)
-                .map_err(|err| positioned(err, step_pos))
+                &mut Scope::new(),
+                fn_name,
+                args,
+                true,
+                true,
+                step_pos,
+            )
         };
 
         if last {
@@ -1756,32 +1785,35 @@ impl<'e> Vm<'e> {
 
         // The real scope may be borrowed by the target, and dispatch does not
         // read it anyway — operators resolve against the engine.
-        let mut detached = Scope::new();
-        let mut context = EvalContext::new(
+        let result = call_engine(
             self.engine,
             &mut self.global,
             &mut self.caches,
-            &mut detached,
-            None,
+            &mut Scope::new(),
+            op_assign_name,
+            &mut [target, &mut rhs],
+            true,
+            false,
+            pos,
         );
-
-        match context.call_fn_raw(op_assign_name, true, false, &mut [target, &mut rhs]) {
+        match result {
             Ok(_) => Ok(()),
             Err(err)
                 if matches!(&*err,
                     EvalAltResult::ErrorFunctionNotFound(name, ..)
                         if name.starts_with(op_assign_name)) =>
             {
-                let mut context = EvalContext::new(
+                let value = call_engine(
                     self.engine,
                     &mut self.global,
                     &mut self.caches,
-                    &mut detached,
-                    None,
-                );
-                let value = context
-                    .call_fn_raw(op_name, true, false, &mut [&mut *target, &mut rhs])
-                    .map_err(|err| positioned(err, pos))?;
+                    &mut Scope::new(),
+                    op_name,
+                    &mut [target, &mut rhs],
+                    true,
+                    false,
+                    pos,
+                )?;
                 *target = value;
                 Ok(())
             }
@@ -2243,11 +2275,17 @@ impl<'e> Vm<'e> {
         // afterwards rather than reusing them.
         let mut args: FnArgsVec<&mut Dynamic> = self.stack[first..].iter_mut().collect();
 
-        let mut context =
-            EvalContext::new(self.engine, &mut self.global, &mut self.caches, scope, None);
-        context
-            .call_fn_raw(name, false, false, &mut args)
-            .map_err(|err| dispatch_failure(err, pos))
+        call_engine(
+            self.engine,
+            &mut self.global,
+            &mut self.caches,
+            scope,
+            name,
+            &mut args,
+            false,
+            false,
+            pos,
+        )
     }
 
     /// The same call, with a variable as its first argument and Rhai's
@@ -2385,17 +2423,17 @@ impl<'e> Vm<'e> {
             // this frame's — see [`Vm::call_stacked`], which has to build one
             // for the same reason and cannot borrow this one because the
             // receiver is holding it.
-            let mut detached = Scope::new();
-            let mut context = EvalContext::new(
+            call_engine(
                 self.engine,
                 &mut self.global,
                 &mut self.caches,
-                &mut detached,
-                None,
-            );
-            context
-                .call_fn_raw(name, true, false, &mut args)
-                .map_err(|err| dispatch_failure(err, pos))
+                &mut Scope::new(),
+                name,
+                &mut args,
+                true,
+                false,
+                pos,
+            )
         };
 
         self.stack.truncate(first);
@@ -2454,18 +2492,17 @@ impl<'e> Vm<'e> {
             let mut args: FnArgsVec<&mut Dynamic> = core::iter::once(entry)
                 .chain(self.stack[first + 1..].iter_mut())
                 .collect();
-            // A scope of the callee's own, for [`Vm::call_stacked`]'s reason.
-            let mut detached = Scope::new();
-            let mut context = EvalContext::new(
+            call_engine(
                 self.engine,
                 &mut self.global,
                 &mut self.caches,
-                &mut detached,
-                None,
-            );
-            context
-                .call_fn_raw(name, true, false, &mut args)
-                .map_err(|err| dispatch_failure(err, pos))
+                &mut Scope::new(),
+                name,
+                &mut args,
+                true,
+                false,
+                pos,
+            )
         };
 
         self.stack.truncate(first);

--- a/src/types/scope.rs
+++ b/src/types/scope.rs
@@ -795,6 +795,20 @@ impl Scope<'_> {
                 AccessMode::ReadOnly => None,
             })
     }
+    /// Get a mutable reference to the value of an entry in the [`Scope`].
+    ///
+    /// If the entry by the specified name is not found, [`None`] is returned.
+    ///
+    /// If the entry is read-only, [`Some`]`(`[`None`]`))` is returned.
+    #[inline]
+    #[must_use]
+    pub(crate) fn get_mut_raw(&mut self, name: &str) -> Option<Option<&mut Dynamic>> {
+        self.search(name)
+            .map(move |n| match self.values[n].access_mode() {
+                AccessMode::ReadWrite => Some(self.get_mut_by_index(n)),
+                AccessMode::ReadOnly => None,
+            })
+    }
     /// Get a mutable reference to the value of an entry in the [`Scope`] based on the index.
     ///
     /// # Panics


### PR DESCRIPTION
Rhai allows a variables resolver to come back with a _shared_ value, which is not considered read-only and the script and write through.  A shared value is only considered read-only if its underlying data is read-only.

This PR fixes this and allows feature parity with Rhai.
