### PR TITLE
VM: Implement missing syntactic functions

### DIFF
--- a/src/func/call.rs
+++ b/src/func/call.rs
@@ -1201,7 +1201,7 @@ impl Engine {
         first_arg: Option<&Expr>,
         args_expr: &[Expr],
         hashes: FnCallHashes,
-        capture_scope: bool,
+        capture_parent_scope: bool,
         pos: Position,
     ) -> RhaiResult {
         let mut first_arg = first_arg;
@@ -1430,7 +1430,7 @@ impl Engine {
         //
         // If so, do it separately because we cannot convert the first argument (if it is a simple
         // variable access) to &mut because `scope` is needed.
-        if capture_scope && !scope.is_empty() {
+        if capture_parent_scope && !scope.is_empty() {
             for expr in first_arg.iter().copied().chain(args_expr.iter()) {
                 let (value, ..) =
                     self.get_arg_value(global, caches, scope, this_ptr.as_deref_mut(), expr)?;

--- a/src/grain/compile/mod.rs
+++ b/src/grain/compile/mod.rs
@@ -1932,37 +1932,23 @@ impl Lowering {
 
     /// Whether a call can go through generic dispatch.
     ///
-    /// Rhai resolves a handful of names syntactically in `eval_fn_call_expr`
-    /// before dispatch ever happens (`func/call.rs:1109-1340`), so routing
-    /// those through `call_fn_raw` would change what they mean. A call that
-    /// captures the enclosing scope is closure construction, and a qualified
-    /// name resolves against imported modules; neither is a plain call.
+    /// Rhai resolves a handful of names syntactically before dispatch ever happens,
+    /// so routing those through `call_fn_raw` would change what they mean.
+    /// A call that captures the enclosing scope is closure construction,
+    /// and a qualified name resolves against imported modules;
+    /// neither is a plain call.
     fn is_lowerable_call(&self, call: &FnCallExpr) -> bool {
+        // These are handled by `is_syntactic_call` above, but only at the
+        // arities Rhai treats syntactically — at any other arity it falls
+        // through to ordinary dispatch, and so must catch them here.
         const SYNTACTIC: &[&str] = &[
             crate::engine::KEYWORD_EVAL,
-            crate::engine::KEYWORD_IS_DEF_VAR,
-            #[cfg(not(feature = "no_function"))]
-            crate::engine::KEYWORD_IS_DEF_FN,
-        ];
-
-        // `is_shared` belongs here for a sharper reason than the rest: Rhai
-        // answers it syntactically in both call positions (`func/call.rs:1240`
-        // and `:929`) and registers no function for it anywhere, so a lowered
-        // call raises `ErrorFunctionNotFound` where the walker returns a bool.
-        const FN_CALL: &[&str] = &[
             crate::engine::KEYWORD_FN_PTR,
             crate::engine::KEYWORD_FN_PTR_CALL,
             crate::engine::KEYWORD_FN_PTR_CURRY,
             #[cfg(not(feature = "no_closure"))]
             crate::engine::KEYWORD_IS_SHARED,
         ];
-
-        // These are handled by `fn_ptr_call` above, but only at the arities
-        // Rhai treats syntactically — at any other arity it falls through to
-        // ordinary dispatch, and so must this.
-        if FN_CALL.contains(&call.name.as_str()) {
-            return false;
-        }
 
         !call_has_namespace!(call)
             && call.args.len() <= u8::MAX as usize

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -2234,6 +2234,125 @@ impl<'e> Vm<'e> {
         Ok(())
     }
 
+    // Some syntactic calls can be self-implemented or short-circuited.
+    fn call_syntactic(
+        &mut self,
+        program: &Program,
+        name: &str,
+        argc: usize,
+        first: usize,
+        scope: &mut Scope,
+        pos: Position,
+    ) -> Result<Option<Dynamic>, Box<EvalAltResult>> {
+        match name {
+            #[cfg(not(feature = "no_closure"))]
+            crate::engine::KEYWORD_IS_SHARED => {
+                return Err(EvalAltResult::ErrorFunctionNotFound(name.to_string(), pos).into())
+            }
+            crate::engine::KEYWORD_IS_DEF_VAR => {
+                if argc != 1 {
+                    return Err(EvalAltResult::ErrorFunctionNotFound(name.to_string(), pos).into());
+                }
+                let var_name = self.stack[first].as_immutable_string_ref().map_err(|typ| {
+                    self.engine
+                        .make_type_mismatch_err::<ImmutableString>(typ, pos)
+                })?;
+                return Ok(Some(scope.contains(&var_name).into()));
+            }
+            #[cfg(not(feature = "no_function"))]
+            crate::engine::KEYWORD_IS_DEF_FN => {
+                let (this_type, fn_name, arity) = match argc {
+                    2 => {
+                        let var_name = self.stack[first]
+                            .as_immutable_string_ref()
+                            .as_deref()
+                            .cloned()
+                            .map_err(|typ| {
+                                self.engine
+                                    .make_type_mismatch_err::<ImmutableString>(typ, pos)
+                            })?;
+                        let arity = self.stack[first + 1]
+                            .as_int()
+                            .map_err(|typ| self.engine.make_type_mismatch_err::<INT>(typ, pos))?;
+                        (None, var_name, arity as usize)
+                    }
+                    3 => {
+                        let this_type = self.stack[first]
+                            .as_immutable_string_ref()
+                            .as_deref()
+                            .cloned()
+                            .map_err(|typ| {
+                                self.engine
+                                    .make_type_mismatch_err::<ImmutableString>(typ, pos)
+                            })?;
+                        let var_name = self.stack[first + 1]
+                            .as_immutable_string_ref()
+                            .as_deref()
+                            .cloned()
+                            .map_err(|typ| {
+                                self.engine
+                                    .make_type_mismatch_err::<ImmutableString>(typ, pos)
+                            })?;
+                        let arity = self.stack[first + 2]
+                            .as_int()
+                            .map_err(|typ| self.engine.make_type_mismatch_err::<INT>(typ, pos))?;
+                        (Some(this_type), var_name, arity as usize)
+                    }
+                    _ => {
+                        return Err(
+                            EvalAltResult::ErrorFunctionNotFound(name.to_string(), pos).into()
+                        )
+                    }
+                };
+
+                // Check if there is a compiled function.
+                for f in program.functions() {
+                    let local_name = program
+                        .name(f.name)
+                        .ok_or_else(|| malformed(format!("no name {}", f.name)))?;
+
+                    if local_name == fn_name.as_str() && f.params.len() == arity {
+                        if let Some(ref this_type) = this_type {
+                            if let Some(local_this_type_index) = f.this_type {
+                                let local_this_type_name =
+                                    program.name(local_this_type_index).ok_or_else(|| {
+                                        malformed(format!("no name {local_this_type_index}"))
+                                    })?;
+
+                                if local_this_type_name == this_type {
+                                    return Ok(Some(Dynamic::TRUE));
+                                }
+                            }
+                        } else if f.this_type.is_none() {
+                            return Ok(Some(Dynamic::TRUE));
+                        }
+                    }
+                }
+
+                // Call into Rhai.
+                let mut args = self.stack[first..].iter_mut().collect::<FnArgsVec<_>>();
+
+                return self
+                    .engine
+                    .exec_syntactic_fn_call(
+                        &mut self.global,
+                        &mut self.caches,
+                        name,
+                        &mut args,
+                        pos,
+                    )
+                    .map_err(|err| dispatch_failure(err, pos))?
+                    .ok_or_else(|| {
+                        EvalAltResult::ErrorFunctionNotFound(name.to_string(), pos).into()
+                    })
+                    .map(Some);
+            }
+            _ => {}
+        }
+
+        Ok(None)
+    }
+
     /// Call `name` with `argc` arguments sitting contiguously from `first` up.
     ///
     /// A function this compiler lowered is called directly, with no hash and no
@@ -2244,15 +2363,13 @@ impl<'e> Vm<'e> {
         &mut self,
         program: &Program,
         name_index: u32,
+        name: &str,
         argc: usize,
         first: usize,
         scope: &mut Scope,
         pos: Position,
     ) -> VmResult {
-        let name = program
-            .name(name_index)
-            .ok_or_else(|| malformed(format!("no name {name_index}")))?;
-
+        // Run compiled function if available.
         if let Some(function) = program.function(name_index, argc) {
             return self.call_compiled(
                 program,
@@ -2295,6 +2412,7 @@ impl<'e> Vm<'e> {
         &mut self,
         program: &Program,
         name_index: u32,
+        name: &str,
         argc: usize,
         receiver: Receiver,
         scope: &mut Scope,
@@ -2302,10 +2420,6 @@ impl<'e> Vm<'e> {
         capture_parent_scope: bool,
         pos: Position,
     ) -> VmResult {
-        let name = program
-            .name(name_index)
-            .ok_or_else(|| malformed(format!("no name {name_index}")))?;
-
         // Every argument count here includes the receiver, so zero of them
         // names no receiver at all and the instruction is nonsense. Only an
         // artifact can say it; the compiler emits one of these for a call that
@@ -2319,17 +2433,15 @@ impl<'e> Vm<'e> {
         // The register is not a scope entry, so it takes a path of its own
         // rather than a third [`Site`].
         if let Receiver::This = receiver {
-            let mut new_scope;
-            let use_scope = if capture_parent_scope {
-                // Reuse parent scope.
-                scope
-            } else {
-                // Create detached scope.
-                new_scope = Scope::new();
-                &mut new_scope
-            };
-
-            return self.call_by_this(program, name_index, name, argc, use_scope, pos);
+            return self.call_by_this(
+                program,
+                name_index,
+                name,
+                argc,
+                scope,
+                capture_parent_scope,
+                pos,
+            );
         }
 
         // A named receiver's value is already argument zero — [`Op::LoadNamed`]
@@ -2383,20 +2495,23 @@ impl<'e> Vm<'e> {
                 let value = scope.get_mut_by_index(index).flatten_clone();
                 self.stack.insert(first, value);
             }
-
-            let mut new_scope;
-            let use_scope = if capture_parent_scope {
-                // Reuse parent scope.
-                scope
-            } else {
-                // Create detached scope.
-                new_scope = Scope::new();
-                &mut new_scope
-            };
-
-            let value = self.call_stacked(program, name_index, argc, first, use_scope, pos);
+            // Check if it is a built-in syntactic function.
+            let value =
+                if let Some(value) = self.call_syntactic(program, name, argc, first, scope, pos)? {
+                    value
+                } else {
+                    // Detach the scope with a new one if not capturing the parent's.
+                    let mut detached;
+                    let scope = if !capture_parent_scope {
+                        detached = Scope::new();
+                        &mut detached
+                    } else {
+                        scope
+                    };
+                    self.call_stacked(program, name_index, name, argc, first, scope, pos)?
+                };
             self.stack.truncate(first);
-            return value;
+            return Ok(value);
         }
 
         let value = {
@@ -2455,6 +2570,7 @@ impl<'e> Vm<'e> {
         name: &str,
         argc: usize,
         scope: &mut Scope,
+        capture_parent_scope: bool,
         pos: Position,
     ) -> VmResult {
         let first = self
@@ -2473,9 +2589,23 @@ impl<'e> Vm<'e> {
             && program.function(name_index, argc).is_none();
 
         if !by_reference {
-            let value = self.call_stacked(program, name_index, argc, first, scope, pos);
+            // Check if it is a built-in syntactic function.
+            let value =
+                if let Some(value) = self.call_syntactic(program, name, argc, first, scope, pos)? {
+                    value
+                } else {
+                    // Detach the scope with a new one if not capturing the parent's.
+                    let mut detached;
+                    let scope = if !capture_parent_scope {
+                        detached = Scope::new();
+                        &mut detached
+                    } else {
+                        scope
+                    };
+                    self.call_stacked(program, name_index, name, argc, first, scope, pos)?
+                };
             self.stack.truncate(first);
-            return value;
+            return Ok(value);
         }
 
         let value = {
@@ -3427,18 +3557,22 @@ impl<'e> Vm<'e> {
                         }
                     }
 
-                    let mut new_scope;
-                    let use_scope = if capture_parent_scope {
-                        // Reuse parent scope.
-                        &mut *scope
+                    // Check if it is a built-in syntactic function.
+                    let value = if let Some(value) =
+                        self.call_syntactic(program, name, argc, first, scope, pos())?
+                    {
+                        value
                     } else {
-                        // Create detached scope.
-                        new_scope = Scope::new();
-                        &mut new_scope
+                        // Detach the scope with a new one if not capturing the parent's.
+                        let mut detached;
+                        let scope = if !capture_parent_scope {
+                            detached = Scope::new();
+                            &mut detached
+                        } else {
+                            &mut *scope
+                        };
+                        self.call_stacked(program, name_index, name, argc, first, scope, pos())?
                     };
-
-                    let value =
-                        self.call_stacked(program, name_index, argc, first, use_scope, pos())?;
                     self.stack.truncate(first);
                     self.stack.push(value);
                 }
@@ -3450,6 +3584,9 @@ impl<'e> Vm<'e> {
                 | code::tag::CALL_THIS_REF
                 | code::tag::CALL_THIS_REF_CAPTURE => {
                     let name_index = u32::from(small(1)?);
+                    let name = program
+                        .name(name_index)
+                        .ok_or_else(|| malformed(format!("no name {name_index}")))?;
                     let argc = code[pc + 3] as usize;
                     // `this` is a register, so this one carries no operand for
                     // the receiver and is two bytes shorter.
@@ -3475,6 +3612,7 @@ impl<'e> Vm<'e> {
                     let value = self.call_by_reference(
                         program,
                         name_index,
+                        name,
                         argc,
                         receiver,
                         scope,

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -35,7 +35,7 @@ use crate::{FnPtr, ImmutableString, NativeCallContext, Position, ThinVec, FUNC_T
 
 mod callback;
 
-use crate::grain::bytecode::{code, AssignOp, Chain, Receiver, Root, Step, StepFlags, Tail};
+use crate::grain::bytecode::{code, AssignOp, Chain, Chunk, Receiver, Root, Step, StepFlags, Tail};
 use crate::grain::program::{Program, SharedModule, SharedProgram};
 
 /// Rhai's own `RhaiResult`, which it does not re-export.
@@ -2234,7 +2234,10 @@ impl<'e> Vm<'e> {
         Ok(())
     }
 
-    // Some syntactic calls can be self-implemented or short-circuited.
+    /// Called only by [`call_syntactic_or_stacked`] after it has checked for a
+    /// syntactic call.
+    ///
+    /// Some syntactic calls can be self-implemented or short-circuited.
     fn call_syntactic(
         &mut self,
         program: &Program,
@@ -2349,7 +2352,10 @@ impl<'e> Vm<'e> {
         Ok(None)
     }
 
-    /// Call `name` with `argc` arguments sitting contiguously from `first` up.
+    /// Called only by [`call_syntactic_or_stacked`] after it has checked for a
+    /// syntactic call.
+    ///
+    /// Call function with `argc` arguments sitting contiguously from `first` up.
     ///
     /// A function this compiler lowered is called directly, with no hash and no
     /// module walk: the call site's name index and the function's come from the
@@ -2397,6 +2403,42 @@ impl<'e> Vm<'e> {
         )
     }
 
+    /// This is the main entry-point for function calls.
+    ///
+    /// First check whether the call is a syntactic one (e.g. `is_def_fn`)
+    /// which are self-implemented or directly called into the
+    /// corresponding Rhai functinon.
+    ///
+    /// If the call is not to a syntactic one, it calls the function
+    /// normally, with arguments pushed onto the stack.
+    fn call_syntactic_or_stacked(
+        &mut self,
+        program: &Program,
+        name_index: u32,
+        name: &str,
+        argc: usize,
+        first: usize,
+        scope: &mut Scope,
+        capture: bool,
+        pos: Position,
+    ) -> VmResult {
+        // Check if it is a built-in syntactic function.
+        match self.call_syntactic(program, name, argc, first, scope, pos)? {
+            Some(value) => Ok(value),
+            None => {
+                // Detach the scope with a new one if not capturing the parent's.
+                let mut detached;
+                let scope = if !capture {
+                    detached = Scope::new();
+                    &mut detached
+                } else {
+                    scope
+                };
+                self.call_stacked(program, name_index, name, argc, first, scope, pos)
+            }
+        }
+    }
+
     /// The same call, with a variable as its first argument and Rhai's
     /// method-call rewrite applied to it (`func/call.rs:1434-1460`).
     ///
@@ -2413,7 +2455,7 @@ impl<'e> Vm<'e> {
         receiver: Receiver,
         scope: &mut Scope,
         base: usize,
-        capture_parent_scope: bool,
+        capture: bool,
         pos: Position,
     ) -> VmResult {
         // Every argument count here includes the receiver, so zero of them
@@ -2429,15 +2471,7 @@ impl<'e> Vm<'e> {
         // The register is not a scope entry, so it takes a path of its own
         // rather than a third [`Site`].
         if let Receiver::This = receiver {
-            return self.call_by_this(
-                program,
-                name_index,
-                name,
-                argc,
-                scope,
-                capture_parent_scope,
-                pos,
-            );
+            return self.call_by_this(program, name_index, name, argc, scope, capture, pos);
         }
 
         // A named receiver's value is already argument zero — [`Op::LoadNamed`]
@@ -2491,21 +2525,9 @@ impl<'e> Vm<'e> {
                 let value = scope.get_mut_by_index(index).flatten_clone();
                 self.stack.insert(first, value);
             }
-            // Check if it is a built-in syntactic function.
-            let value =
-                if let Some(value) = self.call_syntactic(program, name, argc, first, scope, pos)? {
-                    value
-                } else {
-                    // Detach the scope with a new one if not capturing the parent's.
-                    let mut detached;
-                    let scope = if !capture_parent_scope {
-                        detached = Scope::new();
-                        &mut detached
-                    } else {
-                        scope
-                    };
-                    self.call_stacked(program, name_index, name, argc, first, scope, pos)?
-                };
+            let value = self.call_syntactic_or_stacked(
+                program, name_index, name, argc, first, scope, capture, pos,
+            )?;
             self.stack.truncate(first);
             return Ok(value);
         }
@@ -2566,7 +2588,7 @@ impl<'e> Vm<'e> {
         name: &str,
         argc: usize,
         scope: &mut Scope,
-        capture_parent_scope: bool,
+        capture: bool,
         pos: Position,
     ) -> VmResult {
         let first = self
@@ -2585,21 +2607,9 @@ impl<'e> Vm<'e> {
             && program.function(name_index, argc).is_none();
 
         if !by_reference {
-            // Check if it is a built-in syntactic function.
-            let value =
-                if let Some(value) = self.call_syntactic(program, name, argc, first, scope, pos)? {
-                    value
-                } else {
-                    // Detach the scope with a new one if not capturing the parent's.
-                    let mut detached;
-                    let scope = if !capture_parent_scope {
-                        detached = Scope::new();
-                        &mut detached
-                    } else {
-                        scope
-                    };
-                    self.call_stacked(program, name_index, name, argc, first, scope, pos)?
-                };
+            let value = self.call_syntactic_or_stacked(
+                program, name_index, name, argc, first, scope, capture, pos,
+            )?;
             self.stack.truncate(first);
             return Ok(value);
         }
@@ -2636,7 +2646,7 @@ impl<'e> Vm<'e> {
         program: &Program,
         name: &str,
         params: &[u32],
-        chunk: crate::grain::bytecode::Chunk,
+        chunk: Chunk,
         first: usize,
         scope: &mut Scope,
         pos: Position,
@@ -2665,7 +2675,7 @@ impl<'e> Vm<'e> {
         program: &Program,
         name: &str,
         params: &[u32],
-        chunk: crate::grain::bytecode::Chunk,
+        chunk: Chunk,
         first: usize,
         scope: &mut Scope,
         rewind_scope: bool,
@@ -2701,7 +2711,7 @@ impl<'e> Vm<'e> {
         program: &Program,
         name: &str,
         params: &[u32],
-        chunk: crate::grain::bytecode::Chunk,
+        chunk: Chunk,
         first: usize,
         scope: &mut Scope,
         rewind_scope: bool,
@@ -2781,7 +2791,7 @@ impl<'e> Vm<'e> {
         &mut self,
         program: &Program,
         scope: &mut Scope,
-        chunk: crate::grain::bytecode::Chunk,
+        chunk: Chunk,
         base: usize,
         reached: &mut usize,
     ) -> VmResult {
@@ -3505,7 +3515,7 @@ impl<'e> Vm<'e> {
                     let name = program
                         .name(name_index)
                         .ok_or_else(|| malformed(format!("no name {name_index}")))?;
-                    let capture_parent_scope = tag == code::tag::CALL_CAPTURE;
+                    let capture = tag == code::tag::CALL_CAPTURE;
                     let argc = code[pc + 3] as usize;
                     let op = if tag == code::tag::CALL_OP {
                         let index = u32::from(small(4)?);
@@ -3554,21 +3564,16 @@ impl<'e> Vm<'e> {
                     }
 
                     // Check if it is a built-in syntactic function.
-                    let value = if let Some(value) =
-                        self.call_syntactic(program, name, argc, first, scope, pos())?
-                    {
-                        value
-                    } else {
-                        // Detach the scope with a new one if not capturing the parent's.
-                        let mut detached;
-                        let scope = if !capture_parent_scope {
-                            detached = Scope::new();
-                            &mut detached
-                        } else {
-                            &mut *scope
-                        };
-                        self.call_stacked(program, name_index, name, argc, first, scope, pos())?
-                    };
+                    let value = self.call_syntactic_or_stacked(
+                        program,
+                        name_index,
+                        name,
+                        argc,
+                        first,
+                        scope,
+                        capture,
+                        pos(),
+                    )?;
                     self.stack.truncate(first);
                     self.stack.push(value);
                 }
@@ -3598,7 +3603,7 @@ impl<'e> Vm<'e> {
                         }
                         _ => unreachable!(),
                     };
-                    let capture_parent_scope = matches!(
+                    let capture = matches!(
                         tag,
                         code::tag::CALL_LOCAL_REF_CAPTURE
                             | code::tag::CALL_NAMED_REF_CAPTURE
@@ -3613,7 +3618,7 @@ impl<'e> Vm<'e> {
                         receiver,
                         scope,
                         base,
-                        capture_parent_scope,
+                        capture,
                         pos(),
                     )?;
                     self.stack.push(value);

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -113,9 +113,8 @@ fn call_engine(
     )
 }
 
-/// Stamp the call site on an error that passes through a function boundary
-/// unwrapped, as Rhai does for exits and system exceptions
-/// (`func/script.rs:134`).
+/// Stamp the call site on an error that passes through a function boundary unwrapped,
+/// as Rhai does for exits and system exceptions (`func/script.rs:134`).
 fn reposition(mut err: Box<EvalAltResult>, pos: Position) -> Box<EvalAltResult> {
     err.set_position(pos);
     err
@@ -123,9 +122,7 @@ fn reposition(mut err: Box<EvalAltResult>, pos: Position) -> Box<EvalAltResult> 
 
 /// Stamp the site on an error that arrived without one.
 ///
-/// Dispatch raises `ErrorFunctionNotFound` at `Position::NONE` and leaves
-/// positioning to the caller, which has the expression that failed. Unlike
-/// [`reposition`] this never overwrites a position the callee already set.
+/// Unlike [`reposition`] this never overwrites a position the callee already set.
 fn positioned(err: Box<EvalAltResult>, pos: Position) -> Box<EvalAltResult> {
     if err.position().is_none() {
         reposition(err, pos)
@@ -139,7 +136,7 @@ fn positioned(err: Box<EvalAltResult>, pos: Position) -> Box<EvalAltResult> {
 /// This is `fill_position`, which Rhai applies to the whole of
 /// `exec_native_fn_call` — the callee not being found, the call being refused,
 /// and the error a native *returned* alike (`func/call.rs:365`, `:406`,
-/// `:413`). `call_fn_raw` has no position to give, so all of them arrive bare.
+/// `:413`).
 ///
 /// What looks like a counter-example is not one: `1 / 0` reports
 /// `ErrorArithmetic` with no position at all, because under `fast_operators` a
@@ -1817,7 +1814,7 @@ impl<'e> Vm<'e> {
                 *target = value;
                 Ok(())
             }
-            Err(err) => Err(positioned(err, pos)),
+            Err(err) => Err(dispatch_failure(err, pos)),
         }
     }
 
@@ -1903,7 +1900,7 @@ impl<'e> Vm<'e> {
         match resolved {
             Ok(Some(value)) => Ok(Some(value.into_read_only())),
             Ok(None) => Ok(None),
-            Err(err) => Err(positioned(err, pos)),
+            Err(err) => Err(dispatch_failure(err, pos)),
         }
     }
 
@@ -2822,7 +2819,7 @@ impl<'e> Vm<'e> {
 
             self.engine
                 .throw_on_size(*total)
-                .map_err(|err| positioned(err, pos))
+                .map_err(|err| dispatch_failure(err, pos))
         }
     }
 

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -2245,10 +2245,6 @@ impl<'e> Vm<'e> {
         pos: Position,
     ) -> Result<Option<Dynamic>, Box<EvalAltResult>> {
         match name {
-            #[cfg(not(feature = "no_closure"))]
-            crate::engine::KEYWORD_IS_SHARED => {
-                return Err(EvalAltResult::ErrorFunctionNotFound(name.to_string(), pos).into())
-            }
             crate::engine::KEYWORD_IS_DEF_VAR => {
                 if argc != 1 {
                     return Err(EvalAltResult::ErrorFunctionNotFound(name.to_string(), pos).into());

--- a/src/types/fn_ptr.rs
+++ b/src/types/fn_ptr.rs
@@ -461,10 +461,9 @@ impl FnPtr {
         }
 
         // Embedded native Rust function?
-        let mut obj;
-
         match self.typ {
             FnPtrType::Native(ref func) => {
+                let mut cloned_this_ptr;
                 let args = &mut StaticVec::with_capacity(arg_values.len() + 1);
                 args.extend(arg_values.iter_mut());
 
@@ -472,12 +471,11 @@ impl FnPtr {
                 global.level += 1;
                 let engine = context.engine();
                 let pos = context.call_position();
-
                 if let Some(this_ptr) = this_ptr {
                     if self.is_curried() {
-                        obj = this_ptr.clone();
+                        cloned_this_ptr = this_ptr.clone();
                         // Arguments order is: curry + this_ptr (cloned) + args
-                        args.insert(self.curry().len(), &mut obj);
+                        args.insert(self.curry().len(), &mut cloned_this_ptr);
                     } else {
                         // Arguments order is: this_ptr (&mut) + args
                         args.insert(0, this_ptr);
@@ -648,7 +646,7 @@ impl FnPtr {
             .or_else(|err| match *err {
                 ERR::ErrorFunctionNotFound(sig, ..) if sig.starts_with(self.fn_name()) => {
                     if MOVE_PTR {
-                        if let Some(ref mut this_ptr) = this_ptr {
+                        if let Some(this_ptr) = this_ptr.as_deref_mut() {
                             let mut args2 = FnArgsVec::with_capacity(args.len() + extras.len() + 1);
                             if move_this_ptr_to_args == 0 {
                                 args2.push(this_ptr.clone());

--- a/src/types/fn_ptr.rs
+++ b/src/types/fn_ptr.rs
@@ -473,10 +473,15 @@ impl FnPtr {
                 let engine = context.engine();
                 let pos = context.call_position();
 
-                // Arguments order is: curry + this_ptr (cloned) + args
                 if let Some(this_ptr) = this_ptr {
-                    obj = this_ptr.clone();
-                    args.insert(self.curry().len(), &mut obj);
+                    if self.is_curried() {
+                        obj = this_ptr.clone();
+                        // Arguments order is: curry + this_ptr (cloned) + args
+                        args.insert(self.curry().len(), &mut obj);
+                    } else {
+                        // Arguments order is: this_ptr (&mut) + args
+                        args.insert(0, this_ptr);
+                    }
                 }
 
                 let context = (engine, self.fn_name(), None, &*global, pos).into();
@@ -603,11 +608,12 @@ impl FnPtr {
                             if move_this_ptr_to_args == 0 {
                                 args2.push(this_ptr.clone());
                                 args2.extend(args);
+                                args2.extend(extras);
                             } else {
                                 args2.extend(args);
+                                args2.extend(extras);
                                 args2.insert(move_this_ptr_to_args, this_ptr.clone());
                             }
-                            args2.extend(extras);
                             return self.call_raw(ctx, None, args2);
                         }
                     }

--- a/tests/grain/corpus/mod.rs
+++ b/tests/grain/corpus/mod.rs
@@ -163,6 +163,7 @@ pub fn applies_to_this_build(name: &str) -> bool {
                 | "for_over_captured_array"
                 | "for_return_from_body"
                 | "fn_call_captures_parent_scope"
+                | "is_def_fn"
                 | "map_computed_order"
                 | "map_read_of_absent_key_is_not_visible_to_a_closure"
                 | "switch_on_a_shared_subject_matches"
@@ -438,6 +439,8 @@ pub const CASES: &[Case] = &[
     case("let_from_switch", "let x = 2; let y = switch x { 1 => \"one\", 2 => \"two\", _ => \"other\" }; y"),
     case("let_from_if", "let c = true; let y = if c { let a = 1; a } else { let b = 2; b }; y + 10"),
     case("let_from_block", "let a = 3; let y = { let z = a; z * 2 }; y"),
+    case("is_def_var_true", r#"let a = 42; is_def_var("a")"#),
+    case("is_def_var_false", r#"let a = 42; is_def_var("b")"#),
     // A block among a call's arguments, where the scope grows while operands
     // are already on the stack.
     case("block_as_argument", "fn add(a, b) { a + b } let n = 2; add({ let t = n; t + 1 }, 10)"),
@@ -448,6 +451,7 @@ pub const CASES: &[Case] = &[
     // --- functions --------------------------------------------------------
     case("fn_call", "fn add(a, b) { a + b } add(2, 3)"),
     case("fn_call_captures_parent_scope", r#"fn foo(x) { x + y * z }  let x = 42; let y = 1; let z = 9; foo!(x)"#),
+    case("is_def_fn", r#"fn add(x, y) { x + y } is_def_fn("add", 2)"#),
     // Kept shallow deliberately: Rhai's default call-depth limit is far lower
     // in debug builds than in release, and this case is about recursion working
     // at all, not about the limit. The limit gets its own case.


### PR DESCRIPTION
The syntactic functions `is_def_var` and `is_def_fn` are missing from the VM.

This PR implements them.
