### PR TITLE
Clone a chain index before the getter consumes it

### DIFF
--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -1440,6 +1440,13 @@ impl<'e> Vm<'e> {
         let assigning = last && value.is_some();
         let mut detached = Scope::new();
 
+        // Cloned *before* the call, as Rhai clones it (`eval/chaining.rs:706`).
+        // `get_indexed_mut` may reach a custom indexer, and a native's by-value
+        // parameter is bound by `take` (`func/register.rs:69`) — so afterwards
+        // there is nothing left to address the setter with. Only the paths that
+        // can write need it; a read returns below without ever looking.
+        let index_for_setter = (!last || value.is_some()).then(|| idx.clone());
+
         let mut item = match self.engine.get_indexed_mut(
             &mut self.global,
             &mut self.caches,
@@ -1497,7 +1504,7 @@ impl<'e> Vm<'e> {
             // The element was a temporary — a custom indexer's — so the setter
             // is the only way back (`eval/chaining.rs:744`).
             let mut updated = item.take_or_clone();
-            let mut index = idx.clone();
+            let mut index = index_for_setter.expect("a read returns before here");
             self.call_indexer_set(target, &mut index, &mut updated, bracket)?;
         }
 

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -1720,7 +1720,11 @@ impl<'e> Vm<'e> {
         let (out, changed) =
             self.walk_chain(program, chain, rest, &mut temp, operands, value, pos)?;
         if changed {
-            let _ = call(self, setter, &mut [target, &mut temp])?;
+            let _ = call(self, setter, &mut [target, &mut temp]).or_else(|err| match *err {
+                // Fail silently if the property is read-only, as Rhai does (`eval/chaining.rs:1039`).
+                EvalAltResult::ErrorDotExpr(..) => Ok(Dynamic::UNIT),
+                _ => Err(err),
+            })?;
         }
         Ok((out, changed))
     }

--- a/tests/grain/corpus/mod.rs
+++ b/tests/grain/corpus/mod.rs
@@ -97,6 +97,14 @@ pub fn engine() -> rhai::Engine {
             .register_type_with_name::<Holder>("Holder")
             .register_fn("holder", |level: INT| Holder { inner: Widget { level, cells: vec![1, 2, 3] } })
             .register_get_set("inner", |h: &mut Holder| h.inner.clone(), |h: &mut Holder, w: Widget| h.inner = w);
+
+        // The same `Widget`, behind an *indexer* rather than a property. The
+        // getter above is reached with the property name as a static operand;
+        // this one is reached with an index the walk has to evaluate, and a
+        // native's by-value parameter is bound by `take` — so the index a
+        // write-back needs is gone by the time the setter wants it.
+        #[cfg(not(feature = "no_index"))]
+        engine.register_indexer_get_set(|h: &mut Holder, _: INT| h.inner.clone(), |h: &mut Holder, _: INT, w: Widget| h.inner = w);
     }
 
     engine
@@ -227,6 +235,7 @@ pub fn applies_to_this_build(name: &str) -> bool {
             | "host_index_get"
             | "host_index_set"
             | "host_mutation_before_a_failure_survives_in_an_array"
+            | "host_index_temp_set"
             | "host_temp_index_set"
             | "index_assign_array"
             | "index_assign_nested"
@@ -726,6 +735,10 @@ pub const CASES: &[Case] = &[
     // Two levels, so the middle one is a temporary.
     case("host_temp_set", "let h = holder(3); h.inner.level = 8; h.inner.level"),
     case("host_temp_index_set", "let h = holder(3); h.inner[0] = 7; h.inner[0]"),
+    // The mirror of it: an *index* step handing back the temporary, with the
+    // property below. The index has to survive the getter to address the setter
+    // with afterwards.
+    case("host_index_temp_set", "let h = holder(3); h[0].level = 8; h.inner.level"),
     // A mutating call on a temporary: Rhai writes it back, so the change
     // survives.
     case("host_temp_mutates", "let h = holder(3); h.inner.bump(); h.inner.level"),


### PR DESCRIPTION
`index_by_reference` cloned the index for the write-back setter after calling `get_indexed_mut`, which binds a native's by-value parameter by `take`. The setter was called with `()`, found nothing, and `call_indexer_set` swallowed the error. The write was dropped silently. Rhai clones before the same call (`eval/chaining.rs:706`). Only the paths that can write pay for it.