### PR TITLE
Flatten a declaration's initializer in the VM

### DIFF
--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -3289,7 +3289,11 @@ impl<'e> Vm<'e> {
                     let name = program
                         .name(index)
                         .ok_or_else(|| malformed(format!("no name {index}")))?;
-                    let value = self.pop()?;
+                    // Flattened, as Rhai flattens a declaration's initializer
+                    // (`eval/stmt.rs:438`). A native can hand back a cell that is
+                    // already shared, and sharing must stop at the `let` rather
+                    // than becoming a property of the new local.
+                    let value = self.pop()?.flatten();
                     if tag == code::tag::DECLARE_CONST {
                         scope.push_constant_dynamic(name, value);
                     } else {

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -2240,7 +2240,7 @@ impl<'e> Vm<'e> {
     /// Some syntactic calls can be self-implemented or short-circuited.
     fn call_syntactic(
         &mut self,
-        program: &Program,
+        #[cfg_attr(feature = "no_function", allow(unused))] program: &Program,
         name: &str,
         argc: usize,
         first: usize,

--- a/tests/grain/corpus/mod.rs
+++ b/tests/grain/corpus/mod.rs
@@ -74,6 +74,17 @@ pub fn engine() -> rhai::Engine {
             Err("bump_then_fail".into())
         });
 
+    // A host handing back a value that is already shared, which is the only way
+    // a script can be given one: sharing is otherwise something Rhai does to a
+    // variable a closure captured, and loading such a variable flattens it on
+    // the way out. Whether the sharing survives crossing into a `let` is a
+    // difference nothing else here can see.
+    #[cfg(not(feature = "no_closure"))]
+    {
+        let cell = rhai::Dynamic::from(42 as INT).into_shared();
+        engine.register_fn("shared_cell", move || cell.clone());
+    }
+
     // A property is reached with `.`, which `no_object` removes; an indexer
     // with `[..]`, which `no_index` does. Registered apart from the chain
     // above so each can go with the feature that takes its syntax away.
@@ -559,6 +570,13 @@ pub const CASES: &[Case] = &[
     // value outright, so walking one takes the host down rather than returning
     // an error (`eval/chaining.rs:461`).
     case("closure_shared_chain_root", "let a = [1, 2, 3]; { let f = || a[0]; } a[1] = 20; a[1]"),
+    // A host handing back a cell that is *already* shared. Rhai flattens a
+    // declaration's initializer (`eval/stmt.rs:438`), so the sharing stops at
+    // the boundary and the local holds a plain value. Reaching this needs a
+    // native, because loading a variable flattens on the way out either way.
+    // The `closure_` prefix is what keeps it out of a `no_closure` build, where
+    // there is no such thing as a shared value to hand back.
+    case("closure_shared_from_a_native", "let m = shared_cell(); m"),
     // Rhai answers this syntactically and registers no function for it, so a
     // lowered call would fail to resolve where the walker returns a bool.
     case("is_shared_after_capture", "let x = 1; let r = false; { let f = || x; r = is_shared(f); } [is_shared(x), r]"),


### PR DESCRIPTION
`DECLARE_LOCAL` pushed the popped value as-is where Rhai flattens (`eval/stmt.rs:438`), so a native handing back an already-shared cell left the local shared. Loading a variable flattens either way, so reaching this needs a native: `shared_cell` in the corpus engine.