### PR TITLE
Improve debugging support for the VM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,11 @@ required-features = ["metadata", "internals"]
 name = "grain_bench"
 required-features = ["grain"]
 
+# A disassembler, for reading what a script lowered to.
+[[example]]
+name = "grain_dump"
+required-features = ["grain"]
+
 # The grain harnesses, as one binary. `tests/mod.rs` wraps them in an inline
 # `mod grain`, which is what puts their module paths inside `tests/grain/`.
 [[test]]

--- a/examples/grain_dump.rs
+++ b/examples/grain_dump.rs
@@ -1,0 +1,60 @@
+//! Compile a Rhai script to grain bytecode and print the disassembly.
+//!
+//! `cargo run --features grain --example grain_dump -- script.rhai`
+
+use rhai::grain::{Compiler, Program};
+use rhai::Engine;
+
+fn dump(program: &Program, code: &[u8], name: &str, chunk: &rhai::grain::bytecode::Chunk) {
+    println!(
+        "\n{name}  [{}..{}]  max_stack {}",
+        chunk.entry(),
+        chunk.end(),
+        chunk.max_stack()
+    );
+
+    for (at, op) in chunk.ops(code) {
+        let pos = program.position(at);
+        let where_ = match (pos.line(), pos.position()) {
+            (Some(line), Some(col)) => format!("{line}:{col}"),
+            _ => String::new(),
+        };
+        println!("  {at:>5}  {:<8}  {op:?}", where_);
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::env::args()
+        .nth(1)
+        .ok_or("usage: grain_dump <script.rhai>")?;
+    let source = std::fs::read_to_string(&path)?;
+
+    let engine = Engine::new();
+    let ast = engine.compile(&source)?;
+    let program = Compiler::new().compile(&ast);
+
+    println!("{program:?}");
+    println!(
+        "\nresiduals (AST fragments left over): {}",
+        program.residual_count()
+    );
+
+    let code = program.code();
+    dump(&program, code, "main", program.main());
+
+    for f in program.functions() {
+        let label = format!("fn #{} ({} params)", f.name, f.params.len());
+        dump(&program, code, &label, &f.chunk);
+    }
+
+    match program.write_stripped() {
+        Ok(s) => println!(
+            "\nartifact {} bytes, sidecar {} positions",
+            s.artifact.len(),
+            s.sidecar.positions.len()
+        ),
+        Err(e) => println!("\nnot writable: {e:?}"),
+    }
+
+    Ok(())
+}

--- a/src/grain/bytecode/code.rs
+++ b/src/grain/bytecode/code.rs
@@ -177,6 +177,8 @@ pub mod tag {
     pub const CALL_NAMED_REF_CAPTURE: u8 = 0x45;
     /// [`Op::CallRef`](super::Op::CallRef) through [`Receiver::This`](super::Receiver::This) capturing the parent's scope.
     pub const CALL_THIS_REF_CAPTURE: u8 = 0x46;
+    /// [`Op::Statement`](super::Op::Statement).
+    pub const STATEMENT: u8 = 0x47;
 }
 
 /// How wide each tag's instruction is, with 0 for the tags that are not one.
@@ -193,6 +195,7 @@ static WIDTHS: [u8; 256] = {
     widths[tag::POP as usize] = 1;
     widths[tag::TICK as usize] = 1;
     widths[tag::CHECKPOINT as usize] = 1;
+    widths[tag::STATEMENT as usize] = 3;
     widths[tag::MAKE_MAP as usize] = 3;
     widths[tag::CHECK_ARRAY_SIZE as usize] = 3;
     widths[tag::CHECK_MAP_SIZE as usize] = 3;
@@ -649,6 +652,10 @@ pub fn assemble(ops: &[Op]) -> Result<(Vec<u8>, Vec<u32>), AssembleError> {
 
             Op::Tick => code.push(tag::TICK),
             Op::Checkpoint => code.push(tag::CHECKPOINT),
+            Op::Statement { depth } => {
+                code.push(tag::STATEMENT);
+                code.extend_from_slice(&depth.to_le_bytes());
+            }
             Op::Throw => code.push(tag::THROW),
             Op::IterInit => code.push(tag::ITER_INIT),
             Op::IterDrop => code.push(tag::ITER_DROP),
@@ -770,6 +777,7 @@ fn encoded_width(op: &Op) -> usize {
         | Op::StoreLocal(..)
         | Op::DeclareLocal { .. }
         | Op::UnwindTo(..)
+        | Op::Statement { .. }
         | Op::EvalAst { .. }
         | Op::Chain(..)
         | Op::Switch(..)
@@ -966,6 +974,7 @@ pub fn decode(code: &[u8], at: usize) -> Option<Op> {
         tag::UNWIND_TO => Op::UnwindTo(small(1)?),
         tag::TICK => Op::Tick,
         tag::CHECKPOINT => Op::Checkpoint,
+        tag::STATEMENT => Op::Statement { depth: small(1)? },
         tag::THROW => Op::Throw,
         tag::ITER_INIT => Op::IterInit,
         tag::ITER_DROP => Op::IterDrop,
@@ -1145,6 +1154,7 @@ mod tests {
             Op::Rotate(3),
             Op::UnwindTo(6),
             Op::Tick,
+            Op::Statement { depth: 2 },
             Op::EvalAst {
                 residual: 0,
                 rewind_scope: true,

--- a/src/grain/bytecode/op.rs
+++ b/src/grain/bytecode/op.rs
@@ -519,6 +519,28 @@ pub enum Op {
     /// a function body, whose scope is discarded whole.
     Checkpoint,
 
+    /// A statement begins here, at nesting `depth` within its chunk.
+    ///
+    /// Where the debugger stops. Rhai runs its callback per AST node
+    /// (`eval/stmt.rs:269`) and a chunk has no nodes, so the compiler records
+    /// where the statements were and the VM stops there instead. Without this
+    /// there is nothing to stop at, and break-points and stepping are inert.
+    ///
+    /// `depth` is how many statements enclose this one. It is what stepping
+    /// re-arms against: Rhai restores the stepping state when the statement it
+    /// was asked at *ends* (`eval/stmt.rs:271`), and the next marker at the
+    /// same depth or shallower is where that has happened. Without it, a
+    /// `next` over an `if` would step into its body.
+    ///
+    /// Emitted only under `debugging`. An instruction per statement is not
+    /// worth carrying to a device with no callback to call, so a shipping build
+    /// has none. Decoding is unconditional, so an artifact written by a
+    /// debugging build still runs anywhere — it simply cannot be stopped.
+    Statement {
+        /// How many statements enclose this one.
+        depth: u16,
+    },
+
     /// Evaluate residual AST fragment `residual` through Rhai's walker,
     /// pushing its value.
     ///

--- a/src/grain/bytecode/verify.rs
+++ b/src/grain/bytecode/verify.rs
@@ -442,6 +442,7 @@ fn effect(op: &Op, pools: Pools) -> (usize, usize, usize) {
         | Op::UnwindTo(..)
         | Op::Tick
         | Op::Checkpoint
+        | Op::Statement { .. }
         | Op::PushHandler { .. }
         | Op::PopHandler => (0, 0, 0),
 

--- a/src/grain/compile/mod.rs
+++ b/src/grain/compile/mod.rs
@@ -303,6 +303,11 @@ struct Lowering {
     handlers: usize,
     /// Names that are script functions rather than variables.
     script_fns: Vec<ImmutableString>,
+    /// How many statements enclose the one being lowered, for the marker
+    /// [`Lowering::statement`] emits. Restored on the way out, so it is the
+    /// nesting rather than a running count.
+    #[cfg(feature = "debugging")]
+    stmt_depth: u16,
     /// Set when something nested inside an expression defeated the slot model.
     ///
     /// [`Lowering::statement`] says so by returning false, but
@@ -843,6 +848,14 @@ impl Lowering {
             .map(|p| self.push_name(p.clone()))
             .collect();
 
+        // Rhai stops once on entering a body, before its first statement, at a
+        // synthetic node placed on the body itself (`func/script.rs:115-119`).
+        // A marker at the same place is that stop, and puts it in the chunk
+        // rather than in the VM. Depth zero, like the statements it precedes:
+        // it does not enclose them, so stepping from here reaches the first one.
+        #[cfg(feature = "debugging")]
+        self.emit_at(Op::Statement { depth: 0 }, def.body.position());
+
         // A body is a statement list whose last value is the return value,
         // which is what `program` already does.
         let lowered = self.program(def.body.statements(), false);
@@ -897,7 +910,36 @@ impl Lowering {
     }
 
     /// Lower one statement, leaving its value on the stack.
+    ///
+    /// Marks where it begins first, which is what the debugger stops at — see
+    /// [`Op::Statement`]. Every statement gets one, the ones that end up as
+    /// fragments included: the walker evaluating a fragment stops at its own
+    /// node as well, so such a statement stops twice at the same place. Driving
+    /// the residual count to zero is what removes that.
     fn statement(&mut self, stmt: &Stmt) -> bool {
+        #[cfg(feature = "debugging")]
+        let enclosing = {
+            let depth = self.stmt_depth;
+            self.emit_at(Op::Statement { depth }, stmt.position());
+            // Saturating, so a script nested past 65,535 statements marks its
+            // innermost ones as siblings rather than wrapping the depth into a
+            // shallower one. `max_expr_depth` stops a parse long before.
+            self.stmt_depth = depth.saturating_add(1);
+            depth
+        };
+
+        let lowered = self.lower_statement(stmt);
+
+        #[cfg(feature = "debugging")]
+        {
+            self.stmt_depth = enclosing;
+        }
+
+        lowered
+    }
+
+    /// The lowering itself, one arm per kind of statement.
+    fn lower_statement(&mut self, stmt: &Stmt) -> bool {
         match stmt {
             Stmt::Var(payload, flags, ..) => {
                 // `export let x = ...` also binds a module alias, which the

--- a/src/grain/mod.rs
+++ b/src/grain/mod.rs
@@ -117,6 +117,24 @@ assert_eq!(sites[1].unwrap().line, 2); // the call to it
 ```
 "##
 )]
+//! # Debugging
+//!
+//! A `debugging` build marks every statement, and the VM stops at the markers:
+//! `back_trace`, stepping, break-points by position and the function-exit
+//! events all work against a chunk.
+//!
+//! A statement is as fine as the grain gets. Rhai's walker stops at every
+//! *expression* too, which is a node a compiled program no longer has — so a
+//! step lands on the next statement rather than part way through the one it is
+//! on, and a break-point on a function name, a call's arity or a property never
+//! matches, because what a marker hands the callback is a synthetic `Noop` and
+//! not the call. A break-point by position covers the same line.
+//!
+//! The markers are the one part of a program that a shipping build does not
+//! compile: a device with no callback to call has nothing to stop for. They cost
+//! about six bytes per statement where they are compiled — `tests/grain/format.rs`
+//! measures it — and an artifact written without them still runs anywhere, it
+//! simply cannot be stopped.
 // A VM that runs untrusted bytecode has no business containing any, and saying
 // so here makes it the compiler's problem rather than a promise. `crates/
 // rhaigrain-pos` declares the same.

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -120,6 +120,23 @@ fn reposition(mut err: Box<EvalAltResult>, pos: Position) -> Box<EvalAltResult> 
     err
 }
 
+/// Take back off the scope whatever a debugger callback left on it.
+///
+/// Slots are positions. An entry a callback declares sits underneath every
+/// declaration the chunk has yet to make, so the next `let` would land above it
+/// and every slot from there on would name the variable before the one it meant
+/// — silently, and in a program that has nothing to do with the debugger. Rhai
+/// answers this by searching by name from then on (`eval/debugger.rs:436`); a
+/// chunk has no names to search, so the scope goes back to the shape it was
+/// compiled against instead, and what a callback declares does not outlive the
+/// stop it declared it at.
+#[cfg(feature = "debugging")]
+fn rewind_after_stop(scope: &mut Scope, before: usize) {
+    if scope.len() > before {
+        scope.rewind(before);
+    }
+}
+
 /// Stamp the site on an error that arrived without one.
 ///
 /// Unlike [`reposition`] this never overwrites a position the callee already set.
@@ -408,6 +425,16 @@ pub struct Vm<'e> {
     ///
     /// Set by [`Vm::run_chain`], taken by the next [`Vm::record_fault`].
     pending_slot: Option<u32>,
+    /// Steps waiting for the statement that asked for them to end.
+    ///
+    /// Rhai keeps this in a `defer` per AST node (`eval/stmt.rs:271`): a `next`
+    /// runs the statement it was asked at with the debugger quiet, and re-arms
+    /// once that statement is over. A marker is a point rather than a scope, so
+    /// the call level and statement depth it was asked at are recorded here
+    /// instead, and the next marker at or outside them is where the statement
+    /// has ended. Innermost last.
+    #[cfg(feature = "debugging")]
+    pending_steps: Vec<(usize, u16, crate::eval::DebuggerStatus)>,
 }
 
 /// Take a receiver for a callee to own, and say whether it goes back.
@@ -485,6 +512,8 @@ impl<'e> Vm<'e> {
             owns_trace: true,
             chain_step: 0,
             pending_slot: None,
+            #[cfg(feature = "debugging")]
+            pending_steps: Vec::new(),
         }
     }
 
@@ -527,6 +556,10 @@ impl<'e> Vm<'e> {
             owns_trace: false,
             chain_step: 0,
             pending_slot: None,
+            // A step belongs to the statement that asked for it, and that
+            // statement is running in the `Vm` this crossing came from.
+            #[cfg(feature = "debugging")]
+            pending_steps: Vec::new(),
         }
     }
 
@@ -642,6 +675,9 @@ impl<'e> Vm<'e> {
     ) -> (VmResult, Option<Dynamic>) {
         // An entry point in its own right so the trace starts here rather than at `run_main`.
         self.clear_faults();
+        // A step a previous run left waiting is not this one's to honour.
+        #[cfg(feature = "debugging")]
+        self.pending_steps.clear();
 
         let Some(function) = program.function_named(name, args.len()) else {
             return (
@@ -761,20 +797,30 @@ impl<'e> Vm<'e> {
                 // not what the caller asked for. The main chunk gets no
                 // receiver, as `eval_global_statements` does not either.
                 evaluated = unwind_exit(vm.run_main(program, scope)).map(|_| ());
-                if evaluated.is_err() {
-                    return (Ok(Dynamic::UNIT), this);
-                }
             }
-            vm.call_function_with_this(
-                program,
-                name,
-                arg_values,
-                0,
-                scope,
-                options.rewind_scope,
-                Position::NONE,
-                this,
-            )
+
+            let (result, returned) = if evaluated.is_ok() {
+                vm.call_function_with_this(
+                    program,
+                    name,
+                    arg_values,
+                    0,
+                    scope,
+                    options.rewind_scope,
+                    Position::NONE,
+                    this,
+                )
+            } else {
+                (Ok(Dynamic::UNIT), this)
+            };
+
+            // However it went, and whether the call happened at all: Rhai
+            // reports the end of a `call_fn` unconditionally
+            // (`api/call_fn.rs:302-308`).
+            #[cfg(feature = "debugging")]
+            let result = vm.at_end(scope).and(result);
+
+            (result, returned)
         });
 
         // Before the errors below, both of them: Rhai's mutation through `this`
@@ -882,8 +928,16 @@ impl<'e> Vm<'e> {
         scope: &mut Scope,
         wrappers: Option<SharedModule>,
     ) -> VmResult {
-        let result = self.with_environment(program, wrappers, |vm| vm.run_main(program, scope));
-        unwind_exit(result)
+        self.with_environment(program, wrappers, |vm| {
+            // `exit` and a top-level `return` become the run's value before the
+            // debugger hears that it is over, because Rhai maps them inside
+            // `eval_global_statements` (`eval/stmt.rs:1046-1048`) and reports
+            // the end after it.
+            let value = unwind_exit(vm.run_main(program, scope))?;
+            #[cfg(feature = "debugging")]
+            vm.at_end(scope)?;
+            Ok(value)
+        })
     }
 
     /// What a program contributes to `global`, in place for the duration of `f`.
@@ -938,6 +992,9 @@ impl<'e> Vm<'e> {
     /// The main chunk, against an environment the caller has already installed.
     fn run_main(&mut self, program: &Program, scope: &mut Scope) -> VmResult {
         self.clear_faults();
+        // A step a previous run left waiting is not this one's to honour.
+        #[cfg(feature = "debugging")]
+        self.pending_steps.clear();
         let mut pc = program.main().entry() as usize;
         // Slots are indices into the caller's scope, so a caller that arrives
         // with variables already in it shifts every one of them.
@@ -2774,27 +2831,11 @@ impl<'e> Vm<'e> {
         // a scope that holds nothing else — so slot 0 is index 0.
         let mut reached = chunk.entry() as usize;
         let outcome = self.execute(program, scope, chunk, scope_start_len, &mut reached);
+        // Read before the mapping below, which turns the `Return` that carries a
+        // body's value into a success.
+        let failed = outcome.is_err();
 
-        // Pop the frame however the body left — an error escaping a call must not
-        // leave the stack deep, or every later trace is wrong.
-        #[cfg(feature = "debugging")]
-        if let Some(dbg) = self.global.debugger.as_mut() {
-            dbg.rewind_call_stack(orig_call_stack_len);
-        }
-
-        // Rewind scope.
-        if rewind_scope {
-            scope.rewind(scope_start_len);
-        } else if scope_end_len != scope_start_len {
-            // Remove arguments only, leaving new variables in the scope
-            scope.remove_range(scope_start_len, scope_end_len - scope_start_len);
-        }
-
-        if outcome.is_err() {
-            self.record_fault(reached);
-        }
-
-        outcome.or_else(|err| match *err {
+        let result = outcome.or_else(|err| match *err {
             // A `return` inside the body is the body's value.
             EvalAltResult::Return(value, ..) => Ok(value),
             // Exits and system errors pass straight through, positioned at the
@@ -2808,7 +2849,154 @@ impl<'e> Vm<'e> {
                 err,
                 pos,
             ))),
-        })
+        });
+
+        // Mapped first, then reported: Rhai tells the debugger what the *caller*
+        // will see (`func/script.rs:157-186`), with the body's locals still in
+        // scope for the callback to read.
+        #[cfg(feature = "debugging")]
+        let result = self.at_function_exit(scope, result, orig_call_stack_len, pos);
+
+        // Rewind scope.
+        if rewind_scope {
+            scope.rewind(scope_start_len);
+        } else if scope_end_len != scope_start_len {
+            // Remove arguments only, leaving new variables in the scope
+            scope.remove_range(scope_start_len, scope_end_len - scope_start_len);
+        }
+
+        if failed {
+            self.record_fault(reached);
+        }
+
+        result
+    }
+
+    /// Report how a body ended and drop its call stack frame.
+    ///
+    /// The frame goes however the call ended — an error escaping one must not
+    /// leave the stack deep, or every later trace is wrong.
+    #[cfg(feature = "debugging")]
+    fn at_function_exit(
+        &mut self,
+        scope: &mut Scope,
+        result: VmResult,
+        orig_call_stack_len: usize,
+        pos: Position,
+    ) -> VmResult {
+        if !self.engine.is_debugger_registered() {
+            return result;
+        }
+
+        // Only where something is waiting for it: a `FunctionExit` asked for at
+        // this level or outside it, or a step that has to stop somewhere and
+        // this is where the body ran out (`func/script.rs:159-163`).
+        let trigger = match self.global.debugger().status {
+            crate::eval::DebuggerStatus::FunctionExit(n) => n >= self.global.level,
+            crate::eval::DebuggerStatus::Next(.., true) => true,
+            _ => false,
+        };
+
+        let result = if trigger {
+            // The call site, where Rhai has the body's closing brace: a chunk
+            // keeps no position for the end of itself, and the call is the place
+            // Rhai falls back to when the body has none either.
+            let node = crate::ast::Stmt::Noop(pos);
+            let event = match result {
+                Ok(ref value) => crate::eval::DebuggerEvent::FunctionExitWithValue(value),
+                Err(ref err) => crate::eval::DebuggerEvent::FunctionExitWithError(err),
+            };
+
+            let before = scope.len();
+            let reported = self.engine.dbg_raw(
+                &mut self.global,
+                &mut self.caches,
+                scope,
+                self.this.as_mut(),
+                (&node).into(),
+                event,
+            );
+            rewind_after_stop(scope, before);
+
+            match reported {
+                Ok(..) => result,
+                Err(err) => Err(err),
+            }
+        } else {
+            result
+        };
+
+        if let Some(dbg) = self.global.debugger.as_mut() {
+            dbg.rewind_call_stack(orig_call_stack_len);
+        }
+
+        result
+    }
+
+    /// Stop at a statement boundary, as Rhai stops at a statement node
+    /// (`eval/stmt.rs:269`).
+    ///
+    /// `depth` is the marker's, and says which of the steps waiting in
+    /// [`Vm::pending_steps`] belong to statements that have now ended.
+    #[cfg(feature = "debugging")]
+    fn at_statement(
+        &mut self,
+        scope: &mut Scope,
+        depth: u16,
+        pos: Position,
+    ) -> Result<(), Box<EvalAltResult>> {
+        if !self.engine.is_debugger_registered() {
+            return Ok(());
+        }
+
+        let level = self.global.level;
+
+        // A marker inside the statement a step was asked at is one that step
+        // must not stop for — that is what stepping *over* a call or a block
+        // means. Anything at the same depth or outside it, or in a frame further
+        // out, is past the end of that statement.
+        while let Some(&(at_level, at_depth, status)) = self.pending_steps.last() {
+            if level > at_level || (level == at_level && depth > at_depth) {
+                break;
+            }
+            self.pending_steps.pop();
+            self.global.debugger_mut().reset_status(status);
+        }
+
+        let node = crate::ast::Stmt::Noop(pos);
+        let before = scope.len();
+        let resumed = self.engine.dbg_reset(
+            &mut self.global,
+            &mut self.caches,
+            scope,
+            self.this.as_mut(),
+            &node,
+        );
+        rewind_after_stop(scope, before);
+
+        if let Some(status) = resumed? {
+            self.pending_steps.push((level, depth, status));
+        }
+
+        Ok(())
+    }
+
+    /// Tell the debugger the run is over, as Rhai does at the end of an `eval`
+    /// (`api/eval.rs:255-260`).
+    ///
+    /// Only where the run got there: the walker's `?` on the statements means a
+    /// failed script never reaches this.
+    #[cfg(feature = "debugging")]
+    fn at_end(&mut self, scope: &mut Scope) -> Result<(), Box<EvalAltResult>> {
+        if !self.engine.is_debugger_registered() {
+            return Ok(());
+        }
+
+        self.global.debugger_mut().status = crate::eval::DebuggerStatus::Terminate;
+        let node = crate::ast::Stmt::Noop(Position::NONE);
+
+        self.engine
+            .dbg(&mut self.global, &mut self.caches, scope, None, &node)
     }
 
     /// Run one frame, cleaning up after it however it leaves.
@@ -3928,6 +4116,17 @@ impl<'e> Vm<'e> {
                 code::tag::TICK => self.engine.track_operation(&mut self.global, pos())?,
 
                 code::tag::CHECKPOINT => self.unwind_floor = scope.len(),
+
+                code::tag::STATEMENT => {
+                    // Nothing to stop for without the interface to stop at, and
+                    // no marker in the code at all unless it was compiled by a
+                    // build that has one.
+                    #[cfg(feature = "debugging")]
+                    {
+                        let depth = small(1)?;
+                        self.at_statement(scope, depth, pos())?;
+                    }
+                }
 
                 code::tag::PUSH_HANDLER | code::tag::PUSH_HANDLER_VAR => {
                     let target = wide(1)? as usize;

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -2732,6 +2732,13 @@ impl<'e> Vm<'e> {
 
         let scope_start_len = scope.len();
 
+        #[cfg(feature = "debugging")]
+        let orig_call_stack_len = self
+            .global
+            .debugger
+            .as_ref()
+            .map_or(0, |dbg| dbg.call_stack().len());
+
         for (param, slot) in params.iter().zip(first..) {
             let name = program
                 .name(*param)
@@ -2747,10 +2754,33 @@ impl<'e> Vm<'e> {
         }
         let scope_end_len = scope.len();
 
+        // A frame for `back_trace` to see, pushed once the arguments are in the
+        // scope so it reports the values the body will run with — the moment
+        // Rhai picks (`func/script.rs:78`).
+        #[cfg(feature = "debugging")]
+        if self.engine.is_debugger_registered() {
+            let args = scope
+                .iter_inner()
+                .skip(scope_start_len)
+                .map(|(.., v)| v.flatten_clone());
+            let source = self.global.source.clone();
+
+            self.global
+                .debugger_mut()
+                .push_call_stack_frame(name.into(), args, source, pos);
+        }
+
         // A function's parameters are its first locals, sitting at 0 upwards in
         // a scope that holds nothing else — so slot 0 is index 0.
         let mut reached = chunk.entry() as usize;
         let outcome = self.execute(program, scope, chunk, scope_start_len, &mut reached);
+
+        // Pop the frame however the body left — an error escaping a call must not
+        // leave the stack deep, or every later trace is wrong.
+        #[cfg(feature = "debugging")]
+        if let Some(dbg) = self.global.debugger.as_mut() {
+            dbg.rewind_call_stack(orig_call_stack_len);
+        }
 
         // Rewind scope.
         if rewind_scope {

--- a/tests/grain/debugger.rs
+++ b/tests/grain/debugger.rs
@@ -1,0 +1,110 @@
+//! A compiled call must be visible to the debugger.
+//!
+//! `back_trace` reads `global.debugger.call_stack()`, which Rhai fills from
+//! `call_script_fn` (`func/script.rs:78`). The VM's own frames come from
+//! `call_compiled_body`, and a VM that skipped the push would answer a script
+//! that asks where it is with an empty array rather than a wrong one — silent,
+//! and only wrong under a feature most builds do not carry.
+//!
+//! Outside the differential corpus on purpose: registering a debugger changes
+//! what the walker does for *every* script it runs, and the VM has no
+//! per-statement `dbg` hook to match it with. Sharing `corpus::engine()` would
+//! manufacture divergences in cases that are about something else.
+//!
+//! Frame counts are compared against the walker rather than written down. Rhai
+//! decides what a frame is — `back_trace` filters its own, and a `catch` may or
+//! may not leave one behind — so a literal here would pin this harness to
+//! today's answer instead of to agreement.
+
+use rhai::grain::{Compiler, Vm};
+use rhai::{Array, Dynamic, Engine, Scope};
+
+/// An engine that records nothing and steps nowhere.
+///
+/// `Continue` is the whole point: the call stack must be maintained because a
+/// script can read it, not because anything is watching.
+fn engine() -> Engine {
+    let mut engine = Engine::new();
+    engine.register_debugger(
+        |_, dbg| dbg,
+        |_, _, _, _, _| Ok(rhai::debugger::DebuggerCommand::Continue),
+    );
+    engine
+}
+
+/// The trace the VM produces, having first established that it is the VM's.
+fn vm_trace(engine: &Engine, source: &str) -> Array {
+    let ast = engine.compile(source).expect("must compile");
+    let program = Compiler::new().compile(&ast);
+
+    assert_eq!(
+        program.residual_count(),
+        0,
+        "{source:?} must be fully lowered, or the frames counted are the walker's: {:?}",
+        program.first_unsupported(),
+    );
+
+    Vm::new(engine)
+        .eval_with_scope(&mut Scope::new(), &program)
+        .expect("must run")
+        .into_array()
+        .expect("back_trace hands back an array")
+}
+
+fn walker_trace(engine: &Engine, source: &str) -> Array {
+    let ast = engine.compile(source).expect("must compile");
+    engine
+        .eval_ast_with_scope::<Dynamic>(&mut Scope::new(), &ast)
+        .expect("must run under Rhai too")
+        .into_array()
+        .expect("back_trace hands back an array")
+}
+
+/// Recursion, so a single missing push cannot pass by looking like an off-by-one.
+const NESTED: &str = "
+    fn foo(x) {
+        if x >= 5 { back_trace() } else { foo(x + 1) }
+    }
+    foo(0)
+";
+
+#[test]
+fn a_compiled_call_appears_in_the_back_trace() {
+    let engine = engine();
+
+    let ours = vm_trace(&engine, NESTED);
+    let walker = walker_trace(&engine, NESTED);
+
+    assert!(!ours.is_empty(), "a compiled call left no frame at all");
+    assert_eq!(ours.len(), walker.len(), "frame count must match Rhai's");
+}
+
+/// An error unwinding out of a call must take its frame with it.
+///
+/// The push and the pop are not symmetric in the code — the pop has to happen
+/// on the path the body raised on as well as the one it returned on — so a
+/// trace taken *after* a caught throw is the one that catches a leak.
+const AFTER_A_CAUGHT_THROW: &str = r#"
+    fn deep(x) {
+        if x >= 3 { throw "boom" } else { deep(x + 1) }
+    }
+    fn trace() { back_trace() }
+
+    try { deep(0) } catch { }
+
+    trace()
+"#;
+
+#[test]
+fn a_caught_throw_leaves_no_frames_behind() {
+    let engine = engine();
+
+    let ours = vm_trace(&engine, AFTER_A_CAUGHT_THROW);
+    let walker = walker_trace(&engine, AFTER_A_CAUGHT_THROW);
+
+    assert_eq!(
+        ours.len(),
+        walker.len(),
+        "frames from the unwound calls are still on the stack",
+    );
+}

--- a/tests/grain/debugger.rs
+++ b/tests/grain/debugger.rs
@@ -1,61 +1,175 @@
-//! A compiled call must be visible to the debugger.
+//! A compiled program must be visible to the debugger, and stoppable.
 //!
-//! `back_trace` reads `global.debugger.call_stack()`, which Rhai fills from
-//! `call_script_fn` (`func/script.rs:78`). The VM's own frames come from
-//! `call_compiled_body`, and a VM that skipped the push would answer a script
+//! Two claims. The first is that a compiled call is a call: `back_trace` reads
+//! `global.debugger.call_stack()`, which Rhai fills from `call_script_fn`
+//! (`func/script.rs:78`), and a VM that skipped the push would answer a script
 //! that asks where it is with an empty array rather than a wrong one — silent,
 //! and only wrong under a feature most builds do not carry.
 //!
+//! The second is that a chunk can be stopped in. Rhai runs the callback per AST
+//! node and a chunk has no nodes, so the compiler marks where the statements
+//! were (`Op::Statement`) and the VM stops there. Statements are as fine as it
+//! gets: an expression is not a thing a chunk still has, so the walker stops in
+//! places the VM cannot. Every test below therefore says which engine's answer
+//! it is pinning, and compares to the walker only where both can agree.
+//!
 //! Outside the differential corpus on purpose: registering a debugger changes
-//! what the walker does for *every* script it runs, and the VM has no
-//! per-statement `dbg` hook to match it with. Sharing `corpus::engine()` would
-//! manufacture divergences in cases that are about something else.
+//! what *every* script does, and the corpus is about other subjects.
 //!
 //! Frame counts are compared against the walker rather than written down. Rhai
 //! decides what a frame is — `back_trace` filters its own, and a `catch` may or
 //! may not leave one behind — so a literal here would pin this harness to
 //! today's answer instead of to agreement.
 
-use rhai::grain::{Compiler, Vm};
-use rhai::{Array, Dynamic, Engine, Scope};
+use std::sync::{Arc, Mutex};
 
-/// An engine that records nothing and steps nowhere.
-///
-/// `Continue` is the whole point: the call stack must be maintained because a
-/// script can read it, not because anything is watching.
-fn engine() -> Engine {
-    let mut engine = Engine::new();
-    engine.register_debugger(
-        |_, dbg| dbg,
-        |_, _, _, _, _| Ok(rhai::debugger::DebuggerCommand::Continue),
-    );
-    engine
+use rhai::debugger::{BreakPoint, DebuggerCommand, DebuggerEvent};
+use rhai::grain::{Compiler, Program, Vm};
+use rhai::{Array, Dynamic, Engine, Scope, INT};
+// Only a break-point placed by line needs one, and those tests go with the
+// positions.
+#[cfg(not(feature = "no_position"))]
+use rhai::Position;
+
+/// One stop, as the callback saw it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Stop {
+    /// What stopped it.
+    event: &'static str,
+    /// The line of the node it stopped at, or 0 where there is none.
+    line: usize,
+    /// What a function-exit event carried, rendered. Empty for the rest.
+    detail: String,
 }
 
-/// The trace the VM produces, having first established that it is the VM's.
-fn vm_trace(engine: &Engine, source: &str) -> Array {
+/// Where a run stopped, in order.
+type Log = Arc<Mutex<Vec<Stop>>>;
+
+fn describe(event: DebuggerEvent) -> (&'static str, String) {
+    match event {
+        DebuggerEvent::Start => ("start", String::new()),
+        DebuggerEvent::Step => ("step", String::new()),
+        DebuggerEvent::BreakPoint(..) => ("break", String::new()),
+        DebuggerEvent::FunctionExitWithValue(value) => ("exit", value.to_string()),
+        DebuggerEvent::FunctionExitWithError(err) => ("raised", err.to_string()),
+        DebuggerEvent::End => ("end", String::new()),
+        _ => ("unknown", String::new()),
+    }
+}
+
+/// An engine whose debugger records every stop and answers `reply`.
+///
+/// `reply` sees the stops so far with the current one last, which is how a test
+/// says "step until you are inside, then let it run". The log is shared rather
+/// than owned because the interface is `Fn` — and `Send + Sync` under `sync`.
+fn recording(
+    reply: impl Fn(&[Stop]) -> DebuggerCommand + Send + Sync + 'static,
+) -> (Engine, Log) {
+    breaking(Vec::new(), reply)
+}
+
+/// The same, with break-points in place before the run.
+fn breaking(
+    points: Vec<BreakPoint>,
+    reply: impl Fn(&[Stop]) -> DebuggerCommand + Send + Sync + 'static,
+) -> (Engine, Log) {
+    let log: Log = Arc::new(Mutex::new(Vec::new()));
+    let recorded = log.clone();
+
+    let mut engine = Engine::new();
+    #[allow(deprecated)] // not deprecated but unstable
+    engine.register_debugger(
+        move |_, mut dbg| {
+            dbg.break_points_mut().extend(points.iter().cloned());
+            dbg
+        },
+        move |_, event, _, _, pos| {
+            let (event, detail) = describe(event);
+            let mut stops = recorded.lock().expect("nothing else holds the log");
+            stops.push(Stop {
+                event,
+                line: pos.line().unwrap_or(0),
+                detail,
+            });
+            Ok(reply(&stops))
+        },
+    );
+
+    (engine, log)
+}
+
+fn stops(log: &Log) -> Vec<Stop> {
+    log.lock().expect("the run is over").clone()
+}
+
+/// The lines a run stopped at, in order, dropping the events that carry no
+/// position of their own.
+#[cfg(not(feature = "no_position"))]
+fn lines(log: &Log) -> Vec<usize> {
+    stops(log)
+        .iter()
+        .filter(|stop| stop.line > 0)
+        .map(|stop| stop.line)
+        .collect()
+}
+
+fn events(log: &Log) -> Vec<&'static str> {
+    stops(log).iter().map(|stop| stop.event).collect()
+}
+
+/// The program `source` lowers to, having first established that it is wholly
+/// the VM's: a fragment is evaluated by the walker, which stops at its own nodes
+/// and would put them in the log beside ours.
+fn compiled(engine: &Engine, source: &str) -> Program<'static> {
     let ast = engine.compile(source).expect("must compile");
     let program = Compiler::new().compile(&ast);
 
     assert_eq!(
         program.residual_count(),
         0,
-        "{source:?} must be fully lowered, or the frames counted are the walker's: {:?}",
+        "{source:?} must be fully lowered, or the stops counted are the walker's: {:?}",
         program.first_unsupported(),
     );
 
+    program
+}
+
+fn vm_eval(engine: &Engine, source: &str) -> Dynamic {
     Vm::new(engine)
-        .eval_with_scope(&mut Scope::new(), &program)
+        .eval_with_scope(&mut Scope::new(), &compiled(engine, source))
         .expect("must run")
+}
+
+fn walker_eval(engine: &Engine, source: &str) -> Dynamic {
+    walker_eval_with(engine, &mut Scope::new(), source)
+}
+
+/// The same against a scope the caller keeps, for a test that reads what the run
+/// left in it.
+fn walker_eval_with(engine: &Engine, scope: &mut Scope, source: &str) -> Dynamic {
+    let ast = engine.compile(source).expect("must compile");
+    engine
+        .eval_ast_with_scope::<Dynamic>(scope, &ast)
+        .expect("must run under Rhai too")
+}
+
+/// Run it for the stops rather than for the answer.
+fn vm_run(engine: &Engine, source: &str) {
+    let _ = vm_eval(engine, source);
+}
+
+fn walker_run(engine: &Engine, source: &str) {
+    let _ = walker_eval(engine, source);
+}
+
+fn vm_trace(engine: &Engine, source: &str) -> Array {
+    vm_eval(engine, source)
         .into_array()
         .expect("back_trace hands back an array")
 }
 
 fn walker_trace(engine: &Engine, source: &str) -> Array {
-    let ast = engine.compile(source).expect("must compile");
-    engine
-        .eval_ast_with_scope::<Dynamic>(&mut Scope::new(), &ast)
-        .expect("must run under Rhai too")
+    walker_eval(engine, source)
         .into_array()
         .expect("back_trace hands back an array")
 }
@@ -70,7 +184,7 @@ const NESTED: &str = "
 
 #[test]
 fn a_compiled_call_appears_in_the_back_trace() {
-    let engine = engine();
+    let (engine, _) = recording(|_| DebuggerCommand::Continue);
 
     let ours = vm_trace(&engine, NESTED);
     let walker = walker_trace(&engine, NESTED);
@@ -97,7 +211,7 @@ const AFTER_A_CAUGHT_THROW: &str = r#"
 
 #[test]
 fn a_caught_throw_leaves_no_frames_behind() {
-    let engine = engine();
+    let (engine, _) = recording(|_| DebuggerCommand::Continue);
 
     let ours = vm_trace(&engine, AFTER_A_CAUGHT_THROW);
     let walker = walker_trace(&engine, AFTER_A_CAUGHT_THROW);
@@ -106,5 +220,347 @@ fn a_caught_throw_leaves_no_frames_behind() {
         ours.len(),
         walker.len(),
         "frames from the unwound calls are still on the stack",
+    );
+}
+
+/// Three statements, one per line, and nothing the optimizer can fold away.
+///
+/// Every use is a claim about *where* it stopped, so a build with no positions
+/// has nothing to ask of it.
+#[cfg(not(feature = "no_position"))]
+const THREE: &str = "\
+let a = 1;
+a += 1;
+a
+";
+
+/// A call, so a step can go into one and a `next` can go over one.
+///
+/// Line 1 is the body's opening brace, line 2 its only statement, and the call
+/// is on line 5.
+const CALLING: &str = "\
+fn inner(x) {
+    x + 1
+}
+let a = 1;
+let b = inner(a);
+b
+";
+
+#[test]
+#[cfg(not(feature = "no_position"))]
+fn stepping_stops_at_every_statement() {
+    let (engine, log) = recording(|_| DebuggerCommand::StepInto);
+    vm_run(&engine,THREE);
+
+    assert_eq!(lines(&log), vec![1, 2, 3], "one stop per statement, in order");
+    assert_eq!(
+        events(&log),
+        vec!["start", "step", "step", "end"],
+        "the run must announce both of its ends",
+    );
+
+    // The walker stops at expressions too, so it can only be asked for a
+    // superset — that the VM stops nowhere Rhai would not.
+    let (walker_engine, walker) = recording(|_| DebuggerCommand::StepInto);
+    walker_run(&walker_engine,THREE);
+    for line in lines(&log) {
+        assert!(
+            lines(&walker).contains(&line),
+            "line {line} is a stop the walker does not have: {:?}",
+            lines(&walker),
+        );
+    }
+}
+
+#[test]
+#[cfg(not(feature = "no_position"))]
+fn a_break_point_stops_a_compiled_statement() {
+    let point = || BreakPoint::AtPosition {
+        source: None,
+        pos: Position::new(2, 0),
+        enabled: true,
+    };
+
+    let (engine, log) = breaking(vec![point()], |_| DebuggerCommand::Continue);
+    vm_run(&engine,THREE);
+
+    assert_eq!(
+        stops(&log)
+            .iter()
+            .filter(|stop| stop.event == "break")
+            .map(|stop| stop.line)
+            .collect::<Vec<_>>(),
+        vec![2],
+        "the break-point on line 2 fired once, at line 2",
+    );
+
+    // Rhai's own count is not one: a line matches the statement's node and
+    // every expression node on it. Agreement is that the line stops at all.
+    let (walker_engine, walker) = breaking(vec![point()], |_| DebuggerCommand::Continue);
+    walker_run(&walker_engine,THREE);
+    assert!(
+        stops(&walker).iter().any(|stop| stop.event == "break"),
+        "the walker did not stop for the same break-point: {:?}",
+        stops(&walker),
+    );
+}
+
+#[test]
+#[cfg(not(feature = "no_position"))]
+fn a_next_steps_over_a_call() {
+    let (engine, log) = recording(|_| DebuggerCommand::Next);
+    vm_run(&engine,CALLING);
+
+    assert_eq!(lines(&log), vec![4, 5, 6], "the call's own line, not its body");
+
+    let (walker_engine, walker) = recording(|_| DebuggerCommand::Next);
+    walker_run(&walker_engine,CALLING);
+    for log in [&log, &walker] {
+        assert!(
+            !lines(log).contains(&2),
+            "a `next` stopped inside the callee: {:?}",
+            lines(log),
+        );
+    }
+}
+
+/// A block, so a `next` has something to step over that is not a call.
+///
+/// Lines 3 and 4 are inside it, and line 6 is after it.
+#[cfg(not(feature = "no_position"))]
+const BLOCKED: &str = "\
+let a = 1;
+if a == 1 {
+    a += 1;
+    a += 1;
+}
+a
+";
+
+/// The reason a marker carries its nesting depth: without it a `next` at the
+/// `if` would stop at the first statement inside it.
+///
+/// Line 6 is where the two engines part. It is a bare expression statement,
+/// which Rhai treats as transitive — it stops *inside* one rather than at it,
+/// and a `next` only stops at statements, so it does not stop there at all. The
+/// VM's marker is the statement, so it stops once. What the test is about, they
+/// agree on: neither goes into the block.
+#[test]
+#[cfg(not(feature = "no_position"))]
+fn a_next_steps_over_a_block() {
+    let (engine, log) = recording(|_| DebuggerCommand::Next);
+    vm_run(&engine, BLOCKED);
+
+    assert_eq!(lines(&log), vec![1, 2, 6], "the `if`, then what follows it");
+
+    let (walker_engine, walker) = recording(|_| DebuggerCommand::Next);
+    walker_run(&walker_engine, BLOCKED);
+    for log in [&log, &walker] {
+        assert!(
+            !lines(log).iter().any(|line| [3, 4].contains(line)),
+            "a `next` stopped inside the block: {:?}",
+            lines(log),
+        );
+    }
+}
+
+#[test]
+#[cfg(not(feature = "no_position"))]
+fn a_step_goes_into_a_call_and_reports_leaving_it() {
+    let (engine, log) = recording(|_| DebuggerCommand::StepInto);
+    vm_run(&engine,CALLING);
+
+    assert_eq!(
+        lines(&log),
+        vec![4, 5, 1, 2, 5, 6],
+        "entering the body, running its statement, and coming back out",
+    );
+    assert_eq!(
+        stops(&log)
+            .iter()
+            .find(|stop| stop.event == "exit")
+            .map(|stop| stop.detail.clone()),
+        Some("2".to_string()),
+        "leaving `inner` must report what it returned",
+    );
+
+    // The value a body ended with is the one thing about leaving it that both
+    // engines can state exactly.
+    let (walker_engine, walker) = recording(|_| DebuggerCommand::StepInto);
+    walker_run(&walker_engine,CALLING);
+    assert_eq!(
+        stops(&walker)
+            .iter()
+            .find(|stop| stop.event == "exit")
+            .map(|stop| stop.detail.clone()),
+        Some("2".to_string()),
+        "the walker reports the same body's value",
+    );
+}
+
+/// A `throw` out of a call, caught outside it, so the run still finishes.
+const RAISING: &str = "\
+fn boom() {
+    throw 42
+}
+let a = 0;
+try { a = boom(); } catch { a = 1; }
+a
+";
+
+#[test]
+fn leaving_a_call_by_raising_is_reported_as_an_error() {
+    let (engine, log) = recording(|_| DebuggerCommand::StepInto);
+    vm_run(&engine,RAISING);
+
+    let raised: Vec<_> = stops(&log)
+        .iter()
+        .filter(|stop| stop.event == "raised")
+        .map(|stop| stop.detail.clone())
+        .collect();
+
+    assert_eq!(raised.len(), 1, "one call raised, so one such event: {:?}", stops(&log));
+    assert!(
+        raised[0].contains("42"),
+        "the event must carry the error the caller sees, got {:?}",
+        raised[0],
+    );
+
+    let (walker_engine, walker) = recording(|_| DebuggerCommand::StepInto);
+    walker_run(&walker_engine,RAISING);
+    assert!(
+        stops(&walker)
+            .iter()
+            .any(|stop| stop.event == "raised" && stop.detail.contains("42")),
+        "the walker reports the same error: {:?}",
+        stops(&walker),
+    );
+}
+
+#[test]
+#[cfg(not(feature = "no_position"))]
+fn a_function_exit_runs_the_rest_of_the_body() {
+    // Step until the body's statement is reached, ask to leave, then let the
+    // program finish. Keyed on where it is rather than on how many stops that
+    // took, because the two engines do not take the same number.
+    let reply = |stops: &[Stop]| {
+        let inside = |stop: &Stop| stop.line == 2;
+        match stops.last() {
+            Some(stop) if inside(stop) => DebuggerCommand::FunctionExit,
+            _ if stops.iter().any(inside) => DebuggerCommand::Continue,
+            _ => DebuggerCommand::StepInto,
+        }
+    };
+
+    let (engine, log) = recording(reply);
+    vm_run(&engine,CALLING);
+
+    assert_eq!(
+        stops(&log)
+            .iter()
+            .find(|stop| stop.event == "exit")
+            .map(|stop| stop.detail.clone()),
+        Some("2".to_string()),
+        "asking to leave `inner` must stop again as it is left: {:?}",
+        stops(&log),
+    );
+
+    let (walker_engine, walker) = recording(reply);
+    walker_run(&walker_engine,CALLING);
+    assert_eq!(
+        stops(&walker)
+            .iter()
+            .find(|stop| stop.event == "exit")
+            .map(|stop| stop.detail.clone()),
+        Some("2".to_string()),
+        "the walker leaves it the same way",
+    );
+}
+
+/// What a callback declares must not disturb the program it stopped.
+///
+/// A stop can now happen part way through a chunk, so a callback that pushes
+/// onto the scope is a callback that moves every slot the rest of the chunk has
+/// yet to declare. Rhai searches by name once that has happened; a chunk cannot,
+/// so it takes the entry back off instead — see `rewind_after_stop`. The two
+/// engines agree on the program's value for different reasons, and the injected
+/// variable is the visible difference between them.
+///
+/// The run's last stop is the exception, and the callback here skips it: it
+/// happens after the chunk, where there are no slots left to move, so what is
+/// declared there is the caller's to keep as it is under Rhai.
+#[test]
+fn what_a_callback_declares_does_not_outlive_the_stop() {
+    let mut engine = Engine::new();
+    #[allow(deprecated)] // not deprecated but unstable
+    engine.register_debugger(
+        |_, dbg| dbg,
+        |mut context, event, _, _, _| {
+            if describe(event).0 != "end" && context.scope().get_value::<INT>("injected").is_none() {
+                context.scope_mut().push("injected", 99 as INT);
+            }
+            Ok(DebuggerCommand::Continue)
+        },
+    );
+
+    // Declarations after the first stop, so a slot that moved reads the
+    // injected value instead of the variable it names.
+    const DECLARING: &str = "\
+let a = 1;
+let b = 2;
+a + b
+";
+
+    let mut ours = Scope::new();
+    let value = Vm::new(&engine)
+        .eval_with_scope(&mut ours, &compiled(&engine, DECLARING))
+        .expect("must run");
+
+    let mut walked = Scope::new();
+    let expected = walker_eval_with(&engine, &mut walked, DECLARING);
+
+    assert_eq!(
+        format!("{value:?}"),
+        format!("{expected:?}"),
+        "a stop moved the slots underneath the statements after it",
+    );
+    assert!(
+        ours.get_value::<INT>("injected").is_none(),
+        "the callback's variable outlived the stop, so the slots are its problem now",
+    );
+    assert!(
+        walked.get_value::<INT>("injected").is_some(),
+        "Rhai no longer keeps what a callback declares, so this is not the difference",
+    );
+}
+
+/// A break-point on a *name* has nothing to match under the VM, and saying so
+/// here is the point: it is the one kind of stop compiling away the tree costs.
+///
+/// Rhai matches these against the call node itself (`eval/debugger.rs:334`), and
+/// the node a marker hands the callback is a synthetic `Noop` — a chunk keeps no
+/// call expression to offer, and inventing one would hand a debugger arguments
+/// the script never wrote. Position break-points cover the same line.
+#[test]
+fn a_break_point_on_a_function_name_cannot_fire_under_the_vm() {
+    let point = || BreakPoint::AtFunctionName {
+        name: "inner".into(),
+        enabled: true,
+    };
+
+    let (engine, log) = breaking(vec![point()], |_| DebuggerCommand::Continue);
+    vm_run(&engine,CALLING);
+    assert_eq!(
+        events(&log),
+        vec!["start", "end"],
+        "a name break-point stopped the VM, so this limitation is stale",
+    );
+
+    let (walker_engine, walker) = breaking(vec![point()], |_| DebuggerCommand::Continue);
+    walker_run(&walker_engine,CALLING);
+    assert!(
+        events(&walker).contains(&"break"),
+        "the walker no longer stops on a name either, so this is not the VM's gap",
     );
 }

--- a/tests/grain/debugger.rs
+++ b/tests/grain/debugger.rs
@@ -62,17 +62,12 @@ fn describe(event: DebuggerEvent) -> (&'static str, String) {
 /// `reply` sees the stops so far with the current one last, which is how a test
 /// says "step until you are inside, then let it run". The log is shared rather
 /// than owned because the interface is `Fn` — and `Send + Sync` under `sync`.
-fn recording(
-    reply: impl Fn(&[Stop]) -> DebuggerCommand + Send + Sync + 'static,
-) -> (Engine, Log) {
+fn recording(reply: impl Fn(&[Stop]) -> DebuggerCommand + Send + Sync + 'static) -> (Engine, Log) {
     breaking(Vec::new(), reply)
 }
 
 /// The same, with break-points in place before the run.
-fn breaking(
-    points: Vec<BreakPoint>,
-    reply: impl Fn(&[Stop]) -> DebuggerCommand + Send + Sync + 'static,
-) -> (Engine, Log) {
+fn breaking(points: Vec<BreakPoint>, reply: impl Fn(&[Stop]) -> DebuggerCommand + Send + Sync + 'static) -> (Engine, Log) {
     let log: Log = Arc::new(Mutex::new(Vec::new()));
     let recorded = log.clone();
 
@@ -86,11 +81,7 @@ fn breaking(
         move |_, event, _, _, pos| {
             let (event, detail) = describe(event);
             let mut stops = recorded.lock().expect("nothing else holds the log");
-            stops.push(Stop {
-                event,
-                line: pos.line().unwrap_or(0),
-                detail,
-            });
+            stops.push(Stop { event, line: pos.line().unwrap_or(0), detail });
             Ok(reply(&stops))
         },
     );
@@ -106,11 +97,7 @@ fn stops(log: &Log) -> Vec<Stop> {
 /// position of their own.
 #[cfg(not(feature = "no_position"))]
 fn lines(log: &Log) -> Vec<usize> {
-    stops(log)
-        .iter()
-        .filter(|stop| stop.line > 0)
-        .map(|stop| stop.line)
-        .collect()
+    stops(log).iter().filter(|stop| stop.line > 0).map(|stop| stop.line).collect()
 }
 
 fn events(log: &Log) -> Vec<&'static str> {
@@ -124,20 +111,13 @@ fn compiled(engine: &Engine, source: &str) -> Program<'static> {
     let ast = engine.compile(source).expect("must compile");
     let program = Compiler::new().compile(&ast);
 
-    assert_eq!(
-        program.residual_count(),
-        0,
-        "{source:?} must be fully lowered, or the stops counted are the walker's: {:?}",
-        program.first_unsupported(),
-    );
+    assert_eq!(program.residual_count(), 0, "{source:?} must be fully lowered, or the stops counted are the walker's: {:?}", program.first_unsupported(),);
 
     program
 }
 
 fn vm_eval(engine: &Engine, source: &str) -> Dynamic {
-    Vm::new(engine)
-        .eval_with_scope(&mut Scope::new(), &compiled(engine, source))
-        .expect("must run")
+    Vm::new(engine).eval_with_scope(&mut Scope::new(), &compiled(engine, source)).expect("must run")
 }
 
 fn walker_eval(engine: &Engine, source: &str) -> Dynamic {
@@ -148,9 +128,7 @@ fn walker_eval(engine: &Engine, source: &str) -> Dynamic {
 /// left in it.
 fn walker_eval_with(engine: &Engine, scope: &mut Scope, source: &str) -> Dynamic {
     let ast = engine.compile(source).expect("must compile");
-    engine
-        .eval_ast_with_scope::<Dynamic>(scope, &ast)
-        .expect("must run under Rhai too")
+    engine.eval_ast_with_scope::<Dynamic>(scope, &ast).expect("must run under Rhai too")
 }
 
 /// Run it for the stops rather than for the answer.
@@ -163,15 +141,11 @@ fn walker_run(engine: &Engine, source: &str) {
 }
 
 fn vm_trace(engine: &Engine, source: &str) -> Array {
-    vm_eval(engine, source)
-        .into_array()
-        .expect("back_trace hands back an array")
+    vm_eval(engine, source).into_array().expect("back_trace hands back an array")
 }
 
 fn walker_trace(engine: &Engine, source: &str) -> Array {
-    walker_eval(engine, source)
-        .into_array()
-        .expect("back_trace hands back an array")
+    walker_eval(engine, source).into_array().expect("back_trace hands back an array")
 }
 
 /// Recursion, so a single missing push cannot pass by looking like an off-by-one.
@@ -216,11 +190,7 @@ fn a_caught_throw_leaves_no_frames_behind() {
     let ours = vm_trace(&engine, AFTER_A_CAUGHT_THROW);
     let walker = walker_trace(&engine, AFTER_A_CAUGHT_THROW);
 
-    assert_eq!(
-        ours.len(),
-        walker.len(),
-        "frames from the unwound calls are still on the stack",
-    );
+    assert_eq!(ours.len(), walker.len(), "frames from the unwound calls are still on the stack",);
 }
 
 /// Three statements, one per line, and nothing the optimizer can fold away.
@@ -251,25 +221,17 @@ b
 #[cfg(not(feature = "no_position"))]
 fn stepping_stops_at_every_statement() {
     let (engine, log) = recording(|_| DebuggerCommand::StepInto);
-    vm_run(&engine,THREE);
+    vm_run(&engine, THREE);
 
     assert_eq!(lines(&log), vec![1, 2, 3], "one stop per statement, in order");
-    assert_eq!(
-        events(&log),
-        vec!["start", "step", "step", "end"],
-        "the run must announce both of its ends",
-    );
+    assert_eq!(events(&log), vec!["start", "step", "step", "end"], "the run must announce both of its ends",);
 
     // The walker stops at expressions too, so it can only be asked for a
     // superset — that the VM stops nowhere Rhai would not.
     let (walker_engine, walker) = recording(|_| DebuggerCommand::StepInto);
-    walker_run(&walker_engine,THREE);
+    walker_run(&walker_engine, THREE);
     for line in lines(&log) {
-        assert!(
-            lines(&walker).contains(&line),
-            "line {line} is a stop the walker does not have: {:?}",
-            lines(&walker),
-        );
+        assert!(lines(&walker).contains(&line), "line {line} is a stop the walker does not have: {:?}", lines(&walker),);
     }
 }
 
@@ -283,45 +245,29 @@ fn a_break_point_stops_a_compiled_statement() {
     };
 
     let (engine, log) = breaking(vec![point()], |_| DebuggerCommand::Continue);
-    vm_run(&engine,THREE);
+    vm_run(&engine, THREE);
 
-    assert_eq!(
-        stops(&log)
-            .iter()
-            .filter(|stop| stop.event == "break")
-            .map(|stop| stop.line)
-            .collect::<Vec<_>>(),
-        vec![2],
-        "the break-point on line 2 fired once, at line 2",
-    );
+    assert_eq!(stops(&log).iter().filter(|stop| stop.event == "break").map(|stop| stop.line).collect::<Vec<_>>(), vec![2], "the break-point on line 2 fired once, at line 2",);
 
     // Rhai's own count is not one: a line matches the statement's node and
     // every expression node on it. Agreement is that the line stops at all.
     let (walker_engine, walker) = breaking(vec![point()], |_| DebuggerCommand::Continue);
-    walker_run(&walker_engine,THREE);
-    assert!(
-        stops(&walker).iter().any(|stop| stop.event == "break"),
-        "the walker did not stop for the same break-point: {:?}",
-        stops(&walker),
-    );
+    walker_run(&walker_engine, THREE);
+    assert!(stops(&walker).iter().any(|stop| stop.event == "break"), "the walker did not stop for the same break-point: {:?}", stops(&walker),);
 }
 
 #[test]
 #[cfg(not(feature = "no_position"))]
 fn a_next_steps_over_a_call() {
     let (engine, log) = recording(|_| DebuggerCommand::Next);
-    vm_run(&engine,CALLING);
+    vm_run(&engine, CALLING);
 
     assert_eq!(lines(&log), vec![4, 5, 6], "the call's own line, not its body");
 
     let (walker_engine, walker) = recording(|_| DebuggerCommand::Next);
-    walker_run(&walker_engine,CALLING);
+    walker_run(&walker_engine, CALLING);
     for log in [&log, &walker] {
-        assert!(
-            !lines(log).contains(&2),
-            "a `next` stopped inside the callee: {:?}",
-            lines(log),
-        );
+        assert!(!lines(log).contains(&2), "a `next` stopped inside the callee: {:?}", lines(log),);
     }
 }
 
@@ -357,11 +303,7 @@ fn a_next_steps_over_a_block() {
     let (walker_engine, walker) = recording(|_| DebuggerCommand::Next);
     walker_run(&walker_engine, BLOCKED);
     for log in [&log, &walker] {
-        assert!(
-            !lines(log).iter().any(|line| [3, 4].contains(line)),
-            "a `next` stopped inside the block: {:?}",
-            lines(log),
-        );
+        assert!(!lines(log).iter().any(|line| [3, 4].contains(line)), "a `next` stopped inside the block: {:?}", lines(log),);
     }
 }
 
@@ -369,34 +311,16 @@ fn a_next_steps_over_a_block() {
 #[cfg(not(feature = "no_position"))]
 fn a_step_goes_into_a_call_and_reports_leaving_it() {
     let (engine, log) = recording(|_| DebuggerCommand::StepInto);
-    vm_run(&engine,CALLING);
+    vm_run(&engine, CALLING);
 
-    assert_eq!(
-        lines(&log),
-        vec![4, 5, 1, 2, 5, 6],
-        "entering the body, running its statement, and coming back out",
-    );
-    assert_eq!(
-        stops(&log)
-            .iter()
-            .find(|stop| stop.event == "exit")
-            .map(|stop| stop.detail.clone()),
-        Some("2".to_string()),
-        "leaving `inner` must report what it returned",
-    );
+    assert_eq!(lines(&log), vec![4, 5, 1, 2, 5, 6], "entering the body, running its statement, and coming back out",);
+    assert_eq!(stops(&log).iter().find(|stop| stop.event == "exit").map(|stop| stop.detail.clone()), Some("2".to_string()), "leaving `inner` must report what it returned",);
 
     // The value a body ended with is the one thing about leaving it that both
     // engines can state exactly.
     let (walker_engine, walker) = recording(|_| DebuggerCommand::StepInto);
-    walker_run(&walker_engine,CALLING);
-    assert_eq!(
-        stops(&walker)
-            .iter()
-            .find(|stop| stop.event == "exit")
-            .map(|stop| stop.detail.clone()),
-        Some("2".to_string()),
-        "the walker reports the same body's value",
-    );
+    walker_run(&walker_engine, CALLING);
+    assert_eq!(stops(&walker).iter().find(|stop| stop.event == "exit").map(|stop| stop.detail.clone()), Some("2".to_string()), "the walker reports the same body's value",);
 }
 
 /// A `throw` out of a call, caught outside it, so the run still finishes.
@@ -412,30 +336,16 @@ a
 #[test]
 fn leaving_a_call_by_raising_is_reported_as_an_error() {
     let (engine, log) = recording(|_| DebuggerCommand::StepInto);
-    vm_run(&engine,RAISING);
+    vm_run(&engine, RAISING);
 
-    let raised: Vec<_> = stops(&log)
-        .iter()
-        .filter(|stop| stop.event == "raised")
-        .map(|stop| stop.detail.clone())
-        .collect();
+    let raised: Vec<_> = stops(&log).iter().filter(|stop| stop.event == "raised").map(|stop| stop.detail.clone()).collect();
 
     assert_eq!(raised.len(), 1, "one call raised, so one such event: {:?}", stops(&log));
-    assert!(
-        raised[0].contains("42"),
-        "the event must carry the error the caller sees, got {:?}",
-        raised[0],
-    );
+    assert!(raised[0].contains("42"), "the event must carry the error the caller sees, got {:?}", raised[0],);
 
     let (walker_engine, walker) = recording(|_| DebuggerCommand::StepInto);
-    walker_run(&walker_engine,RAISING);
-    assert!(
-        stops(&walker)
-            .iter()
-            .any(|stop| stop.event == "raised" && stop.detail.contains("42")),
-        "the walker reports the same error: {:?}",
-        stops(&walker),
-    );
+    walker_run(&walker_engine, RAISING);
+    assert!(stops(&walker).iter().any(|stop| stop.event == "raised" && stop.detail.contains("42")), "the walker reports the same error: {:?}", stops(&walker),);
 }
 
 #[test]
@@ -454,28 +364,18 @@ fn a_function_exit_runs_the_rest_of_the_body() {
     };
 
     let (engine, log) = recording(reply);
-    vm_run(&engine,CALLING);
+    vm_run(&engine, CALLING);
 
     assert_eq!(
-        stops(&log)
-            .iter()
-            .find(|stop| stop.event == "exit")
-            .map(|stop| stop.detail.clone()),
+        stops(&log).iter().find(|stop| stop.event == "exit").map(|stop| stop.detail.clone()),
         Some("2".to_string()),
         "asking to leave `inner` must stop again as it is left: {:?}",
         stops(&log),
     );
 
     let (walker_engine, walker) = recording(reply);
-    walker_run(&walker_engine,CALLING);
-    assert_eq!(
-        stops(&walker)
-            .iter()
-            .find(|stop| stop.event == "exit")
-            .map(|stop| stop.detail.clone()),
-        Some("2".to_string()),
-        "the walker leaves it the same way",
-    );
+    walker_run(&walker_engine, CALLING);
+    assert_eq!(stops(&walker).iter().find(|stop| stop.event == "exit").map(|stop| stop.detail.clone()), Some("2".to_string()), "the walker leaves it the same way",);
 }
 
 /// What a callback declares must not disturb the program it stopped.
@@ -513,26 +413,14 @@ a + b
 ";
 
     let mut ours = Scope::new();
-    let value = Vm::new(&engine)
-        .eval_with_scope(&mut ours, &compiled(&engine, DECLARING))
-        .expect("must run");
+    let value = Vm::new(&engine).eval_with_scope(&mut ours, &compiled(&engine, DECLARING)).expect("must run");
 
     let mut walked = Scope::new();
     let expected = walker_eval_with(&engine, &mut walked, DECLARING);
 
-    assert_eq!(
-        format!("{value:?}"),
-        format!("{expected:?}"),
-        "a stop moved the slots underneath the statements after it",
-    );
-    assert!(
-        ours.get_value::<INT>("injected").is_none(),
-        "the callback's variable outlived the stop, so the slots are its problem now",
-    );
-    assert!(
-        walked.get_value::<INT>("injected").is_some(),
-        "Rhai no longer keeps what a callback declares, so this is not the difference",
-    );
+    assert_eq!(format!("{value:?}"), format!("{expected:?}"), "a stop moved the slots underneath the statements after it",);
+    assert!(ours.get_value::<INT>("injected").is_none(), "the callback's variable outlived the stop, so the slots are its problem now",);
+    assert!(walked.get_value::<INT>("injected").is_some(), "Rhai no longer keeps what a callback declares, so this is not the difference",);
 }
 
 /// A break-point on a *name* has nothing to match under the VM, and saying so
@@ -544,23 +432,13 @@ a + b
 /// the script never wrote. Position break-points cover the same line.
 #[test]
 fn a_break_point_on_a_function_name_cannot_fire_under_the_vm() {
-    let point = || BreakPoint::AtFunctionName {
-        name: "inner".into(),
-        enabled: true,
-    };
+    let point = || BreakPoint::AtFunctionName { name: "inner".into(), enabled: true };
 
     let (engine, log) = breaking(vec![point()], |_| DebuggerCommand::Continue);
-    vm_run(&engine,CALLING);
-    assert_eq!(
-        events(&log),
-        vec!["start", "end"],
-        "a name break-point stopped the VM, so this limitation is stale",
-    );
+    vm_run(&engine, CALLING);
+    assert_eq!(events(&log), vec!["start", "end"], "a name break-point stopped the VM, so this limitation is stale",);
 
     let (walker_engine, walker) = breaking(vec![point()], |_| DebuggerCommand::Continue);
-    walker_run(&walker_engine,CALLING);
-    assert!(
-        events(&walker).contains(&"break"),
-        "the walker no longer stops on a name either, so this is not the VM's gap",
-    );
+    walker_run(&walker_engine, CALLING);
+    assert!(events(&walker).contains(&"break"), "the walker no longer stops on a name either, so this is not the VM's gap",);
 }

--- a/tests/grain/format.rs
+++ b/tests/grain/format.rs
@@ -942,6 +942,25 @@ fn artifact_size_census() {
     // version, ABI and debug id would dominate a plain ratio and the density
     // this is watching would stop showing through.
     const HEADER: usize = 4 + 2 + 6 + 16;
-    let allowed = source_bytes * 3 + rows.len() * HEADER;
+
+    // Statement markers are allowed for the same way. A `debugging` build puts
+    // one before every statement so the debugger has somewhere to stop
+    // (`Op::Statement`) and no shipping artifact carries any, so counting them
+    // against the encoding would measure the wrong build. Three bytes of
+    // instruction and up to three of position-table entry, counted off the
+    // artifacts rather than guessed at; zero of them anywhere else.
+    const MARKER: usize = 3 + 3;
+    let markers: usize = written
+        .iter()
+        .filter_map(|(_, _, bytes)| Program::read(bytes).ok())
+        .map(|program| {
+            rhai::grain::bytecode::disassemble(program.code())
+                .filter(|(_, op)| matches!(op, rhai::grain::bytecode::Op::Statement { .. }))
+                .count()
+        })
+        .sum();
+    println!("{markers} statement markers, allowed {} bytes", markers * MARKER);
+
+    let allowed = source_bytes * 3 + rows.len() * HEADER + markers * MARKER;
     assert!(artifact_bytes < allowed, "{artifact_bytes} artifact bytes for {source_bytes} of source across {} scripts is not an encoding", rows.len(),);
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -16,6 +16,11 @@ mod grain {
     // method-call syntax to reach the native by.
     #[cfg(not(any(feature = "no_function", feature = "no_index", feature = "no_object")))]
     mod callback;
+    // `back_trace` is registered by the `debugging` package, hands back an array,
+    // and has nothing to report unless a script function was called.
+    #[cfg(feature = "debugging")]
+    #[cfg(not(any(feature = "no_function", feature = "no_index")))]
+    mod debugger;
     mod differential;
     mod format;
     // Both are about execution staying inside a bound, which `unchecked`


### PR DESCRIPTION
Add hooks to pass the debugging tests that previously failed. Also adds a disassembly example.