### PR TITLE
Resolve ambiguity in function pointer resolution.

### DIFF
--- a/src/grain/compile/poolable.rs
+++ b/src/grain/compile/poolable.rs
@@ -23,6 +23,17 @@ use rust_decimal::Decimal;
 /// created against. Keeping it out of the pool leaves it as a fragment, which
 /// evaluates through the path that does the attaching.
 pub(crate) fn is_poolable(value: &Dynamic) -> bool {
+    // A shared cell first, because every question below sees through one:
+    // `is_array` and friends unwrap `Union::Shared`, so a shared array of ints
+    // would answer yes and be pooled by cloning the `Rc` — leaving the pool
+    // aliasing a cell the host can still write to. Nothing a `Program` owns may
+    // alias mutable state: the pool is immutable after `Program::new`, and that
+    // is what makes the reference graph among programs acyclic.
+    #[cfg(not(feature = "no_closure"))]
+    if value.is_shared() {
+        return false;
+    }
+
     // Under `no_float` Rhai has no float type and no `is_float` to ask, so
     // there is nothing here for the question to be about.
     #[cfg(not(feature = "no_float"))]

--- a/src/grain/mod.rs
+++ b/src/grain/mod.rs
@@ -131,5 +131,5 @@ mod vm;
 
 pub use compile::Compiler;
 pub use format::{Sidecar, Stripped};
-pub use program::Program;
+pub use program::{Program, SharedProgram};
 pub use vm::{Fault, Vm};

--- a/src/grain/vm/callback.rs
+++ b/src/grain/vm/callback.rs
@@ -125,7 +125,13 @@ fn invoke(
     // anything it still needs.
     let values: FnArgsVec<Dynamic> = args.iter_mut().map(|arg| mem::take(*arg)).collect();
 
-    Vm::reentrant(context).call_function(
+    let mut vm = Vm::reentrant(context);
+    // A chunk reached this way can itself build a closure, and that pointer
+    // needs the program as much as one built in the outer run does.
+    #[cfg(not(feature = "no_function"))]
+    vm.adopt(program);
+
+    vm.call_function(
         program,
         name,
         values,

--- a/src/grain/vm/callback.rs
+++ b/src/grain/vm/callback.rs
@@ -75,6 +75,14 @@ pub(super) fn wrappers(program: &SharedProgram) -> Module {
         // its declared arity (`types/fn_ptr.rs:501-535`); a name-only pointer,
         // which is all a wrapper can be, cannot. So these are left to Rhai,
         // and `Program::needs_walker` is what keeps its copy alive for them.
+        //
+        // Registering one arity wider and taking the first argument as the
+        // receiver does not rescue it, and fails quietly. The receiver is not
+        // argument zero: for a *curried* pointer Rhai splices the captures in
+        // first and inserts the receiver after them (`types/fn_ptr.rs`, "curry +
+        // this_ptr + args"), so `for_each(|| t += this)` hands such a wrapper
+        // `[t, element]` and binding argument zero writes the sum into the
+        // capture's place. The corpus case of that name is what catches it.
         if function.takes_this {
             continue;
         }

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -401,6 +401,17 @@ pub struct Vm<'e> {
     /// it no longer has would address whatever took its place. Only a caller
     /// holding a [`SharedProgram`] can give it one, so this is `None` under
     /// [`Vm::eval_with_scope`], where a pointer stays late-bound by name.
+    ///
+    /// That the two entry points hand out different pointers is safe for one
+    /// reason, and it is worth stating because it is the thing that could rot:
+    /// a pointer's declared arity is read *only* when a native sizes a call
+    /// through it, a native can reach a compiled chunk *only* through the
+    /// wrappers module, and the wrappers are installed by exactly the calls
+    /// that set this field. So a pointer that cannot describe itself is also a
+    /// pointer no native can reach — such a call fails on the name instead,
+    /// which `callback.rs::without_the_wrappers_the_pointer_does_not_resolve`
+    /// pins. Register wrappers anywhere this is left `None` and that stops
+    /// being true.
     #[cfg(not(feature = "no_function"))]
     owner: Option<SharedProgram>,
     /// Whether this `Vm` started the run, and so may clear its trace.

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -394,6 +394,15 @@ pub struct Vm<'e> {
     /// caller's back on the way out, reproducing `func/call.rs:669` without a
     /// conditional anywhere.
     this: Option<Dynamic>,
+    /// Shared ownership of the running program, where the caller had some.
+    ///
+    /// A function pointer that names a compiled chunk has to carry the program
+    /// with it — it outlives the call that made it, and an index into a table
+    /// it no longer has would address whatever took its place. Only a caller
+    /// holding a [`SharedProgram`] can give it one, so this is `None` under
+    /// [`Vm::eval_with_scope`], where a pointer stays late-bound by name.
+    #[cfg(not(feature = "no_function"))]
+    owner: Option<SharedProgram>,
     /// Whether this `Vm` started the run, and so may clear its trace.
     ///
     /// False for a [`Vm::reentrant`]: a callback clearing the trace would
@@ -482,6 +491,8 @@ impl<'e> Vm<'e> {
             sizes: Vec::new(),
             unwind_floor: 0,
             this: None,
+            #[cfg(not(feature = "no_function"))]
+            owner: None,
             owns_trace: true,
             chain_step: 0,
             pending_slot: None,
@@ -522,6 +533,10 @@ impl<'e> Vm<'e> {
             // A crossing carries no receiver: Rhai binds one only where it
             // dispatches a method, and this arrives through `call_fn_raw`.
             this: None,
+            // Filled by whoever holds the program — `callback::invoke` does,
+            // and hands it over before running anything.
+            #[cfg(not(feature = "no_function"))]
+            owner: None,
             // `global` is a clone, so the trace is shared with the run that
             // called in and is not this call's to clear.
             owns_trace: false,
@@ -873,7 +888,54 @@ impl<'e> Vm<'e> {
     pub fn eval_with_callbacks(&mut self, scope: &mut Scope, program: &SharedProgram) -> VmResult {
         let wrappers =
             (!program.functions().is_empty()).then(|| callback::wrappers(program).into());
-        self.run_with(program, scope, wrappers)
+        #[cfg(not(feature = "no_function"))]
+        let restore = self.adopt(program);
+        let result = self.run_with(program, scope, wrappers);
+        #[cfg(not(feature = "no_function"))]
+        self.release(restore);
+        result
+    }
+
+    /// Take shared ownership of `program` for the duration of a run, returning
+    /// what was there to be put back.
+    ///
+    /// A `Vm` outlives a single run, so this is saved and restored rather than
+    /// assigned: a second run of a different program must not hand out pointers
+    /// into the first.
+    #[cfg(not(feature = "no_function"))]
+    pub(super) fn adopt(&mut self, program: &SharedProgram) -> Option<SharedProgram> {
+        self.owner.replace(program.clone())
+    }
+
+    /// Put back what [`Vm::adopt`] displaced.
+    #[cfg(not(feature = "no_function"))]
+    pub(super) fn release(&mut self, previous: Option<SharedProgram>) {
+        self.owner = previous;
+    }
+
+    /// How a pointer to the function named `name_index` should describe itself.
+    ///
+    /// [`FnPtrType::Compiled`] where the answer is unambiguous and we have the
+    /// program to point into, and [`FnPtrType::Normal`] otherwise — a
+    /// late-bound name, which is what every such pointer was before.
+    #[cfg(not(feature = "no_function"))]
+    fn compiled_pointer(&self, program: &Program, name_index: u32) -> FnPtrType {
+        if let Some(owner) = self.owner.as_ref() {
+            let mut found = program
+                .functions()
+                .iter()
+                .enumerate()
+                .filter(|(_, f)| f.name == name_index && f.this_type.is_none());
+
+            if let (Some((index, _)), None) = (found.next(), found.next()) {
+                return FnPtrType::Compiled {
+                    program: owner.clone(),
+                    index: index as u32,
+                };
+            }
+        }
+
+        FnPtrType::Normal
     }
 
     fn run_with(
@@ -3777,6 +3839,22 @@ impl<'e> Vm<'e> {
                     let name = program
                         .name(index)
                         .ok_or_else(|| malformed(format!("no name {index}")))?;
+                    // A pointer that can answer its own shape, where the caller
+                    // gave us the program to answer from. Rhai's natives size a
+                    // callback from the pointer's declared arity, and a
+                    // name-only pointer leaves them guessing — which is how
+                    // `reduce` came to bind its accumulator and its element the
+                    // wrong way round (`types/fn_ptr.rs`).
+                    //
+                    // Only where exactly one compiled function bears the name:
+                    // this instruction also serves `Fn("f")` folded to a
+                    // constant, and a name with two arities has no one shape to
+                    // declare. Ambiguity stays late-bound.
+                    #[cfg(not(feature = "no_function"))]
+                    let typ = self.compiled_pointer(program, index);
+                    #[cfg(feature = "no_function")]
+                    let typ = FnPtrType::Normal;
+
                     // Non-validated, because `anon$…` is not a name a script could
                     // have written and the validating constructors refuse it.
                     // Nothing unsound rides on that check — a name that will
@@ -3787,7 +3865,7 @@ impl<'e> Vm<'e> {
                             curry: ThinVec::new(),
                             #[cfg(not(feature = "no_function"))]
                             env: None,
-                            typ: FnPtrType::Normal,
+                            typ,
                         }
                         .into(),
                     );

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -929,9 +929,23 @@ impl<'e> Vm<'e> {
     /// [`FnPtrType::Compiled`] where the answer is unambiguous and we have the
     /// program to point into, and [`FnPtrType::Normal`] otherwise — a
     /// late-bound name, which is what every such pointer was before.
+    ///
+    /// Anonymous only, and that is the whole of what keeps a declared shape from
+    /// changing which function runs. `Fn("f")` takes a *string*: it means
+    /// whatever `f` turns out to be at the arity the caller asks for, and Rhai
+    /// resolves it by trying shapes until one dispatches. Declaring a shape
+    /// resolves it here instead, which is a different answer as soon as anything
+    /// else — a host's function, an overload the compiler could not lower — sits
+    /// at a shape Rhai would have reached first. A closure's name is the
+    /// parser's, cannot collide with one, and is the case a native callback
+    /// actually needs sized.
     #[cfg(not(feature = "no_function"))]
     fn compiled_pointer(&self, program: &Program, name_index: u32) -> FnPtrType {
-        if let Some(owner) = self.owner.as_ref() {
+        let anonymous = program
+            .name(name_index)
+            .map_or(false, crate::parser::is_anonymous_fn);
+
+        if let (Some(owner), true) = (self.owner.as_ref(), anonymous) {
             let mut found = program
                 .functions()
                 .iter()

--- a/src/types/fn_ptr.rs
+++ b/src/types/fn_ptr.rs
@@ -26,6 +26,22 @@ pub enum FnPtrType {
     /// Pre-calculated hash of a script-defined function.
     #[cfg(not(feature = "no_function"))]
     Script { num_params: usize, hash: u64 },
+    /// A function the Grain VM compiled, addressed in its own table.
+    ///
+    /// Distinct from [`Script`][FnPtrType::Script], which says two things at
+    /// once: how many parameters the function takes, *and* that it resolves to
+    /// an AST body at a hash in `global.lib[0]`. A compiled function has the
+    /// first and not the second, so claiming `Script` would be a lie the
+    /// dispatcher acts on.
+    ///
+    /// The program travels with the pointer rather than the index alone: a
+    /// pointer escapes to the host, and a bare index into a table it no longer
+    /// has would address whatever happened to be there.
+    #[cfg(all(feature = "grain", not(feature = "no_function")))]
+    Compiled {
+        program: crate::grain::SharedProgram,
+        index: u32,
+    },
     /// Embedded native Rust function.
     #[cfg(not(feature = "sync"))]
     Native(Shared<dyn Fn(NativeCallContext, &mut FnCallArgs) -> RhaiResult + 'static>),
@@ -43,6 +59,11 @@ impl fmt::Display for FnPtrType {
             Self::Normal => f.write_str("Fn"),
             #[cfg(not(feature = "no_function"))]
             Self::Script { .. } => f.write_str("Fn*"),
+            // Its own mark rather than `Fn` or `Fn*`: the first would hide that
+            // the pointer knows its own shape, the second would claim an AST
+            // body it does not have.
+            #[cfg(all(feature = "grain", not(feature = "no_function")))]
+            Self::Compiled { .. } => f.write_str("Fn#"),
             Self::Native(..) => f.write_str("Fn"),
         }
     }

--- a/src/types/fn_ptr.rs
+++ b/src/types/fn_ptr.rs
@@ -38,11 +38,18 @@ pub enum FnPtrType {
     /// pointer escapes to the host, and a bare index into a table it no longer
     /// has would address whatever happened to be there.
     ///
-    /// What this variant is *for* is declaring the callee's shape, which only
-    /// [`FnPtr::declared_shape`] and its one caller read. Everywhere else — the
-    /// dispatch arms in `func/call.rs`, and [`FnPtr::call_raw`] — it deliberately
-    /// falls through to dispatch by name, exactly as [`Normal`][FnPtrType::Normal]
-    /// does, reaching the chunk through the wrapper the VM registered for it
+    /// Only ever an *anonymous* function. A name a script could have written is
+    /// late-bound — `Fn("f")` is whatever `f` is at the arity the caller asks
+    /// for — and declaring a shape would settle that here instead, picking a
+    /// different function from the one Rhai would have found. See
+    /// `Vm::compiled_pointer`.
+    ///
+    /// What this variant is *for* is declaring the callee's shape, and two
+    /// places read it: [`FnPtrType::declared_params`] for how many parameters the
+    /// chunk takes, and [`FnPtr::call_raw`] for whether it can be handed a
+    /// receiver. The dispatch arms in `func/call.rs` ignore it and fall through
+    /// to dispatch by name, exactly as [`Normal`][FnPtrType::Normal] does,
+    /// reaching the chunk through the wrapper the VM registered for it
     /// (`grain/vm/callback.rs`). That is not an oversight: routing a call
     /// straight into the chunk is a larger change, and leaving those sites alone
     /// keeps this variant a strict improvement on the name-only pointer rather
@@ -94,6 +101,29 @@ impl FnPtrType {
             Self::Script { num_params, hash } if *num_params == num_args => {
                 global.lib[0].get_script_fn_by_hash(*hash)
             }
+            _ => None,
+        }
+    }
+
+    /// How many parameters the callee declares.
+    ///
+    /// [`None`] where the pointer cannot say — a bare name, or a native — which
+    /// leaves the caller to guess a shape and correct itself from the resulting
+    /// `ErrorFunctionNotFound`.
+    ///
+    /// Says nothing about the receiver: whether the callee can be handed one is
+    /// [`FnPtr::call_raw`]'s to decide, and it decides the same way wherever the
+    /// call came from.
+    #[must_use]
+    fn declared_params(&self) -> Option<usize> {
+        match self {
+            #[cfg(not(feature = "no_function"))]
+            Self::Script { num_params, .. } => Some(*num_params),
+            #[cfg(all(feature = "grain", not(feature = "no_function")))]
+            Self::Compiled { program, index } => program
+                .functions()
+                .get(*index as usize)
+                .map(|f| f.params.len()),
             _ => None,
         }
     }
@@ -491,6 +521,31 @@ impl FnPtr {
             );
         }
 
+        // A compiled chunk that does not read the receiver cannot be handed one.
+        //
+        // It is reached by name, through a wrapper registered at the chunk's own
+        // arity (`grain/vm/callback.rs`), so a receiver becomes argument zero and
+        // the call is one argument too wide to resolve at all. Rhai's own pointer
+        // has nothing to decide here: a script body binds `this` whether or not
+        // it reads it.
+        //
+        // Here rather than in [`FnPtr::call_raw_with_extra_args`] because this is
+        // the entry every caller reaches — including a host's native, which can
+        // hand over a receiver without going through the argument-shaping above.
+        #[cfg(all(feature = "grain", not(feature = "no_function")))]
+        if let FnPtrType::Compiled { ref program, index } = self.typ {
+            // Read through the index rather than stored beside it: the pointer
+            // carries the program, so the answer is one bounds check away and a
+            // copy in the pointer would be a second place for it to be wrong.
+            if !program
+                .functions()
+                .get(index as usize)
+                .map_or(false, |f| f.takes_this)
+            {
+                this_ptr = None;
+            }
+        }
+
         // Embedded native Rust function?
         match self.typ {
             FnPtrType::Native(ref func) => {
@@ -602,32 +657,6 @@ impl FnPtr {
             }
         }
     }
-    /// How many parameters the callee declares, and whether it can be *handed*
-    /// the receiver rather than having it materialised into the arguments.
-    ///
-    /// [`None`] where the pointer cannot say — a bare name, or a native — which
-    /// leaves the caller to guess a shape and correct itself from the resulting
-    /// `ErrorFunctionNotFound`.
-    ///
-    /// The second half is not decoration. A script body binds `this` whether or
-    /// not it reads it, so Rhai's own pointers answer `true` unconditionally. A
-    /// compiled chunk is reached through a wrapper registered at one arity, and
-    /// only a chunk that reads the receiver is reachable that way at all
-    /// (`grain/vm/callback.rs`) — so handing one to a chunk that does not take
-    /// it means calling a wrapper with an argument too many.
-    #[must_use]
-    fn declared_shape(&self) -> Option<(usize, bool)> {
-        match self.typ {
-            #[cfg(not(feature = "no_function"))]
-            FnPtrType::Script { num_params, .. } => Some((num_params, true)),
-            #[cfg(all(feature = "grain", not(feature = "no_function")))]
-            FnPtrType::Compiled { ref program, index } => program
-                .functions()
-                .get(index as usize)
-                .map(|f| (f.params.len(), f.takes_this)),
-            _ => None,
-        }
-    }
 
     /// Make a call to a function pointer with either a specified number of arguments, or with extra
     /// arguments attached.
@@ -640,16 +669,12 @@ impl FnPtr {
         extras: [Dynamic; E],
         move_this_ptr_to_args: usize,
     ) -> RhaiResult {
-        if let Some((num_params, binds_this)) = self.declared_shape() {
+        if let Some(num_params) = self.typ.declared_params() {
             if num_params == N + self.curry().len() {
-                // `binds_this` is what separates a callee that will be *handed*
-                // the receiver from one that cannot take it. Rhai's own pointers
-                // reach a script body, which binds `this` whether or not it
-                // reads it; a compiled chunk is reached by name, and `call_raw`
-                // would splice the receiver in as argument zero — one more
-                // argument than the callee has room for.
-                let receiver = if binds_this { this_ptr } else { None };
-                return self.call_raw(ctx, receiver, args);
+                // The callee asked for no more than the arguments, so the
+                // receiver stays a receiver. Whether it can take one at all is
+                // `call_raw`'s to answer.
+                return self.call_raw(ctx, this_ptr, args);
             }
             if MOVE_PTR {
                 if let Some(this_ptr) = this_ptr.as_deref() {
@@ -683,11 +708,9 @@ impl FnPtr {
                 let mut args2 = FnArgsVec::with_capacity(args.len() + extras.len());
                 args2.extend(args);
                 args2.extend(extras);
-                // Same reasoning as the first row: the callee asked for the
-                // extras and not for the receiver, so the receiver must stay out
-                // of the argument list.
-                let receiver = if binds_this { this_ptr } else { None };
-                return self.call_raw(ctx, receiver, args2);
+                // As in the first row: the callee asked for the extras, not for
+                // the receiver materialised beside them.
+                return self.call_raw(ctx, this_ptr, args2);
             }
         }
 

--- a/src/types/fn_ptr.rs
+++ b/src/types/fn_ptr.rs
@@ -37,6 +37,16 @@ pub enum FnPtrType {
     /// The program travels with the pointer rather than the index alone: a
     /// pointer escapes to the host, and a bare index into a table it no longer
     /// has would address whatever happened to be there.
+    ///
+    /// What this variant is *for* is declaring the callee's shape, which only
+    /// [`FnPtr::declared_shape`] and its one caller read. Everywhere else — the
+    /// dispatch arms in `func/call.rs`, and [`FnPtr::call_raw`] — it deliberately
+    /// falls through to dispatch by name, exactly as [`Normal`][FnPtrType::Normal]
+    /// does, reaching the chunk through the wrapper the VM registered for it
+    /// (`grain/vm/callback.rs`). That is not an oversight: routing a call
+    /// straight into the chunk is a larger change, and leaving those sites alone
+    /// keeps this variant a strict improvement on the name-only pointer rather
+    /// than a second way to call one.
     #[cfg(all(feature = "grain", not(feature = "no_function")))]
     Compiled {
         program: crate::grain::SharedProgram,
@@ -592,6 +602,33 @@ impl FnPtr {
             }
         }
     }
+    /// How many parameters the callee declares, and whether it can be *handed*
+    /// the receiver rather than having it materialised into the arguments.
+    ///
+    /// [`None`] where the pointer cannot say — a bare name, or a native — which
+    /// leaves the caller to guess a shape and correct itself from the resulting
+    /// `ErrorFunctionNotFound`.
+    ///
+    /// The second half is not decoration. A script body binds `this` whether or
+    /// not it reads it, so Rhai's own pointers answer `true` unconditionally. A
+    /// compiled chunk is reached through a wrapper registered at one arity, and
+    /// only a chunk that reads the receiver is reachable that way at all
+    /// (`grain/vm/callback.rs`) — so handing one to a chunk that does not take
+    /// it means calling a wrapper with an argument too many.
+    #[must_use]
+    fn declared_shape(&self) -> Option<(usize, bool)> {
+        match self.typ {
+            #[cfg(not(feature = "no_function"))]
+            FnPtrType::Script { num_params, .. } => Some((num_params, true)),
+            #[cfg(all(feature = "grain", not(feature = "no_function")))]
+            FnPtrType::Compiled { ref program, index } => program
+                .functions()
+                .get(index as usize)
+                .map(|f| (f.params.len(), f.takes_this)),
+            _ => None,
+        }
+    }
+
     /// Make a call to a function pointer with either a specified number of arguments, or with extra
     /// arguments attached.
     fn _call_with_extra_args<const MOVE_PTR: bool, const N: usize, const E: usize>(
@@ -603,48 +640,55 @@ impl FnPtr {
         extras: [Dynamic; E],
         move_this_ptr_to_args: usize,
     ) -> RhaiResult {
-        match self.typ {
-            #[cfg(not(feature = "no_function"))]
-            FnPtrType::Script { num_params, .. } => {
-                if num_params == N + self.curry().len() {
-                    return self.call_raw(ctx, this_ptr, args);
-                }
-                if MOVE_PTR {
-                    if let Some(this_ptr) = this_ptr.as_deref() {
-                        if num_params == N + 1 + self.curry().len() {
-                            let mut args2 = FnArgsVec::with_capacity(args.len() + 1);
-                            if move_this_ptr_to_args == 0 {
-                                args2.push(this_ptr.clone());
-                                args2.extend(args);
-                            } else {
-                                args2.extend(args);
-                                args2.insert(move_this_ptr_to_args, this_ptr.clone());
-                            }
-                            return self.call_raw(ctx, None, args2);
+        if let Some((num_params, binds_this)) = self.declared_shape() {
+            if num_params == N + self.curry().len() {
+                // `binds_this` is what separates a callee that will be *handed*
+                // the receiver from one that cannot take it. Rhai's own pointers
+                // reach a script body, which binds `this` whether or not it
+                // reads it; a compiled chunk is reached by name, and `call_raw`
+                // would splice the receiver in as argument zero — one more
+                // argument than the callee has room for.
+                let receiver = if binds_this { this_ptr } else { None };
+                return self.call_raw(ctx, receiver, args);
+            }
+            if MOVE_PTR {
+                if let Some(this_ptr) = this_ptr.as_deref() {
+                    if num_params == N + 1 + self.curry().len() {
+                        let mut args2 = FnArgsVec::with_capacity(args.len() + 1);
+                        if move_this_ptr_to_args == 0 {
+                            args2.push(this_ptr.clone());
+                            args2.extend(args);
+                        } else {
+                            args2.extend(args);
+                            args2.insert(move_this_ptr_to_args, this_ptr.clone());
                         }
-                        if num_params == N + E + 1 + self.curry().len() {
-                            let mut args2 = FnArgsVec::with_capacity(args.len() + extras.len() + 1);
-                            if move_this_ptr_to_args == 0 {
-                                args2.push(this_ptr.clone());
-                                args2.extend(args);
-                                args2.extend(extras);
-                            } else {
-                                args2.extend(args);
-                                args2.extend(extras);
-                                args2.insert(move_this_ptr_to_args, this_ptr.clone());
-                            }
-                            return self.call_raw(ctx, None, args2);
+                        return self.call_raw(ctx, None, args2);
+                    }
+                    if num_params == N + E + 1 + self.curry().len() {
+                        let mut args2 = FnArgsVec::with_capacity(args.len() + extras.len() + 1);
+                        if move_this_ptr_to_args == 0 {
+                            args2.push(this_ptr.clone());
+                            args2.extend(args);
+                            args2.extend(extras);
+                        } else {
+                            args2.extend(args);
+                            args2.extend(extras);
+                            args2.insert(move_this_ptr_to_args, this_ptr.clone());
                         }
+                        return self.call_raw(ctx, None, args2);
                     }
                 }
-                if num_params == N + E + self.curry().len() {
-                    let mut args2 = FnArgsVec::with_capacity(args.len() + extras.len());
-                    args2.extend(args);
-                    args2.extend(extras);
-                    return self.call_raw(ctx, this_ptr, args2);
-                }
             }
-            _ => (),
+            if num_params == N + E + self.curry().len() {
+                let mut args2 = FnArgsVec::with_capacity(args.len() + extras.len());
+                args2.extend(args);
+                args2.extend(extras);
+                // Same reasoning as the first row: the callee asked for the
+                // extras and not for the receiver, so the receiver must stay out
+                // of the argument list.
+                let receiver = if binds_this { this_ptr } else { None };
+                return self.call_raw(ctx, receiver, args2);
+            }
         }
 
         self.call_raw(ctx, this_ptr.as_deref_mut(), args.clone())

--- a/tests/grain/callback.rs
+++ b/tests/grain/callback.rs
@@ -11,7 +11,7 @@
 use super::corpus;
 
 use rhai::grain::{Compiler, Vm};
-use rhai::{Dynamic, Engine, Scope};
+use rhai::{Dynamic, Engine, Scope, INT};
 
 /// Run a source through the VM with the callback wrappers installed.
 fn run(engine: &Engine, source: &str) -> Result<String, String> {
@@ -71,6 +71,67 @@ fn a_bare_function_name_is_a_pointer() {
     agree("fn double(x) { x * 2 } fn apply(f, v) { f.call(v) } apply(double, 4)");
     // A variable of the same name still wins over the function.
     agree("fn double(x) { x * 2 } let double = 7; double");
+}
+
+/// A native that hands a receiver straight to `FnPtr::call_raw`.
+///
+/// Every callback in Rhai's own library shapes its arguments first, and that is
+/// where a receiver meant for a chunk that cannot take one gets dropped. A
+/// host's native has no reason to: `call_raw` is public and takes an
+/// `Option<&mut Dynamic>`, so this is the shortest route from a receiver to a
+/// compiled chunk, and the drop has to happen there too.
+#[cfg(not(feature = "no_object"))]
+fn engine_that_hands_over_a_receiver() -> Engine {
+    let mut engine = corpus::engine();
+    engine.register_fn("apply_to", |ctx: rhai::NativeCallContext, receiver: &mut Dynamic, f: rhai::FnPtr| f.call_raw(&ctx, Some(receiver), []));
+    engine
+}
+
+#[test]
+#[cfg(not(feature = "no_object"))]
+fn a_native_can_hand_a_receiver_to_a_chunk_that_ignores_it() {
+    let engine = engine_that_hands_over_a_receiver();
+
+    // The chunk reads no receiver, so the wrapper is registered at no arguments
+    // and the one it is offered would make the call unresolvable.
+    let source = "let v = 21; v.apply_to(|| 42)";
+    assert_eq!(walk(&engine, source), Ok("42".to_string()));
+    assert_eq!(run(&engine, source), walk(&engine, source), "{source}");
+
+    // And one that does read it still gets it.
+    let source = "let v = 21; v.apply_to(|| this * 2)";
+    assert_eq!(walk(&engine, source), Ok("42".to_string()));
+    assert_eq!(run(&engine, source), walk(&engine, source), "{source}");
+}
+
+/// A pointer to a written name reaches the function Rhai reaches, which is
+/// whichever one fits the arity the caller settles on.
+///
+/// The engine here has a one-parameter `pick` beside the script's
+/// two-parameter one, so *which* of them a spelling reaches is visible in the
+/// answer. Without the collision every spelling agrees for free and the test
+/// says nothing, which is what the last assertion guards.
+///
+/// `Fn("pick")` is the late-bound spelling: Rhai tries shapes until one
+/// dispatches, and the one-parameter native is reached first. A compiled pointer
+/// that declared its chunk's arity would answer with the script function
+/// instead — right, arguably, and not what the walker does. See
+/// `Vm::compiled_pointer`.
+#[test]
+fn a_written_name_reaches_the_function_the_walker_reaches() {
+    let mut engine = corpus::engine();
+    engine.register_fn("pick", |_x: INT| -1 as INT);
+
+    const DECLARED: &str = "fn pick(v, i) { v + i } let a = [10, 20]; ";
+
+    for tail in ["a.map(Fn(\"pick\"))", "a.map(pick)", "a.map(|v, i| pick(v, i))"] {
+        let source = &format!("{DECLARED}{tail}");
+        assert_eq!(walk(&engine, source), run(&engine, source), "{source}");
+    }
+
+    let late = &format!("{DECLARED}a.map(Fn(\"pick\"))");
+    let early = &format!("{DECLARED}a.map(|v, i| pick(v, i))");
+    assert_ne!(run(&engine, late), run(&engine, early), "both spellings reached the same function, so the collision this rests on is gone",);
 }
 
 /// A capture arrives, and has the right value.

--- a/tests/grain/callback.rs
+++ b/tests/grain/callback.rs
@@ -53,6 +53,7 @@ fn a_native_can_call_a_closure_back() {
     agree("let a = [1, 2, 3, 4]; a.filter(|x| x % 2 == 0)");
 }
 
+
 #[test]
 fn a_native_can_call_a_named_function_back() {
     agree("fn double(x) { x * 2 } let a = [1, 2, 3]; a.map(Fn(\"double\"))");
@@ -164,16 +165,37 @@ fn a_callback_costs_more_call_levels() {
     }
 }
 
+/// The whole reason `eval_with_callbacks` exists. A plain eval leaves Rhai
+/// nowhere to look, and the failure is a lookup failure rather than anything
+/// worse.
+///
+/// It is also what keeps the two entry points from meaning different things.
+/// `eval_with_scope` borrows the program, so a pointer it builds has no shared
+/// ownership to carry and cannot declare how many parameters its chunk takes —
+/// which is what the natives above size their calls from. That weakness is
+/// unreachable rather than merely unlikely: the only route from a native to a
+/// compiled chunk is a wrapper, and the run that installs no wrappers is the
+/// same run that hands out the weaker pointer. The call dies on the name before
+/// an argument list is ever built.
+///
+/// Every shape the wrappers path had to be taught is checked, not just `map`:
+/// if one of them ever *did* resolve here it would be answering with whatever
+/// order a pointer that cannot describe itself happens to produce, which is the
+/// silent-wrong-answer case nothing else would catch.
 #[test]
 fn without_the_wrappers_the_pointer_does_not_resolve() {
-    // The whole reason `eval_with_callbacks` exists. A plain eval leaves Rhai
-    // nowhere to look, and the failure is a lookup failure rather than
-    // anything worse.
     let engine = corpus::engine();
-    let source = "let a = [1, 2, 3]; a.map(|x| x * 2)";
-    let ast = engine.compile(source).unwrap();
-    let program = Compiler::new().compile(&ast);
 
-    let err = Vm::new(&engine).eval_with_scope(&mut Scope::new(), &program).unwrap_err();
-    assert!(format!("{err:?}").contains("ErrorFunctionNotFound"), "{err}");
+    for source in [
+        "let a = [1, 2, 3]; a.map(|x| x * 2)",
+        "let a = [1, 2, 3]; a.reduce(|a, v| if a == () { v } else { a + v })",
+        "let s = 0; let a = [10, 20, 30]; a.for_each(|i| s += i); s",
+    ] {
+        let ast = engine.compile(source).unwrap();
+        let program = Compiler::new().compile(&ast);
+        assert!(program.makes_fn_pointers(), "{source} must be a program a host is told to run with callbacks",);
+
+        let err = Vm::new(&engine).eval_with_scope(&mut Scope::new(), &program).unwrap_err();
+        assert!(format!("{err:?}").contains("ErrorFunctionNotFound"), "{source}: {err}");
+    }
 }

--- a/tests/grain/callback.rs
+++ b/tests/grain/callback.rs
@@ -53,7 +53,6 @@ fn a_native_can_call_a_closure_back() {
     agree("let a = [1, 2, 3, 4]; a.filter(|x| x % 2 == 0)");
 }
 
-
 #[test]
 fn a_native_can_call_a_named_function_back() {
     agree("fn double(x) { x * 2 } let a = [1, 2, 3]; a.map(Fn(\"double\"))");
@@ -186,11 +185,7 @@ fn a_callback_costs_more_call_levels() {
 fn without_the_wrappers_the_pointer_does_not_resolve() {
     let engine = corpus::engine();
 
-    for source in [
-        "let a = [1, 2, 3]; a.map(|x| x * 2)",
-        "let a = [1, 2, 3]; a.reduce(|a, v| if a == () { v } else { a + v })",
-        "let s = 0; let a = [10, 20, 30]; a.for_each(|i| s += i); s",
-    ] {
+    for source in ["let a = [1, 2, 3]; a.map(|x| x * 2)", "let a = [1, 2, 3]; a.reduce(|a, v| if a == () { v } else { a + v })", "let s = 0; let a = [10, 20, 30]; a.for_each(|i| s += i); s"] {
         let ast = engine.compile(source).unwrap();
         let program = Compiler::new().compile(&ast);
         assert!(program.makes_fn_pointers(), "{source} must be a program a host is told to run with callbacks",);

--- a/tests/grain/corpus/mod.rs
+++ b/tests/grain/corpus/mod.rs
@@ -159,6 +159,7 @@ pub fn applies_to_this_build(name: &str) -> bool {
             name,
             "block_as_argument"
                 | "error_a_skipped_function_cannot_see_the_caller"
+                | "error_map_callback_this_and_an_argument"
                 | "error_wrong_arity"
                 | "for_over_captured_array"
                 | "for_return_from_body"
@@ -218,6 +219,7 @@ pub fn applies_to_this_build(name: &str) -> bool {
             | "error_host_index_bounds"
             | "error_index_into_an_unindexable_step"
             | "error_index_into_an_unindexable_step_deep"
+            | "error_map_callback_this_and_an_argument"
             | "error_no_function_for_the_receiver"
             | "error_property_on_a_temporary"
             | "error_temp_root_index_runs_first"
@@ -303,6 +305,7 @@ pub fn applies_to_this_build(name: &str) -> bool {
                 | "error_const_root_method_step"
                 | "error_fn_ptr_unknown_name"
                 | "error_index_into_an_unindexable_step_deep"
+                | "error_map_callback_this_and_an_argument"
                 | "error_map_write_through_an_absent_key"
                 | "error_method_on_a_variable"
                 | "error_op_assign_undefined_for_types"
@@ -820,6 +823,11 @@ pub const CASES: &[Case] = &[
     case("closure_for_each_binds_this", "let t = 0; [1, 2, 3].for_each(|| t += this); t"),
     // And the argument form, which takes the element as a parameter instead.
     case("closure_map_takes_an_argument", "[1, 2, 3].map(|x| x * 2)"),
+    // A callback that declares a parameter *and* reads `this`. The element goes
+    // into the parameter and nothing binds the receiver, so this is
+    // `ErrorUnboundThis` — the one shape a wrapper that took its first argument
+    // as a receiver would answer instead of raising.
+    case("error_map_callback_this_and_an_argument", "[1, 2, 3].map(|x| this + x)"),
     // `type_of` has no registered implementation anywhere — Rhai answers it by
     // name — so it is reached through the same door every other call is.
     // A constant argument is folded by the optimizer and proves nothing.

--- a/tests/grain/corpus/mod.rs
+++ b/tests/grain/corpus/mod.rs
@@ -203,7 +203,10 @@ pub fn applies_to_this_build(name: &str) -> bool {
             | "closure_filter_binds_this"
             | "closure_for_each_binds_this"
             | "closure_in_filter"
+            | "closure_in_for_each_index"
             | "closure_in_map"
+            | "closure_in_reduce"
+            | "closure_in_reduce_rev"
             | "closure_map_binds_this"
             | "closure_map_takes_an_argument"
             | "closure_shared_chain_root"
@@ -285,7 +288,12 @@ pub fn applies_to_this_build(name: &str) -> bool {
                 | "closure_filter_binds_this"
                 | "closure_for_each_binds_this"
                 | "closure_in_filter"
+                | "closure_in_for_each_index"
                 | "closure_in_map"
+                | "closure_in_map_filter"
+                | "closure_in_map_retain"
+                | "closure_in_reduce"
+                | "closure_in_reduce_rev"
                 | "closure_map_binds_this"
                 | "closure_map_takes_an_argument"
                 | "closure_shared_op_assign"
@@ -564,6 +572,20 @@ pub const CASES: &[Case] = &[
     case("is_shared_after_capture", "let x = 1; let r = false; { let f = || x; r = is_shared(f); } [is_shared(x), r]"),
     case("closure_in_map", "[1, 2, 3].map(|x| x * 2)"),
     case("closure_in_filter", "[1, 2, 3, 4].filter(|x| x % 2 == 0)"),
+    // Every native taking a callback offers it a menu of argument shapes and
+    // picks by the pointer's declared arity. `map` and `filter` want the element
+    // at index zero, which is also where a pointer that declares nothing ends up
+    // putting it — so they agree by luck and cover none of the rest.
+    //
+    // These four do not. `reduce` wants the element at index *one*, after the
+    // accumulator; `Map` hands the key as an argument and the value as the
+    // receiver; and `for_each` wants the index and the element as `this`, so a
+    // receiver spliced into the arguments is one too many.
+    case("closure_in_reduce", r#"[1, 2, 3].reduce(|a, v| if a == () { v } else { a + v })"#),
+    case("closure_in_reduce_rev", r#"[1, 2, 3].reduce_rev(|a, v| if a == () { v } else { a + v })"#),
+    case("closure_in_map_filter", r#"#{ a: 1, b: 2 }.filter(|k, v| v > 1).len()"#),
+    case("closure_in_map_retain", r#"let m = #{ a: 1, b: 2 }; m.retain(|k, v| v > 1); m.len()"#),
+    case("closure_in_for_each_index", "let s = 0; [10, 20, 30].for_each(|i| s += i); s"),
     // --- chained lvalues --------------------------------------------------
     // Each of these needs a different `Target` variant and its write-back.
     case("index_assign_array", "let a = [1, 2, 3]; a[1] = 99; a"),

--- a/tests/grain/scope.rs
+++ b/tests/grain/scope.rs
@@ -674,6 +674,28 @@ fn a_closure_pointer_carries_its_program_when_it_can() {
     assert!(owned.starts_with("Fn#(\"anon$"), "a program to carry, so its own kind: {owned}",);
 }
 
+/// A pointer to a name a script could have written stays late-bound, even with
+/// the program in hand to describe it with.
+///
+/// `Fn("f")` takes a string: it means whatever `f` is at the arity the caller
+/// asks for, and Rhai settles that by trying shapes until one dispatches. A
+/// pointer that declared a shape would settle it here instead — see
+/// `Vm::compiled_pointer` — so only an anonymous function gets one.
+#[test]
+#[cfg(not(feature = "no_function"))]
+fn a_pointer_to_a_written_name_does_not_declare_a_shape() {
+    let engine = corpus::engine();
+    let source = "fn pick(v, i) { v + i } let f = Fn(\"pick\"); f";
+
+    let ast = engine.compile(source).expect("must compile");
+    let program = Compiler::new().compile(&ast).into_shared();
+    assert_eq!(program.residual_count(), 0, "the pointer must lower");
+
+    let owned = Vm::new(&engine).eval_with_callbacks(&mut Scope::new(), &program).expect("must run");
+
+    assert!(format!("{owned:?}").starts_with("Fn(\"pick\""), "a written name must stay a bare name: {owned:?}",);
+}
+
 /// Calling a compiled function from outside, which is what a native wrapper
 /// will do once compiled chunks are registered for callbacks.
 #[test]

--- a/tests/grain/scope.rs
+++ b/tests/grain/scope.rs
@@ -643,6 +643,37 @@ fn a_closure_pointer_is_late_bound() {
     assert_ne!(ours, walker, "if these ever match, delete this test");
 }
 
+/// The same closure, run the way a program that hands pointers out must be run.
+///
+/// [`Vm::eval_with_scope`] borrows the program, so there is no shared ownership
+/// to put in a pointer and it stays late-bound by name — which is what the test
+/// above pins. [`Vm::eval_with_callbacks`] has some, and the pointer carries it:
+/// enough to answer how many parameters the chunk takes, which is what every
+/// native taking a callback sizes its call from.
+///
+/// Rendered apart from both of Rhai's kinds on purpose. `Fn` would hide that the
+/// pointer knows its own shape and `Fn*` would claim an AST body it does not
+/// have.
+#[test]
+#[cfg(not(feature = "no_function"))]
+fn a_closure_pointer_carries_its_program_when_it_can() {
+    let engine = corpus::engine();
+    let source = "let n = 1; let f = |x| x + n; f";
+
+    let ast = engine.compile(source).expect("must compile");
+    let program = Compiler::new().compile(&ast);
+    assert_eq!(program.residual_count(), 0, "the closure must lower");
+
+    let borrowed = Vm::new(&engine).eval_with_scope(&mut Scope::new(), &program).expect("must run");
+
+    let shared = program.into_shared();
+    let owned = Vm::new(&engine).eval_with_callbacks(&mut Scope::new(), &shared).expect("must run");
+
+    let (borrowed, owned) = (format!("{borrowed:?}"), format!("{owned:?}"));
+    assert!(borrowed.starts_with("Fn(\"anon$"), "no program to carry, so a bare name: {borrowed}",);
+    assert!(owned.starts_with("Fn#(\"anon$"), "a program to carry, so its own kind: {owned}",);
+}
+
 /// Calling a compiled function from outside, which is what a native wrapper
 /// will do once compiled chunks are registered for callbacks.
 #[test]


### PR DESCRIPTION
Grain had an issue where its use of `Normal` function pointers led to resultion ambiguity that caused incorrect behavior. For example:

```ts
let t = 0; [1,2,3].for_each(|i| t += i); t
```

Before, Grain would bind `i` to `this`, resulting in an incorrect value for `t` of 6 instead of 3. Now this no longer happens due to my introduction of `FnPtrType::Compiled`, which properly tracks function pointer information for Grain calls.