### PR TITLE
EXPERIMENTAL: compiled vm callback

### DIFF
--- a/fuzz/fuzz_targets/grain_generated.rs
+++ b/fuzz/fuzz_targets/grain_generated.rs
@@ -111,12 +111,7 @@ fn compare(engine: &Engine, source: &str) -> Option<(String, String)> {
 
     let program = Compiler::new().compile(&ast);
     let mut vm_scope = Scope::new();
-    let ours = if program.makes_fn_pointers() {
-        let program = program.into_shared();
-        Vm::new(engine).eval_with_callbacks(&mut vm_scope, &program)
-    } else {
-        Vm::new(engine).eval_with_scope(&mut vm_scope, &program)
-    };
+    let ours = Vm::new(engine).eval_with_callbacks(&mut vm_scope, &program);
     Some((outcome(&vm_scope, ours)?, expected))
 }
 

--- a/fuzz/fuzz_targets/grain_roundtrip.rs
+++ b/fuzz/fuzz_targets/grain_roundtrip.rs
@@ -87,18 +87,12 @@ fuzz_target!(|source: String| {
         return;
     };
 
-    let program = Compiler::new().compile(&ast);
+    let program = Compiler::new().compile(&ast).into_shared();
 
     let expected = outcome(|scope| engine.eval_ast_with_scope::<Dynamic>(scope, &ast));
     // A program that can hand a pointer to a native has to be run the way such
     // a program is meant to be run, or every one of them reads as a divergence.
-    let shared = program
-        .makes_fn_pointers()
-        .then(|| Compiler::new().compile(&ast).into_shared());
-    let run = |scope: &mut Scope| match &shared {
-        Some(shared) => Vm::new(&engine).eval_with_callbacks(scope, shared),
-        None => Vm::new(&engine).eval_with_scope(scope, &program),
-    };
+    let run = |scope: &mut Scope| Vm::new(&engine).eval_with_callbacks(scope, program);
 
     let direct = outcome(run);
     if expected == "budget" || direct == "budget" {

--- a/src/grain/compile/mod.rs
+++ b/src/grain/compile/mod.rs
@@ -157,9 +157,6 @@ impl Compiler {
                 name: f.name,
                 params: f.params,
                 this_type: f.this_type,
-                // Derived from the chunk by `Program::new`, which is the one
-                // place that can see the assembled bytes.
-                takes_this: false,
                 chunk: Chunk::new(
                     offsets[f.first_op],
                     offsets[f.first_op + f.op_count],
@@ -167,35 +164,6 @@ impl Compiler {
                 ),
             })
             .collect();
-
-        // Rhai's own functions are carried whenever anything might still reach
-        // for them: a function this compiler skipped, or a fragment that could
-        // call one. With neither, every call resolves in the table above and
-        // the library — an `AST`'s whole function tree — can be dropped.
-        //
-        // The third case is a pointer to a `this`-taking chunk. Rhai reaches a
-        // compiled function through a registered wrapper, and a wrapper is
-        // registered at one arity — but a native calling a pointer against a
-        // receiver decides for itself how many arguments to append beside it,
-        // so no single arity is right. Rhai's own pointer carries the body and
-        // sizes the call from it, which is what its copy is kept here for. See
-        // `callback::wrappers`, which skips exactly these.
-        #[cfg(not(feature = "no_function"))]
-        let lib = {
-            let escapes_as_pointer = crate::grain::program::makes_fn_pointers(&code)
-                && functions
-                    .iter()
-                    .any(|f| crate::grain::program::takes_this(&code, f.chunk, &lowering.chains));
-            let needs_walker = skipped > 0 || !lowering.residuals.is_empty() || escapes_as_pointer;
-            (needs_walker && !ast.shared_lib().is_empty()).then(|| ast.shared_lib().clone())
-        };
-        // Under `no_function` there is no function tree to carry, whichever way
-        // the fallbacks above went.
-        #[cfg(feature = "no_function")]
-        let lib = {
-            let _ = skipped;
-            None
-        };
 
         let mut program = Program::new(
             code.into(),
@@ -212,7 +180,6 @@ impl Compiler {
                 assign_ops: lowering.assign_ops,
                 chains: lowering.chains,
                 switches: lowering.switches,
-                lib,
                 #[cfg(not(feature = "no_module"))]
                 resolver: ast.resolver.clone(),
                 source: ast.source().map(Into::into),

--- a/src/grain/compile/poolable.rs
+++ b/src/grain/compile/poolable.rs
@@ -23,6 +23,17 @@ use rust_decimal::Decimal;
 /// created against. Keeping it out of the pool leaves it as a fragment, which
 /// evaluates through the path that does the attaching.
 pub(crate) fn is_poolable(value: &Dynamic) -> bool {
+    // A shared cell first, because every question below sees through one:
+    // `is_array` and friends unwrap `Union::Shared`, so a shared array of ints
+    // would answer yes and be pooled by cloning the `Rc` — leaving the pool
+    // aliasing a cell the host can still write to. Nothing a `Program` owns may
+    // alias mutable state: the pool is immutable after `Program::new`, and that
+    // is what makes the reference graph among programs acyclic.
+    #[cfg(not(feature = "no_closure"))]
+    if value.is_shared() {
+        return false;
+    }
+
     // Under `no_float` Rhai has no float type and no `is_float` to ask, so
     // there is nothing here for the question to be about.
     #[cfg(not(feature = "no_float"))]

--- a/src/grain/format/read.rs
+++ b/src/grain/format/read.rs
@@ -207,9 +207,6 @@ pub(super) fn read(bytes: &[u8]) -> Result<Program<'_>, ReadError> {
             name,
             this_type,
             params,
-            // Not encoded: derived from the chunk by `Program::new`, so a loaded
-            // program and a compiled one cannot disagree about it.
-            takes_this: false,
             chunk: get_chunk(&mut cursor)?,
         });
     }
@@ -248,9 +245,6 @@ pub(super) fn read(bytes: &[u8]) -> Result<Program<'_>, ReadError> {
             assign_ops,
             chains,
             switches,
-            // Script functions are still ASTs, so `write` refuses a program
-            // that has any and a loaded one never does.
-            lib: None,
             #[cfg(not(feature = "no_module"))]
             resolver: None,
             source,

--- a/src/grain/format/write.rs
+++ b/src/grain/format/write.rs
@@ -100,9 +100,6 @@ pub(super) fn write(program: &Program, positions: Positions) -> Result<Vec<u8>, 
             pos,
         });
     }
-    if program.lib().is_some() {
-        return Err(WriteError::HasScriptFunctions);
-    }
 
     let mut out = Vec::new();
     out.extend_from_slice(&MAGIC);

--- a/src/grain/mod.rs
+++ b/src/grain/mod.rs
@@ -149,5 +149,5 @@ mod vm;
 
 pub use compile::Compiler;
 pub use format::{Sidecar, Stripped};
-pub use program::Program;
+pub use program::{Program, SharedProgram};
 pub use vm::{Fault, Vm};

--- a/src/grain/program.rs
+++ b/src/grain/program.rs
@@ -7,8 +7,8 @@ use crate::module_resolvers::StaticModuleResolver;
 use crate::{ast::Expr, ast::Stmt, tokenizer::Token, Dynamic, ImmutableString, Module, Shared};
 
 use crate::grain::bytecode::{
-    site_to_position, sites, AssignOp, Chain, Chunk, Code, Op, Pools, Positions, Root, Strings,
-    Switch, TableError,
+    site_to_position, sites, AssignOp, Chain, Chunk, Code, Pools, Positions, Strings, Switch,
+    TableError,
 };
 use crate::grain::format::Sidecar;
 
@@ -47,12 +47,6 @@ pub struct Function {
     ///
     /// `None` for an ordinary function, which is nearly all of them.
     pub this_type: Option<u32>,
-    /// Whether the body reads or writes the frame's receiver.
-    ///
-    /// Derived from the chunk rather than encoded — see [`takes_this`]. It is
-    /// what keeps such a function reachable by Rhai, which needs the body to
-    /// size a call a native makes through a pointer.
-    pub takes_this: bool,
     pub chunk: Chunk,
 }
 
@@ -86,10 +80,6 @@ pub struct Program<'a> {
 
     /// The deepest chunk's operand-stack need, cached.
     max_stack: u16,
-
-    /// Whether the program can hand a function pointer to something that
-    /// might call it back. See [`Program::makes_fn_pointers`].
-    makes_fn_pointers: bool,
 
     /// Whether any function was declared for a receiver type.
     ///
@@ -147,15 +137,6 @@ pub struct Program<'a> {
     /// hasher that would disagree with it.
     switches: Vec<Switch>,
 
-    /// Script functions the compiler did not lower, as Rhai's own library, so
-    /// a fragment can still call one the ordinary way.
-    ///
-    /// `None` when the script declared none, which is every program that came
-    /// from an artifact. An empty `Module` is 264 bytes and a reference count,
-    /// which is a fifth of what loading a small program retains — worth not
-    /// allocating for something nothing will look in.
-    lib: Option<SharedModule>,
-
     /// Reinstated on the runtime state at each run, mirroring
     /// `Engine::eval_ast_with_scope_raw`, so `import` resolves as it would have.
     #[cfg(not(feature = "no_module"))]
@@ -178,10 +159,6 @@ impl core::fmt::Debug for Program<'_> {
             .field("names", &self.names.len())
             .field("residuals", &self.residuals.len())
             .field("compiled_fns", &self.functions.len())
-            .field(
-                "walked_fns",
-                &self.lib.as_ref().map_or(0, |lib| lib.count().1),
-            )
             .field("positions", &!self.positions.is_stripped())
             .finish()
     }
@@ -224,63 +201,6 @@ fn node_position(node: &ASTNode) -> rhai::Position {
     }
 }
 
-/// Whether any instruction in `code` produces a function pointer.
-///
-/// Read off the bytes rather than tracked while lowering, because a program
-/// read from an artifact has no lowering to have tracked it — and the answer
-/// has to be the same either way or one of the two paths silently loses its
-/// callbacks.
-///
-/// Deliberately over-broad: it says yes to a pointer that is only ever called
-/// directly. Narrowing it would mean deciding where a pointer *goes*, which is
-/// a dataflow question over values that outlive the instruction that made
-/// them. Being wrong the other way loses a call at run time.
-pub(crate) fn makes_fn_pointers(code: &[u8]) -> bool {
-    use crate::grain::bytecode::code::tag;
-
-    crate::grain::bytecode::disassemble(code)
-        .any(|(at, ..)| matches!(code[at], tag::MAKE_CLOSURE | tag::MAKE_FN_PTR | tag::CURRY))
-}
-
-/// Whether a chunk reads or writes the frame's receiver.
-///
-/// Read off the bytes for [`makes_fn_pointers`]'s reason: a program loaded from
-/// an artifact never saw the body it came from.
-///
-/// It decides whether Rhai has to be able to reach the function itself. A
-/// pointer to a `this`-taking chunk cannot go through a native wrapper — the
-/// wrapper is registered at one arity, and how many arguments Rhai will ask for
-/// depends on what the *native* appends, which the wrapper cannot know. So such
-/// a function is left to Rhai, which has the body and can size the call itself.
-pub(crate) fn takes_this(code: &[u8], chunk: Chunk, chains: &[Chain]) -> bool {
-    use crate::grain::bytecode::code::tag;
-
-    let (entry, end) = (chunk.entry() as usize, chunk.end() as usize);
-    if end > code.len() || entry > end {
-        return false;
-    }
-
-    crate::grain::bytecode::disassemble(&code[entry..end]).any(|(at, op)| {
-        match code[entry + at] {
-            tag::LOAD_THIS
-            | tag::LOAD_THIS_SHARED
-            | tag::REQUIRE_THIS
-            | tag::ASSIGN_THIS
-            | tag::ASSIGN_THIS_OP
-            | tag::CALL_THIS_REF
-            | tag::CALL_FN_PTR_ON_THIS => true,
-            // A chain says where it is rooted in the pool, not in the code.
-            tag::CHAIN => match op {
-                Op::Chain(index) => chains
-                    .get(index as usize)
-                    .map_or(false, |chain| matches!(chain.root, Root::This { .. })),
-                _ => false,
-            },
-            _ => false,
-        }
-    })
-}
-
 /// Everything a program holds besides its code, gathered so the constructor
 /// does not take ten positional arguments.
 pub(crate) struct Parts<'a> {
@@ -298,7 +218,6 @@ pub(crate) struct Parts<'a> {
     pub assign_ops: Vec<AssignOp>,
     pub chains: Vec<Chain>,
     pub switches: Vec<Switch>,
-    pub lib: Option<SharedModule>,
     #[cfg(not(feature = "no_module"))]
     pub resolver: Option<Shared<StaticModuleResolver>>,
     pub source: Option<ImmutableString>,
@@ -311,15 +230,7 @@ impl<'a> Program<'a> {
         functions: Vec<Function>,
         parts: Parts<'a>,
     ) -> Self {
-        let makes_fn_pointers = makes_fn_pointers(&code);
         let has_typed_methods = functions.iter().any(|f| f.this_type.is_some());
-
-        // Derived here so a program means the same whether it was compiled or
-        // loaded, and so the flag cannot disagree with the bytes it describes.
-        let mut functions = functions;
-        for function in &mut functions {
-            function.takes_this = takes_this(&code, function.chunk, &parts.chains);
-        }
 
         // Derived from the diagnostics it was built with, unless a loader
         // supplied the artifact's.
@@ -335,7 +246,6 @@ impl<'a> Program<'a> {
             main,
             functions,
             max_stack: 0,
-            makes_fn_pointers,
             has_typed_methods,
             positions: parts.positions,
             debug_id,
@@ -346,7 +256,6 @@ impl<'a> Program<'a> {
             assign_ops: parts.assign_ops,
             chains: parts.chains,
             switches: parts.switches,
-            lib: parts.lib,
             #[cfg(not(feature = "no_module"))]
             resolver: parts.resolver,
             source: parts.source,
@@ -366,7 +275,6 @@ impl<'a> Program<'a> {
             main: self.main,
             functions: self.functions,
             max_stack: self.max_stack,
-            makes_fn_pointers: self.makes_fn_pointers,
             has_typed_methods: self.has_typed_methods,
             positions: self.positions,
             debug_id: self.debug_id,
@@ -377,7 +285,6 @@ impl<'a> Program<'a> {
             assign_ops: self.assign_ops,
             chains: self.chains,
             switches: self.switches,
-            lib: self.lib,
             #[cfg(not(feature = "no_module"))]
             resolver: self.resolver,
             source: self.source,
@@ -386,10 +293,6 @@ impl<'a> Program<'a> {
 
     /// Give up the artifact and share the program, so a native can be handed a
     /// way back into it.
-    ///
-    /// What [`Vm::eval_with_callbacks`](crate::grain::Vm::eval_with_callbacks) takes.
-    /// Worth the copy only when [`makes_fn_pointers`](Self::makes_fn_pointers)
-    /// says a pointer can escape.
     #[must_use]
     pub fn into_shared(self) -> SharedProgram {
         Shared::new(self.into_owned())
@@ -512,23 +415,6 @@ impl<'a> Program<'a> {
         self.functions.iter().find(|f| {
             f.params.len() == argc && f.this_type.is_none() && self.name(f.name) == Some(name)
         })
-    }
-
-    /// Whether this program can hand a function pointer to something that
-    /// might call it back.
-    ///
-    /// A compiled function lives in this program's own table and nowhere Rhai
-    /// can see, so a native that calls a pointer — `map`, `filter` — cannot
-    /// reach one. Making it reachable means registering a wrapper, and Rhai
-    /// requires a registered function to be `'static`, so the wrapper has to
-    /// own the program: [`Program::into_owned`] first, at the cost of the
-    /// borrowed-from-the-artifact loading that is the point of the format.
-    ///
-    /// This is how a host decides whether to pay that, without having to read
-    /// the script. False is the common answer and costs nothing.
-    #[must_use]
-    pub fn makes_fn_pointers(&self) -> bool {
-        self.makes_fn_pointers
     }
 
     /// How much operand stack the deepest chunk needs.
@@ -757,10 +643,6 @@ impl<'a> Program<'a> {
         })
     }
 
-    pub(crate) fn lib(&self) -> Option<&SharedModule> {
-        self.lib.as_ref()
-    }
-
     #[cfg(not(feature = "no_module"))]
     pub(crate) fn resolver(&self) -> Option<&Shared<StaticModuleResolver>> {
         self.resolver.as_ref()
@@ -788,7 +670,6 @@ mod tests {
                 name,
                 params: vec![0; argc],
                 this_type,
-                takes_this: false,
                 chunk: whole,
             })
             .collect();
@@ -807,7 +688,6 @@ mod tests {
                 assign_ops: Vec::new(),
                 chains: Vec::new(),
                 switches: Vec::new(),
-                lib: None,
                 #[cfg(not(feature = "no_module"))]
                 resolver: None,
                 source: None,

--- a/src/grain/vm/callback.rs
+++ b/src/grain/vm/callback.rs
@@ -31,7 +31,7 @@ use core::mem;
 use std::prelude::v1::*;
 
 use crate::{
-    func::RhaiFunc, Dynamic, FnArgsVec, FuncRegistration, Module, NativeCallContext, Shared,
+    func::RhaiFunc, Dynamic, FnArgsVec, FuncRegistration, Module, NativeCallContext, Scope, Shared,
     SmartString,
 };
 
@@ -63,19 +63,11 @@ pub(super) fn wrappers(program: &SharedProgram) -> Module {
     }
 
     for function in program.functions() {
-        let arity = function.params.len();
+        // A compiled chunk automatically takes an additional argument
+        // for `this`, push to the very front.
+        let arity = function.params.len() + 1;
+
         if arity > MAX_PARAMS {
-            continue;
-        }
-        // A `this`-taking chunk cannot be reached this way. A wrapper is
-        // registered at one arity, and how many arguments Rhai asks for depends
-        // on what the *native* appends beside the receiver — `map` adds an
-        // index, `reduce` adds the running result — which the wrapper has no way
-        // to know. Rhai's own pointer carries the body and sizes the call from
-        // its declared arity (`types/fn_ptr.rs:501-535`); a name-only pointer,
-        // which is all a wrapper can be, cannot. So these are left to Rhai,
-        // and `Program::needs_walker` is what keeps its copy alive for them.
-        if function.takes_this {
             continue;
         }
         let Some(name) = program.name(function.name) else {
@@ -88,19 +80,26 @@ pub(super) fn wrappers(program: &SharedProgram) -> Module {
         // One closure for every arity, rather than the fixed-arity shapes
         // `Module::set_native_fn` generates. `Dynamic` parameters throughout
         // mean the types never have to line up, only the count.
+
         let wrapper = move |context: Option<NativeCallContext>, args: &mut [&mut Dynamic]| {
-            invoke(&owner, &called, context.as_ref(), args)
+            // Always extracts the first argument for `this`.
+            let (this_ptr, args) = args
+                .split_first_mut()
+                .ok_or_else(|| malformed("a callback wrapper was given no `this`".into()))?;
+
+            invoke_with_this(&owner, &called, context.as_ref(), args, Some(this_ptr))
         };
 
+        // Always register as a method.
         FuncRegistration::new(name)
             .in_internal_namespace()
             .set_into_module_raw(
                 &mut module,
                 vec![TypeId::of::<Dynamic>(); arity],
-                RhaiFunc::Pure {
+                RhaiFunc::Method {
                     func: Shared::new(wrapper),
                     has_context: true,
-                    is_pure: true,
+                    is_pure: false,
                     is_volatile: false,
                 },
             );
@@ -110,11 +109,12 @@ pub(super) fn wrappers(program: &SharedProgram) -> Module {
 }
 
 /// Run one chunk for a native that called back into us.
-fn invoke(
+fn invoke_with_this(
     program: &SharedProgram,
     name: &str,
     context: Option<&NativeCallContext>,
     args: &mut [&mut Dynamic],
+    this_ptr: Option<&mut Dynamic>,
 ) -> VmResult {
     // Registered with `has_context`, so Rhai always supplies one.
     let context =
@@ -125,11 +125,22 @@ fn invoke(
     // anything it still needs.
     let values: FnArgsVec<Dynamic> = args.iter_mut().map(|arg| mem::take(*arg)).collect();
 
-    Vm::reentrant(context).call_function(
+    let mut vm = Vm::reentrant(context);
+    // A chunk reached this way can itself build a closure, and that pointer
+    // needs the program as much as one built in the outer run does.
+    #[cfg(not(feature = "no_function"))]
+    vm.adopt(program);
+
+    let scope = &mut Scope::new();
+    vm.call_function_with_this(
         program,
         name,
         values,
         context.call_level(),
+        scope,
+        true,
         context.call_position(),
+        this_ptr.cloned(),
     )
+    .0
 }

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -387,6 +387,26 @@ pub struct Vm<'e> {
     /// caller's back on the way out, reproducing `func/call.rs:669` without a
     /// conditional anywhere.
     this: Option<Dynamic>,
+    /// Shared ownership of the running program, where the caller had some.
+    ///
+    /// A function pointer that names a compiled chunk has to carry the program
+    /// with it — it outlives the call that made it, and an index into a table
+    /// it no longer has would address whatever took its place. Only a caller
+    /// holding a [`SharedProgram`] can give it one, so this is `None` under
+    /// [`Vm::eval_with_scope`], where a pointer stays late-bound by name.
+    ///
+    /// That the two entry points hand out different pointers is safe for one
+    /// reason, and it is worth stating because it is the thing that could rot:
+    /// a pointer's declared arity is read *only* when a native sizes a call
+    /// through it, a native can reach a compiled chunk *only* through the
+    /// wrappers module, and the wrappers are installed by exactly the calls
+    /// that set this field. So a pointer that cannot describe itself is also a
+    /// pointer no native can reach — such a call fails on the name instead,
+    /// which `callback.rs::without_the_wrappers_the_pointer_does_not_resolve`
+    /// pins. Register wrappers anywhere this is left `None` and that stops
+    /// being true.
+    #[cfg(not(feature = "no_function"))]
+    owner: Option<SharedProgram>,
     /// Whether this `Vm` started the run, and so may clear its trace.
     ///
     /// False for a [`Vm::reentrant`]: a callback clearing the trace would
@@ -486,6 +506,8 @@ impl<'e> Vm<'e> {
             sizes: Vec::new(),
             unwind_floor: 0,
             this: None,
+            #[cfg(not(feature = "no_function"))]
+            owner: None,
             owns_trace: true,
             chain_step: 0,
             pending_slot: None,
@@ -529,6 +551,10 @@ impl<'e> Vm<'e> {
             // A crossing carries no receiver: Rhai binds one only where it
             // dispatches a method, and this arrives through `call_fn_raw`.
             this: None,
+            // Filled by whoever holds the program — `callback::invoke` does,
+            // and hands it over before running anything.
+            #[cfg(not(feature = "no_function"))]
+            owner: None,
             // `global` is a clone, so the trace is shared with the run that
             // called in and is not this call's to clear.
             owns_trace: false,
@@ -877,12 +903,6 @@ impl<'e> Vm<'e> {
     /// back, and `map` looks the pointer up its own way. See the `callback`
     /// module.
     ///
-    /// Only worth the owned program when [`Program::makes_fn_pointers`] says a
-    /// pointer can escape; [`eval_with_scope`](Self::eval_with_scope) is
-    /// otherwise identical and copies nothing. A program that needs this and
-    /// does not get it still runs — the pointer simply fails to resolve, as
-    /// `ErrorFunctionNotFound`, at the point the native tries to call it.
-    ///
     /// Read the `callback` module before relying on it: a crossing is slower than the
     /// walker, and a *capturing* closure handed to a native that binds `this`
     /// arrives with its arguments rotated.
@@ -897,7 +917,50 @@ impl<'e> Vm<'e> {
     pub fn eval_with_callbacks(&mut self, scope: &mut Scope, program: &SharedProgram) -> VmResult {
         let wrappers =
             (!program.functions().is_empty()).then(|| callback::wrappers(program).into());
-        self.run_with(program, scope, wrappers)
+        #[cfg(not(feature = "no_function"))]
+        let restore = self.adopt(program);
+        let result = self.run_with(program, scope, wrappers);
+        #[cfg(not(feature = "no_function"))]
+        self.release(restore);
+        result
+    }
+
+    /// Take shared ownership of `program` for the duration of a run, returning
+    /// what was there to be put back.
+    ///
+    /// A `Vm` outlives a single run, so this is saved and restored rather than
+    /// assigned: a second run of a different program must not hand out pointers
+    /// into the first.
+    #[cfg(not(feature = "no_function"))]
+    pub(super) fn adopt(&mut self, program: &SharedProgram) -> Option<SharedProgram> {
+        self.owner.replace(program.clone())
+    }
+
+    /// Put back what [`Vm::adopt`] displaced.
+    #[cfg(not(feature = "no_function"))]
+    pub(super) fn release(&mut self, previous: Option<SharedProgram>) {
+        self.owner = previous;
+    }
+
+    /// How a pointer to the function named `name_index` should describe itself.
+    ///
+    /// [`FnPtrType::Compiled`] where the answer is unambiguous and we have the
+    /// program to point into, and [`FnPtrType::Normal`] otherwise — a
+    /// late-bound name, which is what every such pointer was before.
+    #[cfg(not(feature = "no_function"))]
+    fn compiled_pointer(&self, program: &Program, name_index: u32) -> FnPtrType {
+        if self.owner.is_some() {
+            let mut found = program
+                .functions()
+                .iter()
+                .filter(|f| f.name == name_index && f.this_type.is_none());
+
+            if let (Some(_), None) = (found.next(), found.next()) {
+                return FnPtrType::Compiled;
+            }
+        }
+
+        FnPtrType::Normal
     }
 
     fn run_with(
@@ -934,15 +997,8 @@ impl<'e> Vm<'e> {
         #[cfg(not(feature = "no_function"))]
         let orig_lib_len = self.global.lib.len();
         #[cfg(not(feature = "no_function"))]
-        {
-            if let Some(lib) = program.lib() {
-                self.global.lib.push(lib.clone());
-            }
-            // Last, so the search — which runs in reverse — reaches a compiled
-            // function before whatever the compiler left Rhai to interpret.
-            if let Some(wrappers) = wrappers {
-                self.global.lib.push(wrappers);
-            }
+        if let Some(wrappers) = wrappers {
+            self.global.lib.push(wrappers);
         }
         // Without script functions there is no library to stack them in, and
         // `wrappers` is `None` for want of anything to wrap.
@@ -4053,6 +4109,22 @@ impl<'e> Vm<'e> {
                     let name = program
                         .name(index)
                         .ok_or_else(|| malformed(format!("no name {index}")))?;
+                    // A pointer that can answer its own shape, where the caller
+                    // gave us the program to answer from. Rhai's natives size a
+                    // callback from the pointer's declared arity, and a
+                    // name-only pointer leaves them guessing — which is how
+                    // `reduce` came to bind its accumulator and its element the
+                    // wrong way round (`types/fn_ptr.rs`).
+                    //
+                    // Only where exactly one compiled function bears the name:
+                    // this instruction also serves `Fn("f")` folded to a
+                    // constant, and a name with two arities has no one shape to
+                    // declare. Ambiguity stays late-bound.
+                    #[cfg(not(feature = "no_function"))]
+                    let typ = self.compiled_pointer(program, index);
+                    #[cfg(feature = "no_function")]
+                    let typ = FnPtrType::Normal;
+
                     // Non-validated, because `anon$…` is not a name a script could
                     // have written and the validating constructors refuse it.
                     // Nothing unsound rides on that check — a name that will
@@ -4063,7 +4135,7 @@ impl<'e> Vm<'e> {
                             curry: Default::default(),
                             #[cfg(not(feature = "no_function"))]
                             env: None,
-                            typ: FnPtrType::Normal,
+                            typ,
                         }
                         .into(),
                     );
@@ -4367,7 +4439,6 @@ mod tests {
                 name: index as u32,
                 params: Vec::new(),
                 this_type: None,
-                takes_this: false,
                 chunk: Chunk::new(end_of(span.start), end_of(span.end), 8),
             })
             .collect();
@@ -4386,7 +4457,6 @@ mod tests {
                 assign_ops: Vec::new(),
                 chains,
                 switches: Vec::new(),
-                lib: None,
                 #[cfg(not(feature = "no_module"))]
                 resolver: None,
                 source: None,

--- a/src/types/fn_ptr.rs
+++ b/src/types/fn_ptr.rs
@@ -26,6 +26,9 @@ pub enum FnPtrType {
     /// Pre-calculated hash of a script-defined function.
     #[cfg(not(feature = "no_function"))]
     Script { num_params: usize, hash: u64 },
+    /// A function the Grain VM compiled.
+    #[cfg(all(feature = "grain", not(feature = "no_function")))]
+    Compiled,
     /// Embedded native Rust function.
     #[cfg(not(feature = "sync"))]
     Native(Shared<dyn Fn(NativeCallContext, &mut FnCallArgs) -> RhaiResult + 'static>),
@@ -43,6 +46,8 @@ impl fmt::Display for FnPtrType {
             Self::Normal => f.write_str("Fn"),
             #[cfg(not(feature = "no_function"))]
             Self::Script { .. } => f.write_str("Fn*"),
+            #[cfg(all(feature = "grain", not(feature = "no_function")))]
+            Self::Compiled => f.write_str("Fn#"),
             Self::Native(..) => f.write_str("Fn"),
         }
     }
@@ -428,6 +433,9 @@ impl FnPtr {
         let mut arg_values = arg_values.as_mut();
         let mut args_data;
 
+        #[cfg(all(feature = "grain", not(feature = "no_function")))]
+        let mut dummy = Dynamic::UNIT;
+
         if self.is_curried() {
             args_data = FnArgsVec::with_capacity(self.curry().len() + arg_values.len());
             args_data.extend(self.curry().iter().cloned());
@@ -460,8 +468,8 @@ impl FnPtr {
             );
         }
 
-        // Embedded native Rust function?
         match self.typ {
+            // Embedded native Rust function
             FnPtrType::Native(ref func) => {
                 let mut cloned_this_ptr;
                 let args = &mut StaticVec::with_capacity(arg_values.len() + 1);
@@ -487,6 +495,19 @@ impl FnPtr {
                 return func(context, args)
                     .and_then(|r| engine.check_data_size(r, pos))
                     .map_err(|err| err.fill_position(pos));
+            }
+            #[cfg(all(feature = "grain", not(feature = "no_function")))]
+            // VM-compiled chunk which may use the `this` pointer.
+            FnPtrType::Compiled => {
+                // Since the chunk is actually a script-ed function, the `this` pointer goes into
+                // the first position.
+                let args = &mut arg_values.iter_mut().collect::<FnArgsVec<_>>();
+                if let Some(this_ptr) = this_ptr.as_deref_mut() {
+                    args.insert(0, this_ptr);
+                } else {
+                    args.insert(0, &mut dummy);
+                }
+                return context.call_native_fn_raw(self.fn_name(), true, args);
             }
             _ => (),
         }

--- a/tests/grain/callback.rs
+++ b/tests/grain/callback.rs
@@ -43,7 +43,6 @@ fn lowered(source: &str) {
     let ast = engine.compile(source).unwrap();
     let program = Compiler::new().compile(&ast);
     assert!(program.residual_count() == 0, "{source} still fragments, so it does not test the callback path",);
-    assert!(program.makes_fn_pointers(), "{source}");
 }
 
 #[test]
@@ -51,6 +50,13 @@ fn a_native_can_call_a_closure_back() {
     lowered("let a = [1, 2, 3]; a.map(|x| x * 2)");
     agree("let a = [1, 2, 3]; a.map(|x| x * 2)");
     agree("let a = [1, 2, 3, 4]; a.filter(|x| x % 2 == 0)");
+}
+
+#[test]
+fn a_native_can_call_a_closure_back_with_this() {
+    agree("let t = 0; [1, 2, 3].for_each(|| t += this); t");
+    agree("[1, 2, 3].map(|| this * this)");
+    agree("[1, 2, 3].reduce(|sum| if sum == () { this } else { sum + this })");
 }
 
 #[test]

--- a/tests/grain/corpus/mod.rs
+++ b/tests/grain/corpus/mod.rs
@@ -235,7 +235,12 @@ pub fn applies_to_this_build(name: &str) -> bool {
             | "closure_filter_binds_this"
             | "closure_for_each_binds_this"
             | "closure_in_filter"
+            | "closure_in_for_each_index"
             | "closure_in_map"
+            | "closure_in_map_with_this"
+            | "closure_in_reduce"
+            | "closure_in_reduce_rev"
+            | "closure_in_reduce_with_this"
             | "closure_map_binds_this"
             | "closure_map_takes_an_argument"
             | "closure_shared_chain_root"
@@ -322,7 +327,14 @@ pub fn applies_to_this_build(name: &str) -> bool {
                 | "closure_filter_binds_this"
                 | "closure_for_each_binds_this"
                 | "closure_in_filter"
+                | "closure_in_for_each_index"
                 | "closure_in_map"
+                | "closure_in_map_with_this"
+                | "closure_in_map_filter"
+                | "closure_in_map_retain"
+                | "closure_in_reduce"
+                | "closure_in_reduce_rev"
+                | "closure_in_reduce_with_this"
                 | "closure_map_binds_this"
                 | "closure_map_takes_an_argument"
                 | "closure_shared_op_assign"
@@ -612,6 +624,16 @@ pub const CASES: &[Case] = &[
     case("is_shared_after_capture", "let x = 1; let r = false; { let f = || x; r = is_shared(f); } [is_shared(x), r]"),
     case("closure_in_map", "[1, 2, 3].map(|x| x * 2)"),
     case("closure_in_filter", "[1, 2, 3, 4].filter(|x| x % 2 == 0)"),
+    // Every native taking a callback offers it a menu of argument shapes and
+    // picks by the pointer's declared arity. And different functions need
+    // to place the `this` pointer in different positions.
+    case("closure_in_map_with_this", r#"[1, 2, 3].map(|| this * this)"#),
+    case("closure_in_reduce", r#"[1, 2, 3].reduce(|a, v| if a == () { v } else { a + v })"#),
+    case("closure_in_reduce_rev", r#"[1, 2, 3].reduce_rev(|a, v| if a == () { v } else { a + v })"#),
+    case("closure_in_reduce_using_this", r#"[1, 2, 3].reduce(|sum| if sum == () { this } else { sum + this })"#),
+    case("closure_in_map_filter", r#"#{ a: 1, b: 2 }.filter(|k, v| v > 1).len()"#),
+    case("closure_in_map_retain", r#"let m = #{ a: 1, b: 2 }; m.retain(|k, v| v > 1); m.len()"#),
+    case("closure_in_for_each_index", "let s = 0; [10, 20, 30].for_each(|i| s += i); s"),
     // --- chained lvalues --------------------------------------------------
     // Each of these needs a different `Target` variant and its write-back.
     case("index_assign_array", "let a = [1, 2, 3]; a[1] = 99; a"),

--- a/tests/grain/differential.rs
+++ b/tests/grain/differential.rs
@@ -45,18 +45,14 @@ fn run_stock(engine: &Engine, source: &str) -> Outcome {
 fn run_vm(engine: &Engine, source: &str) -> Outcome {
     let mut scope = Scope::new();
     let result = engine.compile(source).map_err(|err| format!("{err:?}")).and_then(|ast| {
-        let program = Compiler::new().compile(&ast);
+        let program = Compiler::new().compile(&ast).into_shared();
         // A program that can hand a pointer to a native has to be run the
         // way such a program is meant to be run, or the comparison is
         // against a configuration nobody would ship.
-        if program.makes_fn_pointers() {
-            let program = program.into_shared();
-            Vm::new(engine).eval_with_callbacks(&mut scope, &program)
-        } else {
-            Vm::new(engine).eval_with_scope(&mut scope, &program)
-        }
-        .map(|value| format!("{value:?}"))
-        .map_err(|err| format!("{err:?}"))
+        Vm::new(engine)
+            .eval_with_callbacks(&mut scope, &program)
+            .map(|value| format!("{value:?}"))
+            .map_err(|err| format!("{err:?}"))
     });
 
     Outcome { result, scope: snapshot_scope(&scope) }

--- a/tests/grain/format.rs
+++ b/tests/grain/format.rs
@@ -34,13 +34,8 @@ fn snapshot(scope: &Scope, result: Result<Dynamic, Box<rhai::EvalAltResult>>) ->
 /// bytes, which is the property that makes an artifact self-describing.
 fn run(engine: &Engine, program: Program) -> Outcome {
     let mut scope = Scope::new();
-    let result = if program.makes_fn_pointers() {
-        let program = program.into_shared();
-        Vm::new(engine).eval_with_callbacks(&mut scope, &program)
-    } else {
-        Vm::new(engine).eval_with_scope(&mut scope, &program)
-    };
-
+    let program = program.into_shared();
+    let result = Vm::new(engine).eval_with_callbacks(&mut scope, &program);
     snapshot(&scope, result)
 }
 
@@ -266,14 +261,8 @@ fn a_golden_artifact_written_by_an_older_build_still_runs() {
         };
         let ran = {
             let mut scope = golden_scope();
-            // Whether the program can hand a pointer to a native is read back off
-            // the bytes, so how it must be run is part of what is being checked.
-            let result = if loaded.makes_fn_pointers() {
-                let loaded = loaded.into_shared();
-                Vm::new(&engine).eval_with_callbacks(&mut scope, &loaded)
-            } else {
-                Vm::new(&engine).eval_with_scope(&mut scope, &loaded)
-            };
+            let loaded = loaded.into_shared();
+            let result = Vm::new(&engine).eval_with_callbacks(&mut scope, &loaded);
             snapshot(&scope, result)
         };
 
@@ -787,21 +776,12 @@ fn a_caught_error_leaves_no_frames_behind() {
 }
 
 /// Run a program that is expected to fail, keeping the error and the trace.
-///
-/// Mirrors [`run`]'s split on `makes_fn_pointers`: a program that hands a
-/// pointer to a native has to be shared to be run at all.
 #[cfg(not(any(feature = "no_position", feature = "unchecked", feature = "no_function")))]
 fn fail(engine: &Engine, program: Program, what: &str) -> (rhai::EvalAltResult, Vec<rhai::grain::Fault>) {
     let mut scope = Scope::new();
     let mut vm = Vm::new(engine);
-
-    let result = if program.makes_fn_pointers() {
-        let program = program.into_shared();
-        vm.eval_with_callbacks(&mut scope, &program)
-    } else {
-        vm.eval_with_scope(&mut scope, &program)
-    };
-
+    let program = program.into_shared();
+    let result = vm.eval_with_callbacks(&mut scope, &program);
     let error = result.err().unwrap_or_else(|| panic!("{what}: the case must fail"));
     (*error, vm.fault_trace())
 }

--- a/tests/grain/fuzz.rs
+++ b/tests/grain/fuzz.rs
@@ -294,14 +294,9 @@ fn generated_scripts_agree_with_the_walker() {
             valued += 1;
         }
 
-        let program = Compiler::new().compile(&ast);
+        let program = Compiler::new().compile(&ast).into_shared();
         let mut vm_scope = Scope::new();
-        let ours = if program.makes_fn_pointers() {
-            let program = program.into_shared();
-            Vm::new(&engine).eval_with_callbacks(&mut vm_scope, &program)
-        } else {
-            Vm::new(&engine).eval_with_scope(&mut vm_scope, &program)
-        };
+        let ours = Vm::new(&engine).eval_with_callbacks(&mut vm_scope, &program);
         let ours = snapshot(&vm_scope, ours);
 
         if hit_a_limit(&ours) {

--- a/tests/grain/scope.rs
+++ b/tests/grain/scope.rs
@@ -643,6 +643,32 @@ fn a_closure_pointer_is_late_bound() {
     assert_ne!(ours, walker, "if these ever match, delete this test");
 }
 
+/// The same closure, run the way a program that hands pointers out must be run.
+///
+/// Rendered apart from both of Rhai's kinds on purpose. `Fn` would hide that the
+/// pointer knows its own shape and `Fn*` would claim an AST body it does not
+/// have. `Fn#` is the one that says "this is a compiled chunk, and it knows its
+/// own shape".
+#[test]
+#[cfg(not(feature = "no_function"))]
+fn a_closure_pointer_is_identified_to_rhai_as_compiled() {
+    let engine = corpus::engine();
+    let source = "let n = 1; let f = |x| x + n; f";
+
+    let ast = engine.compile(source).expect("must compile");
+    let program = Compiler::new().compile(&ast);
+    assert_eq!(program.residual_count(), 0, "the closure must lower");
+
+    let borrowed = Vm::new(&engine).eval_with_scope(&mut Scope::new(), &program).expect("must run");
+
+    let shared = program.into_shared();
+    let owned = Vm::new(&engine).eval_with_callbacks(&mut Scope::new(), &shared).expect("must run");
+
+    let (borrowed, owned) = (format!("{borrowed:?}"), format!("{owned:?}"));
+    assert!(borrowed.starts_with("Fn(\"anon$"), "a bare name: {borrowed}",);
+    assert!(owned.starts_with("Fn#(\"anon$"), "compiled chunk: {owned}",);
+}
+
 /// Calling a compiled function from outside, which is what a native wrapper
 /// will do once compiled chunks are registered for callbacks.
 #[test]
@@ -716,41 +742,6 @@ fn call_fn_mirrors_the_engines() {
     // And a missing name still misses.
     let err = vm.call_fn::<INT>(&mut scope, &program, "nope", (1 as INT,)).expect_err("no such function");
     assert!(matches!(*err, rhai::EvalAltResult::ErrorFunctionNotFound(..)), "got {err:?}",);
-}
-
-/// The flag a host uses to decide whether a program has to be owned.
-///
-/// Registering compiled functions so a native can call one back requires a
-/// `'static` wrapper, which means owning the program and giving up the
-/// borrowed-from-the-artifact loading. Nobody should have to read a script to
-/// find out whether that is needed — and the answer must be the same for a
-/// compiled program and for the same program read back, or one of the two
-/// paths quietly loses its callbacks.
-#[test]
-#[cfg(not(any(feature = "no_function", feature = "no_object")))]
-fn the_compiler_says_whether_a_program_makes_function_pointers() {
-    let engine = corpus::engine();
-
-    for (source, expected) in [
-        ("let a = 1; a + 2", false),
-        ("fn f(x) { x } f(1)", false),
-        ("let s = 0; for i in 0..3 { s += i; } s", false),
-        // Every shape that produces one.
-        ("let n = \"ab\" + \"s\"; Fn(n)", true),
-        ("let n = 1; let f = |x| x + n; f.call(2)", true),
-        ("fn t(x) { x } let f = Fn(\"t\"); f.call(1)", true),
-        ("fn a(x, y) { x } let n = \"a\"; Fn(n).curry(1)", true),
-    ] {
-        let ast = engine.compile(source).expect("must compile");
-        let program = Compiler::new().compile(&ast);
-        assert_eq!(program.makes_fn_pointers(), expected, "for {source:?}",);
-
-        // Read off the code, so an artifact answers the same.
-        if let Ok(bytes) = program.write() {
-            let reloaded = rhai::grain::Program::read(&bytes).expect("must load");
-            assert_eq!(reloaded.makes_fn_pointers(), expected, "after a round trip, for {source:?}",);
-        }
-    }
 }
 
 /// The whole reason for the opcode: these now cross a wire.


### PR DESCRIPTION
@ImTheSquid I have pushed an experimental branch called `experimental-compiled-vm-callback` which illustrates my idea. Can you take a look? For reference only at this point.

What it does:

* Eliminated a lot of the stuff such as `makes_pointer`, `needs_this`, etc.

* Eliminated the need to keep a lib of the AST for walking. This has the side effect that some features such as `import`, `eval` etc. won't compile.

* Seems to work with anything I've thrown at it so far...

* Eliminated the need to consider arity in callbacks... everything just works, because the arity is not in question -- the function is scripted, and it always has `this` (even if unused), so the shape is fixed.

* Surgical changes in `fn_ptr.rs`... It is now simply `FnPtrType::Compiled` with no attached info. Just a marker.

* There is no observed regression in performance.

The essence is these two changes.  They make sure compiled chunks are always called with a `this` pointer at the front (it may be a dummy if not used).  This takes care of all our arity problems.

```rust
#[cfg(all(feature = "grain", not(feature = "no_function")))]
// VM-compiled chunk
FnPtrType::Compiled => {
    // Since the chunk is actually a script-ed function, the `this` pointer goes into
    // the first position.
    let args = &mut arg_values.iter_mut().collect::<FnArgsVec<_>>();
    if let Some(this_ptr) = this_ptr.as_deref_mut() {
        args.insert(0, this_ptr);
    } else {
        args.insert(0, &mut dummy);
    }
    return context.call_native_fn_raw(self.fn_name(), true, args);
}
```

```rust
// A compiled chunk automatically takes an additional argument
// for `this`, push to the very front.
let arity = function.params.len() + 1;

                :

let wrapper = move |context: Option<NativeCallContext>, args: &mut [&mut Dynamic]| {
    // Always extracts the first argument for `this`.
    let (this_ptr, args) = args
        .split_first_mut()
        .ok_or_else(|| malformed("a callback wrapper was given no `this`".into()))?;

    invoke_with_this(&owner, &called, context.as_ref(), args, Some(this_ptr))
};
```
