### PR TITLE
VM: Implement callbacks from native Rust code

### DIFF
--- a/examples/grain_bench.rs
+++ b/examples/grain_bench.rs
@@ -138,6 +138,7 @@ const CASES: &[Case] = &[
     // Also the only case here that indexes: the `a.push(i)` loop is a chain
     // rooted at a local, so it is what says the root is still being walked
     // where it lives rather than copied out and put back.
+    #[cfg(not(feature = "no_function"))]
     Case {
         name: "native callbacks",
         source: "let a = []; for i in 0..500 { a.push(i); } \

--- a/src/ast/ast.rs
+++ b/src/ast/ast.rs
@@ -63,7 +63,7 @@ impl fmt::Debug for AST {
                     fp.field(&sig, &block.statements())
                 }
                 #[cfg(feature = "grain")]
-                super::script_fn::ScriptFuncPayload::GrainVM(..) => {
+                super::script_fn::ScriptFuncPayload::GrainVM { .. } => {
                     fp.field(&sig, &"<Grain VM function chunk>")
                 }
             };
@@ -805,7 +805,7 @@ impl AST {
                     }
                 }
                 #[cfg(feature = "grain")]
-                super::script_fn::ScriptFuncPayload::GrainVM(..) => (),
+                super::script_fn::ScriptFuncPayload::GrainVM { .. } => (),
             }
         }
 

--- a/src/ast/ast.rs
+++ b/src/ast/ast.rs
@@ -1,6 +1,6 @@
 //! Module defining the AST (abstract syntax tree).
 
-use super::{ASTFlags, Expr, FnAccess, ScriptFuncPayload, Stmt};
+use super::{ASTFlags, Expr, FnAccess, Stmt};
 use crate::{expose_under_internals, Dynamic, FnNamespace, ImmutableString, Position, ThinVec};
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
@@ -59,8 +59,13 @@ impl fmt::Debug for AST {
         for (.., fn_def) in self.lib.iter_script_fn() {
             let sig = fn_def.to_string();
             match fn_def.body {
-                ScriptFuncPayload::Statements(ref block) => fp.field(&sig, &block.statements()),
-                ScriptFuncPayload::GrainVM(..) => fp.field(&sig, &"<Grain VM function chunk>"),
+                super::script_fn::ScriptFuncPayload::Statements(ref block) => {
+                    fp.field(&sig, &block.statements())
+                }
+                #[cfg(feature = "grain")]
+                super::script_fn::ScriptFuncPayload::GrainVM(..) => {
+                    fp.field(&sig, &"<Grain VM function chunk>")
+                }
             };
         }
 
@@ -792,14 +797,15 @@ impl AST {
         #[cfg(not(feature = "no_function"))]
         for fn_def in self.iter_fn_def() {
             match fn_def.body {
-                ScriptFuncPayload::Statements(ref block) => {
+                super::script_fn::ScriptFuncPayload::Statements(ref block) => {
                     for stmt in block.statements() {
                         if !stmt.walk(path, on_node) {
                             return false;
                         }
                     }
                 }
-                _ => (),
+                #[cfg(feature = "grain")]
+                super::script_fn::ScriptFuncPayload::GrainVM(..) => (),
             }
         }
 

--- a/src/ast/ast.rs
+++ b/src/ast/ast.rs
@@ -60,6 +60,7 @@ impl fmt::Debug for AST {
             let sig = fn_def.to_string();
             match fn_def.body {
                 ScriptFuncPayload::Statements(ref block) => fp.field(&sig, &block.statements()),
+                ScriptFuncPayload::GrainVM(..) => fp.field(&sig, &"<Grain VM function chunk>"),
             };
         }
 
@@ -798,6 +799,7 @@ impl AST {
                         }
                     }
                 }
+                _ => (),
             }
         }
 

--- a/src/ast/ast.rs
+++ b/src/ast/ast.rs
@@ -1,6 +1,6 @@
 //! Module defining the AST (abstract syntax tree).
 
-use super::{ASTFlags, Expr, FnAccess, Stmt};
+use super::{ASTFlags, Expr, FnAccess, ScriptFuncPayload, Stmt};
 use crate::{expose_under_internals, Dynamic, FnNamespace, ImmutableString, Position, ThinVec};
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
@@ -58,7 +58,9 @@ impl fmt::Debug for AST {
         #[cfg(not(feature = "no_function"))]
         for (.., fn_def) in self.lib.iter_script_fn() {
             let sig = fn_def.to_string();
-            fp.field(&sig, &fn_def.body.statements());
+            match fn_def.body {
+                ScriptFuncPayload::Statements(ref block) => fp.field(&sig, &block.statements()),
+            };
         }
 
         fp.finish()
@@ -787,9 +789,15 @@ impl AST {
             }
         }
         #[cfg(not(feature = "no_function"))]
-        for stmt in self.iter_fn_def().flat_map(|f| f.body.iter()) {
-            if !stmt.walk(path, on_node) {
-                return false;
+        for fn_def in self.iter_fn_def() {
+            match fn_def.body {
+                ScriptFuncPayload::Statements(ref block) => {
+                    for stmt in block.statements() {
+                        if !stmt.walk(path, on_node) {
+                            return false;
+                        }
+                    }
+                }
             }
         }
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -18,7 +18,7 @@ pub use ident::Ident;
 #[cfg(not(feature = "no_module"))]
 pub use namespace::Namespace;
 #[cfg(not(feature = "no_function"))]
-pub use script_fn::{ScriptFnMetadata, ScriptFuncDef};
+pub use script_fn::{ScriptFnMetadata, ScriptFuncDef, ScriptFuncPayload};
 pub use stmt::{
     CaseBlocksList, FlowControl, OpAssignment, RangeCase, Stmt, StmtBlock, StmtBlockContainer,
     SwitchCasesCollection,

--- a/src/ast/script_fn.rs
+++ b/src/ast/script_fn.rs
@@ -31,7 +31,8 @@ impl ScriptFuncPayload {
     pub const fn position(&self) -> Position {
         match self {
             Self::Statements(block) => block.position(),
-            _ => Position::NONE,
+            #[cfg(feature = "grain")]
+            ScriptFuncPayload::GrainVM(..) => Position::NONE,
         }
     }
     /// Get the end position.
@@ -40,7 +41,8 @@ impl ScriptFuncPayload {
     pub const fn end_position(&self) -> Position {
         match self {
             Self::Statements(block) => block.end_position(),
-            _ => Position::NONE,
+            #[cfg(feature = "grain")]
+            ScriptFuncPayload::GrainVM(..) => Position::NONE,
         }
     }
 }
@@ -55,9 +57,9 @@ pub struct ScriptFuncDef {
     pub name: ImmutableString,
     /// Function access mode.
     pub access: FnAccess,
-    #[cfg(not(feature = "no_object"))]
     /// Type of `this` pointer, if any.
     /// Not available under `no_object`.
+    #[cfg(not(feature = "no_object"))]
     pub this_type: Option<ImmutableString>,
     /// Names of function parameters.
     pub params: FnArgsVec<ImmutableString>,

--- a/src/ast/script_fn.rs
+++ b/src/ast/script_fn.rs
@@ -2,17 +2,50 @@
 #![cfg(not(feature = "no_function"))]
 
 use super::{FnAccess, StmtBlock};
-use crate::{FnArgsVec, ImmutableString};
+use crate::{FnArgsVec, ImmutableString, Position};
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
 use std::{fmt, hash::Hash};
+
+/// A type containing the body of a script-defined function.
+#[derive(Debug, Clone)]
+pub enum ScriptFuncPayload {
+    /// Normal statements block.
+    Statements(StmtBlock),
+}
+
+impl Default for ScriptFuncPayload {
+    #[inline(always)]
+    fn default() -> Self {
+        Self::Statements(StmtBlock::NONE)
+    }
+}
+
+impl ScriptFuncPayload {
+    /// Get the start position.
+    #[inline(always)]
+    #[must_use]
+    pub const fn position(&self) -> Position {
+        match self {
+            Self::Statements(block) => block.position(),
+        }
+    }
+    /// Get the end position.
+    #[inline(always)]
+    #[must_use]
+    pub const fn end_position(&self) -> Position {
+        match self {
+            Self::Statements(block) => block.end_position(),
+        }
+    }
+}
 
 /// _(internals)_ A type containing information on a script-defined function.
 /// Exported under the `internals` feature only.
 #[derive(Debug, Clone)]
 pub struct ScriptFuncDef {
     /// Function body.
-    pub body: StmtBlock,
+    pub body: ScriptFuncPayload,
     /// Function name.
     pub name: ImmutableString,
     /// Function access mode.
@@ -49,7 +82,7 @@ impl ScriptFuncDef {
         Self {
             name: self.name.clone(),
             access: self.access,
-            body: StmtBlock::NONE,
+            body: <_>::default(),
             #[cfg(not(feature = "no_object"))]
             this_type: self.this_type.clone(),
             params: self.params.clone(),

--- a/src/ast/script_fn.rs
+++ b/src/ast/script_fn.rs
@@ -12,6 +12,9 @@ use std::{fmt, hash::Hash};
 pub enum ScriptFuncPayload {
     /// Normal statements block.
     Statements(StmtBlock),
+    /// _(grain)_ A Rhai Grain VM to run the function body.
+    #[cfg(feature = "grain")]
+    GrainVM(crate::grain::SharedProgram),
 }
 
 impl Default for ScriptFuncPayload {
@@ -28,6 +31,7 @@ impl ScriptFuncPayload {
     pub const fn position(&self) -> Position {
         match self {
             Self::Statements(block) => block.position(),
+            _ => Position::NONE,
         }
     }
     /// Get the end position.
@@ -36,6 +40,7 @@ impl ScriptFuncPayload {
     pub const fn end_position(&self) -> Position {
         match self {
             Self::Statements(block) => block.end_position(),
+            _ => Position::NONE,
         }
     }
 }

--- a/src/ast/script_fn.rs
+++ b/src/ast/script_fn.rs
@@ -14,7 +14,11 @@ pub enum ScriptFuncPayload {
     Statements(StmtBlock),
     /// _(grain)_ A Rhai Grain VM to run the function body.
     #[cfg(feature = "grain")]
-    GrainVM(crate::grain::SharedProgram),
+    GrainVM {
+        program: crate::grain::SharedProgram,
+        params: FnArgsVec<u32>,
+        chunk: crate::grain::bytecode::Chunk,
+    },
 }
 
 impl Default for ScriptFuncPayload {
@@ -32,7 +36,7 @@ impl ScriptFuncPayload {
         match self {
             Self::Statements(block) => block.position(),
             #[cfg(feature = "grain")]
-            ScriptFuncPayload::GrainVM(..) => Position::NONE,
+            ScriptFuncPayload::GrainVM { .. } => Position::NONE,
         }
     }
     /// Get the end position.
@@ -42,7 +46,7 @@ impl ScriptFuncPayload {
         match self {
             Self::Statements(block) => block.end_position(),
             #[cfg(feature = "grain")]
-            ScriptFuncPayload::GrainVM(..) => Position::NONE,
+            ScriptFuncPayload::GrainVM { .. } => Position::NONE,
         }
     }
 }

--- a/src/ast/script_fn.rs
+++ b/src/ast/script_fn.rs
@@ -2,7 +2,7 @@
 #![cfg(not(feature = "no_function"))]
 
 use super::{FnAccess, StmtBlock};
-use crate::{FnArgsVec, ImmutableString, Position};
+use crate::{types::Span, FnArgsVec, ImmutableString, Position};
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
 use std::{fmt, hash::Hash};
@@ -18,6 +18,7 @@ pub enum ScriptFuncPayload {
         program: crate::grain::SharedProgram,
         params: FnArgsVec<u32>,
         chunk: crate::grain::bytecode::Chunk,
+        span: Span,
     },
 }
 
@@ -32,11 +33,11 @@ impl ScriptFuncPayload {
     /// Get the start position.
     #[inline(always)]
     #[must_use]
-    pub const fn position(&self) -> Position {
+    pub const fn start_position(&self) -> Position {
         match self {
             Self::Statements(block) => block.position(),
             #[cfg(feature = "grain")]
-            ScriptFuncPayload::GrainVM { .. } => Position::NONE,
+            ScriptFuncPayload::GrainVM { span, .. } => span.start(),
         }
     }
     /// Get the end position.
@@ -46,7 +47,7 @@ impl ScriptFuncPayload {
         match self {
             Self::Statements(block) => block.end_position(),
             #[cfg(feature = "grain")]
-            ScriptFuncPayload::GrainVM { .. } => Position::NONE,
+            ScriptFuncPayload::GrainVM { span, .. } => span.end(),
         }
     }
 }

--- a/src/func/call.rs
+++ b/src/func/call.rs
@@ -728,15 +728,19 @@ impl Engine {
                 let fn_def = &*fn_def;
                 let env = env.as_deref();
 
+                // Short-circuit empty script function body
                 match fn_def.body {
-                    crate::ast::script_fn::ScriptFuncPayload::Statements(ref block)
-                        if block.is_empty() =>
-                    {
-                        return Ok((Dynamic::UNIT, false))
+                    crate::ast::script_fn::ScriptFuncPayload::Statements(ref block) => {
+                        if block.is_empty() {
+                            return Ok((Dynamic::UNIT, false));
+                        }
                     }
-                    _ => (),
+                    // We don't know about Grain functions, so call it anyway
+                    #[cfg(feature = "grain")]
+                    crate::ast::script_fn::ScriptFuncPayload::GrainVM { .. } => (),
                 }
 
+                // Make empty scope for function call
                 let mut empty_scope;
                 let scope = if let Some(scope) = _scope {
                     scope
@@ -745,9 +749,11 @@ impl Engine {
                     &mut empty_scope
                 };
 
+                // Swap source
                 let orig_source = mem::replace(&mut global.source, source);
                 defer! { global => move |g| g.source = orig_source }
 
+                // Execute function call
                 return if _is_method_call {
                     // Method call of script function - map first argument to `this`
                     let (first_arg, args) = args.split_first_mut().unwrap();

--- a/src/func/call.rs
+++ b/src/func/call.rs
@@ -2,7 +2,7 @@
 
 use super::{get_builtin_binary_op_fn, get_builtin_op_assignment_fn, RhaiFunc};
 use crate::api::default_limits::MAX_DYNAMIC_PARAMETERS;
-use crate::ast::{Expr, FnCallExpr, FnCallHashes, ScriptFuncPayload};
+use crate::ast::{Expr, FnCallExpr, FnCallHashes};
 use crate::engine::{
     KEYWORD_DEBUG, KEYWORD_EVAL, KEYWORD_FN_PTR, KEYWORD_FN_PTR_CALL, KEYWORD_FN_PTR_CURRY,
     KEYWORD_IS_DEF_VAR, KEYWORD_PRINT, KEYWORD_TYPE_OF,
@@ -729,7 +729,9 @@ impl Engine {
                 let env = env.as_deref();
 
                 match fn_def.body {
-                    ScriptFuncPayload::Statements(ref block) if block.is_empty() => {
+                    crate::ast::script_fn::ScriptFuncPayload::Statements(ref block)
+                        if block.is_empty() =>
+                    {
                         return Ok((Dynamic::UNIT, false))
                     }
                     _ => (),

--- a/src/func/call.rs
+++ b/src/func/call.rs
@@ -2,7 +2,7 @@
 
 use super::{get_builtin_binary_op_fn, get_builtin_op_assignment_fn, RhaiFunc};
 use crate::api::default_limits::MAX_DYNAMIC_PARAMETERS;
-use crate::ast::{Expr, FnCallExpr, FnCallHashes};
+use crate::ast::{Expr, FnCallExpr, FnCallHashes, ScriptFuncPayload};
 use crate::engine::{
     KEYWORD_DEBUG, KEYWORD_EVAL, KEYWORD_FN_PTR, KEYWORD_FN_PTR_CALL, KEYWORD_FN_PTR_CURRY,
     KEYWORD_IS_DEF_VAR, KEYWORD_PRINT, KEYWORD_TYPE_OF,
@@ -728,8 +728,11 @@ impl Engine {
                 let fn_def = &*fn_def;
                 let env = env.as_deref();
 
-                if fn_def.body.is_empty() {
-                    return Ok((Dynamic::UNIT, false));
+                match fn_def.body {
+                    ScriptFuncPayload::Statements(ref block) if block.is_empty() => {
+                        return Ok((Dynamic::UNIT, false))
+                    }
+                    _ => (),
                 }
 
                 let mut empty_scope;

--- a/src/func/script.rs
+++ b/src/func/script.rs
@@ -2,7 +2,7 @@
 #![cfg(not(feature = "no_function"))]
 
 use super::call::FnCallArgs;
-use crate::ast::{EncapsulatedEnviron, ScriptFuncDef};
+use crate::ast::{EncapsulatedEnviron, ScriptFuncDef, ScriptFuncPayload};
 use crate::eval::{Caches, GlobalRuntimeState};
 use crate::{Dynamic, Engine, Position, RhaiResult, Scope, ERR};
 #[cfg(feature = "no_std")]
@@ -43,13 +43,24 @@ impl Engine {
             return Err(ERR::ErrorStackOverflow(pos).into());
         }
 
-        #[cfg(feature = "debugging")]
-        if self.debugger_interface.is_none() && fn_def.body.is_empty() {
-            return Ok(Dynamic::UNIT);
+        // Guard against too many variables
+        #[cfg(not(feature = "unchecked"))]
+        if scope.len() + fn_def.params.len() > self.max_variables() {
+            return Err(ERR::ErrorTooManyVariables(pos).into());
         }
-        #[cfg(not(feature = "debugging"))]
-        if fn_def.body.is_empty() {
-            return Ok(Dynamic::UNIT);
+
+        match fn_def.body {
+            #[cfg(feature = "debugging")]
+            ScriptFuncPayload::Statements(ref block)
+                if self.debugger_interface.is_none() && block.is_empty() =>
+            {
+                return Ok(Dynamic::UNIT)
+            }
+            #[cfg(not(feature = "debugging"))]
+            ScriptFuncPayload::Statements(ref block) if block.is_empty() => {
+                return Ok(Dynamic::UNIT)
+            }
+            _ => (),
         }
 
         let orig_scope_len = scope.len();
@@ -62,12 +73,6 @@ impl Engine {
             .debugger
             .as_ref()
             .map_or(0, |dbg| dbg.call_stack().len());
-
-        // Guard against too many variables
-        #[cfg(not(feature = "unchecked"))]
-        if scope.len() + fn_def.params.len() > self.max_variables() {
-            return Err(ERR::ErrorTooManyVariables(pos).into());
-        }
 
         // Put arguments into scope as variables
         scope.extend(fn_def.params.iter().cloned().zip(args.iter_mut().map(|v| {
@@ -118,43 +123,47 @@ impl Engine {
         }
 
         // Evaluate the function
-        let mut _result: RhaiResult = self
-            .eval_stmt_block(
-                global,
-                caches,
-                scope,
-                this_ptr.as_deref_mut(),
-                fn_def.body.statements(),
-                rewind_scope,
-            )
-            .or_else(|err| match *err {
-                // Convert return statement to return value
-                ERR::Return(x, ..) => Ok(x),
-                // Exit value is passed straight-through
-                mut err @ ERR::Exit(..) => {
-                    err.set_position(pos);
-                    Err(err.into())
-                }
-                // System errors are passed straight-through
-                mut err if err.is_system_exception() => {
-                    err.set_position(pos);
-                    Err(err.into())
-                }
-                // Other errors are wrapped in `ErrorInFunctionCall`
-                _ => Err(ERR::ErrorInFunctionCall(
-                    fn_def.name.to_string(),
-                    #[cfg(not(feature = "no_module"))]
-                    _env.and_then(|env| env.lib.last())
-                        .and_then(|m| m.id())
-                        .unwrap_or_else(|| global.source().unwrap_or(""))
-                        .to_string(),
-                    #[cfg(feature = "no_module")]
-                    global.source().unwrap_or("").to_string(),
-                    err,
-                    pos,
+        let mut _result: RhaiResult = match fn_def.body {
+            // Normal statements block
+            ScriptFuncPayload::Statements(ref body) => {
+                self.eval_stmt_block(
+                    global,
+                    caches,
+                    scope,
+                    this_ptr.as_deref_mut(),
+                    body.statements(),
+                    rewind_scope,
                 )
-                .into()),
-            });
+                .or_else(|err| match *err {
+                    // Convert return statement to return value
+                    ERR::Return(x, ..) => Ok(x),
+                    // Exit value is passed straight-through
+                    mut err @ ERR::Exit(..) => {
+                        err.set_position(pos);
+                        Err(err.into())
+                    }
+                    // System errors are passed straight-through
+                    mut err if err.is_system_exception() => {
+                        err.set_position(pos);
+                        Err(err.into())
+                    }
+                    // Other errors are wrapped in `ErrorInFunctionCall`
+                    _ => Err(ERR::ErrorInFunctionCall(
+                        fn_def.name.to_string(),
+                        #[cfg(not(feature = "no_module"))]
+                        _env.and_then(|env| env.lib.last())
+                            .and_then(|m| m.id())
+                            .unwrap_or_else(|| global.source().unwrap_or(""))
+                            .to_string(),
+                        #[cfg(feature = "no_module")]
+                        global.source().unwrap_or("").to_string(),
+                        err,
+                        pos,
+                    )
+                    .into()),
+                })
+            }
+        };
 
         #[cfg(feature = "debugging")]
         if self.is_debugger_registered() {

--- a/src/func/script.rs
+++ b/src/func/script.rs
@@ -169,12 +169,18 @@ impl Engine {
             }
             // Rhai Grain VM
             #[cfg(feature = "grain")]
-            ScriptFuncPayload::GrainVM(ref program) => {
+            ScriptFuncPayload::GrainVM {
+                ref program,
+                ref params,
+                chunk,
+            } => {
                 let context = (self, fn_def.name.as_str(), global.source(), &*global, pos).into();
                 let mut vm = crate::grain::Vm::reentrant(&context);
                 vm.call_function_with_this(
                     program,
                     fn_def.name.as_str(),
+                    params,
+                    chunk,
                     arg_values,
                     global.level,
                     scope,

--- a/src/func/script.rs
+++ b/src/func/script.rs
@@ -114,7 +114,7 @@ impl Engine {
             },
         );
 
-        let mut arg_slots = 0;
+        let mut _arg_slots = 0;
 
         // Evaluate the function
         let mut _result: RhaiResult = match fn_def.body {
@@ -122,7 +122,7 @@ impl Engine {
             ScriptFuncPayload::Statements(ref body) => {
                 // Put arguments into scope as variables
                 scope.extend(fn_def.params.iter().cloned().zip(arg_values));
-                arg_slots = fn_def.params.len();
+                _arg_slots = fn_def.params.len();
 
                 #[cfg(feature = "debugging")]
                 if self.is_debugger_registered() {
@@ -218,9 +218,9 @@ impl Engine {
         // Remove all local variables and imported modules
         if rewind_scope {
             scope.rewind(orig_scope_len);
-        } else if arg_slots > 0 {
+        } else if _arg_slots > 0 {
             // Remove arguments only, leaving new variables in the scope
-            scope.remove_range(orig_scope_len, arg_slots);
+            scope.remove_range(orig_scope_len, _arg_slots);
         }
         global.lib.truncate(orig_lib_len);
         #[cfg(not(feature = "no_module"))]

--- a/src/func/script.rs
+++ b/src/func/script.rs
@@ -4,7 +4,7 @@
 use super::call::FnCallArgs;
 use crate::ast::{EncapsulatedEnviron, ScriptFuncDef, ScriptFuncPayload};
 use crate::eval::{Caches, GlobalRuntimeState};
-use crate::{Dynamic, Engine, Position, RhaiResult, Scope, ERR};
+use crate::{Dynamic, Engine, FnArgsVec, Position, RhaiResult, Scope, ERR};
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
 
@@ -74,20 +74,18 @@ impl Engine {
             .as_ref()
             .map_or(0, |dbg| dbg.call_stack().len());
 
-        // Put arguments into scope as variables
-        scope.extend(fn_def.params.iter().cloned().zip(args.iter_mut().map(|v| {
-            // Actually consume the arguments instead of cloning them
-            v.take()
-        })));
+        // Put collect function call arguments.
+        // Actually consume the arguments instead of cloning them.
+        let arg_values = args.iter_mut().map(|v| v.take()).collect::<FnArgsVec<_>>();
 
         // Push a new call stack frame
         #[cfg(feature = "debugging")]
         if self.is_debugger_registered() {
             let fn_name = fn_def.name.clone();
-            let args = scope
-                .iter_inner()
-                .skip(orig_scope_len)
-                .map(|(.., v)| v.flatten_clone());
+            let args = arg_values
+                .iter()
+                .map(Dynamic::flatten_clone)
+                .collect::<FnArgsVec<_>>();
             let source = global.source.clone();
 
             global
@@ -116,16 +114,22 @@ impl Engine {
             },
         );
 
-        #[cfg(feature = "debugging")]
-        if self.is_debugger_registered() {
-            let node = crate::ast::Stmt::Noop(fn_def.body.position());
-            self.dbg(global, caches, scope, this_ptr.as_deref_mut(), &node)?;
-        }
+        let mut arg_slots = 0;
 
         // Evaluate the function
         let mut _result: RhaiResult = match fn_def.body {
             // Normal statements block
             ScriptFuncPayload::Statements(ref body) => {
+                // Put arguments into scope as variables
+                scope.extend(fn_def.params.iter().cloned().zip(arg_values));
+                arg_slots = fn_def.params.len();
+
+                #[cfg(feature = "debugging")]
+                if self.is_debugger_registered() {
+                    let node = crate::ast::Stmt::Noop(fn_def.body.position());
+                    self.dbg(global, caches, scope, this_ptr.as_deref_mut(), &node)?;
+                }
+
                 self.eval_stmt_block(
                     global,
                     caches,
@@ -163,6 +167,23 @@ impl Engine {
                     .into()),
                 })
             }
+            // Rhai Grain VM
+            #[cfg(feature = "grain")]
+            ScriptFuncPayload::GrainVM(ref program) => {
+                let context = (self, fn_def.name.as_str(), global.source(), &*global, pos).into();
+                let mut vm = crate::grain::Vm::reentrant(&context);
+                vm.call_function_with_this(
+                    program,
+                    fn_def.name.as_str(),
+                    arg_values,
+                    global.level,
+                    scope,
+                    rewind_scope,
+                    pos,
+                    this_ptr.as_deref_mut().cloned(),
+                )
+                .0
+            }
         };
 
         #[cfg(feature = "debugging")]
@@ -197,9 +218,9 @@ impl Engine {
         // Remove all local variables and imported modules
         if rewind_scope {
             scope.rewind(orig_scope_len);
-        } else if !args.is_empty() {
+        } else if arg_slots > 0 {
             // Remove arguments only, leaving new variables in the scope
-            scope.remove_range(orig_scope_len, args.len());
+            scope.remove_range(orig_scope_len, arg_slots);
         }
         global.lib.truncate(orig_lib_len);
         #[cfg(not(feature = "no_module"))]

--- a/src/func/script.rs
+++ b/src/func/script.rs
@@ -176,7 +176,11 @@ impl Engine {
             } => {
                 let context = (self, fn_def.name.as_str(), global.source(), &*global, pos).into();
                 let mut vm = crate::grain::Vm::reentrant(&context);
-                vm.call_function_with_this(
+
+                // The value in the `this` pointer is cloned
+                let this_ptr_value = this_ptr.as_deref_mut().cloned();
+
+                let (result, new_this_ptr) = vm.call_function_with_this(
                     program,
                     fn_def.name.as_str(),
                     params,
@@ -186,9 +190,17 @@ impl Engine {
                     scope,
                     rewind_scope,
                     pos,
-                    this_ptr.as_deref_mut().cloned(),
-                )
-                .0
+                    this_ptr_value,
+                );
+
+                // Write back new value for the `this` pointer
+                if let Some(this_ptr) = this_ptr.as_deref_mut() {
+                    if let Some(new_this_ptr) = new_this_ptr {
+                        *this_ptr = new_this_ptr;
+                    }
+                }
+
+                result
             }
         };
 

--- a/src/func/script.rs
+++ b/src/func/script.rs
@@ -49,20 +49,23 @@ impl Engine {
             return Err(ERR::ErrorTooManyVariables(pos).into());
         }
 
+        // Short-circuit empty function body
         match fn_def.body {
-            #[cfg(feature = "debugging")]
-            ScriptFuncPayload::Statements(ref block)
-                if self.debugger_interface.is_none() && block.is_empty() =>
-            {
-                return Ok(Dynamic::UNIT)
+            ScriptFuncPayload::Statements(ref block) => {
+                let is_empty = block.is_empty();
+                #[cfg(feature = "debugging")]
+                let is_empty = is_empty && self.debugger_interface.is_none();
+
+                if is_empty {
+                    return Ok(Dynamic::UNIT);
+                }
             }
-            #[cfg(not(feature = "debugging"))]
-            ScriptFuncPayload::Statements(ref block) if block.is_empty() => {
-                return Ok(Dynamic::UNIT)
-            }
-            _ => (),
+            // We don't know about Grain functions, so call it anyway
+            #[cfg(feature = "grain")]
+            ScriptFuncPayload::GrainVM { .. } => (),
         }
 
+        // Save the original state
         let orig_scope_len = scope.len();
         let orig_lib_len = global.lib.len();
         #[cfg(not(feature = "no_module"))]
@@ -126,7 +129,7 @@ impl Engine {
 
                 #[cfg(feature = "debugging")]
                 if self.is_debugger_registered() {
-                    let node = crate::ast::Stmt::Noop(fn_def.body.position());
+                    let node = crate::ast::Stmt::Noop(fn_def.body.start_position());
                     self.dbg(global, caches, scope, this_ptr.as_deref_mut(), &node)?;
                 }
 
@@ -173,6 +176,7 @@ impl Engine {
                 ref program,
                 ref params,
                 chunk,
+                ..
             } => {
                 let context = (self, fn_def.name.as_str(), global.source(), &*global, pos).into();
                 let mut vm = crate::grain::Vm::reentrant(&context);

--- a/src/grain/compile/mod.rs
+++ b/src/grain/compile/mod.rs
@@ -160,9 +160,6 @@ impl Compiler {
                 name: f.name,
                 params: f.params,
                 this_type: f.this_type,
-                // Derived from the chunk by `Program::new`, which is the one
-                // place that can see the assembled bytes.
-                takes_this: false,
                 chunk: Chunk::new(
                     offsets[f.first_op],
                     offsets[f.first_op + f.op_count],
@@ -187,11 +184,7 @@ impl Compiler {
         // `callback::wrappers`, which skips exactly these.
         #[cfg(not(feature = "no_function"))]
         let lib = {
-            let escapes_as_pointer = caps.contains(Caps::FN_PTR)
-                && functions
-                    .iter()
-                    .any(|f| crate::grain::program::takes_this(&code, f.chunk, &lowering.chains));
-            let needs_walker = skipped > 0 || !lowering.residuals.is_empty() || escapes_as_pointer;
+            let needs_walker = skipped > 0 || !lowering.residuals.is_empty();
             (needs_walker && !ast.shared_lib().is_empty()).then(|| ast.shared_lib().clone())
         };
         // Under `no_function` there is no function tree to carry, whichever way
@@ -870,9 +863,11 @@ impl Lowering {
             .map(|p| self.push_name(p.clone()))
             .collect();
 
-        // The scripted function's body must be an AST statements list.
         let body = match &def.body {
+            // The scripted function's body must be an AST statements list.
             ScriptFuncPayload::Statements(body) => body,
+            // For some reason, if it is a Grain chunk, then fail to lower.
+            ScriptFuncPayload::GrainVM(..) => return None,
         };
 
         // Rhai stops once on entering a body, before its first statement, at a
@@ -881,7 +876,7 @@ impl Lowering {
         // rather than in the VM. Depth zero, like the statements it precedes:
         // it does not enclose them, so stepping from here reaches the first one.
         #[cfg(feature = "debugging")]
-        self.emit_at(Op::Statement { depth: 0 }, def.body.position());
+        self.emit_at(Op::Statement { depth: 0 }, body.position());
 
         // A body is a statement list whose last value is the return value,
         // which is what `program` already does.

--- a/src/grain/compile/mod.rs
+++ b/src/grain/compile/mod.rs
@@ -7,11 +7,11 @@ use core::mem;
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
 
-#[cfg(not(feature = "no_function"))]
-use crate::ast::ScriptFuncDef;
 use crate::ast::{
     ASTFlags, Expr, FlowControl, FnCallExpr, OpAssignment, Stmt, StmtBlock, SwitchCasesCollection,
 };
+#[cfg(not(feature = "no_function"))]
+use crate::ast::{ScriptFuncDef, ScriptFuncPayload};
 use crate::tokenizer::Token;
 use crate::types::Span;
 use crate::{Dynamic, ImmutableString, Position, AST};
@@ -870,6 +870,11 @@ impl Lowering {
             .map(|p| self.push_name(p.clone()))
             .collect();
 
+        // The scripted function's body must be an AST statements list.
+        let body = match &def.body {
+            ScriptFuncPayload::Statements(body) => body,
+        };
+
         // Rhai stops once on entering a body, before its first statement, at a
         // synthetic node placed on the body itself (`func/script.rs:115-119`).
         // A marker at the same place is that stop, and puts it in the chunk
@@ -880,7 +885,7 @@ impl Lowering {
 
         // A body is a statement list whose last value is the return value,
         // which is what `program` already does.
-        let lowered = self.program(def.body.statements(), false);
+        let lowered = self.program(body.statements(), false);
 
         self.slots = saved_slots;
         self.loops = saved_loops;

--- a/src/grain/compile/mod.rs
+++ b/src/grain/compile/mod.rs
@@ -867,7 +867,7 @@ impl Lowering {
             // The scripted function's body must be an AST statements list.
             ScriptFuncPayload::Statements(body) => body,
             // For some reason, if it is a Grain chunk, then fail to lower.
-            ScriptFuncPayload::GrainVM(..) => return None,
+            ScriptFuncPayload::GrainVM { .. } => return None,
         };
 
         // Rhai stops once on entering a body, before its first statement, at a

--- a/src/grain/compile/mod.rs
+++ b/src/grain/compile/mod.rs
@@ -864,10 +864,14 @@ impl Lowering {
             .collect();
 
         let body = match &def.body {
-            // The scripted function's body must be an AST statements list.
+            // The function's body must be an AST statements block.
             ScriptFuncPayload::Statements(body) => body,
-            // For some reason, if it is a Grain chunk, then fail to lower.
-            ScriptFuncPayload::GrainVM { .. } => return None,
+            // This should not happen: the only way for a `GrainVM` to appear
+            // is for Grain to generate it inside a callback wrapper.
+            // So Grain should never be handed another Grain function to compile.
+            ScriptFuncPayload::GrainVM { .. } => {
+                unreachable!("AST compiled by Rhai never contains a GrainVM function body")
+            }
         };
 
         // Rhai stops once on entering a body, before its first statement, at a

--- a/src/grain/compile/poolable.rs
+++ b/src/grain/compile/poolable.rs
@@ -23,6 +23,17 @@ use rust_decimal::Decimal;
 /// created against. Keeping it out of the pool leaves it as a fragment, which
 /// evaluates through the path that does the attaching.
 pub(crate) fn is_poolable(value: &Dynamic) -> bool {
+    // A shared cell first, because every question below sees through one:
+    // `is_array` and friends unwrap `Union::Shared`, so a shared array of ints
+    // would answer yes and be pooled by cloning the `Rc` — leaving the pool
+    // aliasing a cell the host can still write to. Nothing a `Program` owns may
+    // alias mutable state: the pool is immutable after `Program::new`, and that
+    // is what makes the reference graph among programs acyclic.
+    #[cfg(not(feature = "no_closure"))]
+    if value.is_shared() {
+        return false;
+    }
+
     // Under `no_float` Rhai has no float type and no `is_float` to ask, so
     // there is nothing here for the question to be about.
     #[cfg(not(feature = "no_float"))]

--- a/src/grain/compile/poolable.rs
+++ b/src/grain/compile/poolable.rs
@@ -73,6 +73,12 @@ pub(crate) fn is_poolable(value: &Dynamic) -> bool {
         return value.read_lock::<Decimal>().is_some();
     }
 
+    // Disregard the embedded environment in the FnPtr because it most likely
+    // will simply be the collection of all functions in the program.
+    if value.is_fnptr() {
+        return value.read_lock::<rhai::FnPtr>().is_some();
+    }
+
     // A range is a host type by representation but not by nature: Rhai builds
     // one for `0..5` and indexes strings and arrays with it, and its `TypeId`
     // is one both sides can name. Without this every slice is a fragment.
@@ -80,6 +86,6 @@ pub(crate) fn is_poolable(value: &Dynamic) -> bool {
         return true;
     }
 
-    // Anything else — FnPtr, TimeStamp, Decimal, a host type, a shared cell.
+    // Anything else — TimeStamp, a custom type, a shared cell.
     false
 }

--- a/src/grain/format/read.rs
+++ b/src/grain/format/read.rs
@@ -209,9 +209,6 @@ pub(super) fn read(bytes: &[u8]) -> Result<Program<'_>, ReadError> {
             name,
             this_type,
             params,
-            // Not encoded: derived from the chunk by `Program::new`, so a loaded
-            // program and a compiled one cannot disagree about it.
-            takes_this: false,
             chunk: get_chunk(&mut cursor)?,
         });
     }

--- a/src/grain/format/write.rs
+++ b/src/grain/format/write.rs
@@ -39,7 +39,7 @@ pub enum WriteError {
     /// chunks, so its functions are ASTs an artifact cannot hold.
     HasScriptFunctions,
     /// A pooled constant carries something that has no meaning in another
-    /// process — a host type, a function pointer, a clock reading.
+    /// process — a custom type, a clock reading etc.
     UnserializableConstant {
         /// Index into the constant pool
         index: usize,

--- a/src/grain/mod.rs
+++ b/src/grain/mod.rs
@@ -149,5 +149,5 @@ mod vm;
 
 pub use compile::Compiler;
 pub use format::{Sidecar, Stripped};
-pub use program::Program;
+pub use program::{Program, SharedProgram};
 pub use vm::{Fault, Vm};

--- a/src/grain/program.rs
+++ b/src/grain/program.rs
@@ -47,6 +47,7 @@ pub struct Function {
     ///
     /// `None` for an ordinary function, which is nearly all of them.
     pub this_type: Option<u32>,
+    /// The function's chunk.
     pub chunk: Chunk,
 }
 

--- a/src/grain/program.rs
+++ b/src/grain/program.rs
@@ -7,8 +7,8 @@ use crate::module_resolvers::StaticModuleResolver;
 use crate::{ast::Expr, ast::Stmt, tokenizer::Token, Dynamic, ImmutableString, Module, Shared};
 
 use crate::grain::bytecode::{
-    site_to_position, sites, AssignOp, Chain, Chunk, Code, Op, Pools, Positions, Root, Strings,
-    Switch, TableError,
+    site_to_position, sites, AssignOp, Chain, Chunk, Code, Pools, Positions, Strings, Switch,
+    TableError,
 };
 use crate::grain::format::{Caps, Sidecar};
 
@@ -47,12 +47,6 @@ pub struct Function {
     ///
     /// `None` for an ordinary function, which is nearly all of them.
     pub this_type: Option<u32>,
-    /// Whether the body reads or writes the frame's receiver.
-    ///
-    /// Derived from the chunk rather than encoded — see [`takes_this`]. It is
-    /// what keeps such a function reachable by Rhai, which needs the body to
-    /// size a call a native makes through a pointer.
-    pub takes_this: bool,
     pub chunk: Chunk,
 }
 
@@ -223,45 +217,6 @@ fn node_position(node: &ASTNode) -> rhai::Position {
     }
 }
 
-/// Whether a chunk reads or writes the frame's receiver.
-///
-/// Read off the bytes for [`makes_fn_pointers`]'s reason: a program loaded from
-/// an artifact never saw the body it came from.
-///
-/// It decides whether Rhai has to be able to reach the function itself. A
-/// pointer to a `this`-taking chunk cannot go through a native wrapper — the
-/// wrapper is registered at one arity, and how many arguments Rhai will ask for
-/// depends on what the *native* appends, which the wrapper cannot know. So such
-/// a function is left to Rhai, which has the body and can size the call itself.
-pub(crate) fn takes_this(code: &[u8], chunk: Chunk, chains: &[Chain]) -> bool {
-    use crate::grain::bytecode::code::tag;
-
-    let (entry, end) = (chunk.entry() as usize, chunk.end() as usize);
-    if end > code.len() || entry > end {
-        return false;
-    }
-
-    crate::grain::bytecode::disassemble(&code[entry..end]).any(|(at, op)| {
-        match code[entry + at] {
-            tag::LOAD_THIS
-            | tag::LOAD_THIS_SHARED
-            | tag::REQUIRE_THIS
-            | tag::ASSIGN_THIS
-            | tag::ASSIGN_THIS_OP
-            | tag::CALL_THIS_REF
-            | tag::CALL_FN_PTR_ON_THIS => true,
-            // A chain says where it is rooted in the pool, not in the code.
-            tag::CHAIN => match op {
-                Op::Chain(index) => chains
-                    .get(index as usize)
-                    .map_or(false, |chain| matches!(chain.root, Root::This { .. })),
-                _ => false,
-            },
-            _ => false,
-        }
-    })
-}
-
 /// Everything a program holds besides its code, gathered so the constructor
 /// does not take ten positional arguments.
 pub(crate) struct Parts<'a> {
@@ -294,13 +249,6 @@ impl<'a> Program<'a> {
         parts: Parts<'a>,
     ) -> Self {
         let has_typed_methods = functions.iter().any(|f| f.this_type.is_some());
-
-        // Derived here so a program means the same whether it was compiled or
-        // loaded, and so the flag cannot disagree with the bytes it describes.
-        let mut functions = functions;
-        for function in &mut functions {
-            function.takes_this = takes_this(&code, function.chunk, &parts.chains);
-        }
 
         // Derived from the diagnostics it was built with, unless a loader
         // supplied the artifact's.
@@ -781,7 +729,6 @@ mod tests {
                 name,
                 params: vec![0; argc],
                 this_type,
-                takes_this: false,
                 chunk: whole,
             })
             .collect();

--- a/src/grain/vm/callback.rs
+++ b/src/grain/vm/callback.rs
@@ -70,8 +70,6 @@ pub(super) fn wrappers(program: &SharedProgram) -> Module {
             continue;
         };
 
-        let owner = program.clone();
-
         let params = function
             .params
             .iter()
@@ -80,7 +78,11 @@ pub(super) fn wrappers(program: &SharedProgram) -> Module {
             .collect();
 
         module.set_script_fn(ScriptFuncDef {
-            body: ScriptFuncPayload::GrainVM(owner),
+            body: ScriptFuncPayload::GrainVM {
+                program: program.clone(),
+                params: function.params.iter().copied().collect(),
+                chunk: function.chunk,
+            },
             name: name.into(),
             access: FnAccess::Private,
             #[cfg(not(feature = "no_object"))]

--- a/src/grain/vm/callback.rs
+++ b/src/grain/vm/callback.rs
@@ -32,6 +32,7 @@ use std::prelude::v1::*;
 use crate::{
     ast::script_fn::{ScriptFuncDef, ScriptFuncPayload},
     grain::program::SharedProgram,
+    types::Span,
     FnAccess, Module,
 };
 
@@ -82,6 +83,10 @@ pub(super) fn wrappers(program: &SharedProgram) -> Module {
                 program: program.clone(),
                 params: function.params.iter().copied().collect(),
                 chunk: function.chunk,
+                span: Span::new(
+                    program.position(function.chunk.entry() as usize),
+                    program.position(function.chunk.end() as usize),
+                ),
             },
             name: name.into(),
             access: FnAccess::Private,

--- a/src/grain/vm/callback.rs
+++ b/src/grain/vm/callback.rs
@@ -29,10 +29,11 @@
 use std::prelude::v1::*;
 
 #[cfg(not(feature = "no_function"))]
-use crate::ast::script_fn::{ScriptFuncDef, ScriptFuncPayload};
-use crate::{FnAccess, Module};
-
-use crate::grain::program::SharedProgram;
+use crate::{
+    ast::script_fn::{ScriptFuncDef, ScriptFuncPayload},
+    grain::program::SharedProgram,
+    FnAccess, Module,
+};
 
 /// The most parameters a wrapper is registered for.
 ///
@@ -42,6 +43,7 @@ use crate::grain::program::SharedProgram;
 /// wrapper would be registered and never found, so it is left out rather than
 /// silently dead. Direct dispatch has no such bound; this limits only what a
 /// native can call back into.
+#[cfg(not(feature = "no_function"))]
 const MAX_PARAMS: usize = 16;
 
 /// A wrapper per compiled function, for Rhai to resolve a pointer against.
@@ -81,6 +83,7 @@ pub(super) fn wrappers(program: &SharedProgram) -> Module {
             body: ScriptFuncPayload::GrainVM(owner),
             name: name.into(),
             access: FnAccess::Private,
+            #[cfg(not(feature = "no_object"))]
             this_type: None,
             params,
             #[cfg(feature = "metadata")]

--- a/src/grain/vm/callback.rs
+++ b/src/grain/vm/callback.rs
@@ -25,17 +25,13 @@
 //! Neither touches a pointer called directly from compiled code, which is
 //! `Op::CallFnPtr` and never comes through here.
 
-use core::any::TypeId;
-use core::mem;
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
 
-use crate::{
-    func::RhaiFunc, Dynamic, FnArgsVec, FuncRegistration, Module, NativeCallContext, Shared,
-    SmartString,
-};
+#[cfg(not(feature = "no_function"))]
+use crate::ast::script_fn::{ScriptFuncDef, ScriptFuncPayload};
+use crate::{FnAccess, Module};
 
-use super::{malformed, Vm, VmResult};
 use crate::grain::program::SharedProgram;
 
 /// The most parameters a wrapper is registered for.
@@ -52,6 +48,7 @@ const MAX_PARAMS: usize = 16;
 ///
 /// Built once per run rather than cached on the program: the closures hold the
 /// program, so anything the program held back would be a cycle.
+#[cfg(not(feature = "no_function"))]
 pub(super) fn wrappers(program: &SharedProgram) -> Module {
     let mut module = Module::new();
 
@@ -67,69 +64,29 @@ pub(super) fn wrappers(program: &SharedProgram) -> Module {
         if arity > MAX_PARAMS {
             continue;
         }
-        // A `this`-taking chunk cannot be reached this way. A wrapper is
-        // registered at one arity, and how many arguments Rhai asks for depends
-        // on what the *native* appends beside the receiver — `map` adds an
-        // index, `reduce` adds the running result — which the wrapper has no way
-        // to know. Rhai's own pointer carries the body and sizes the call from
-        // its declared arity (`types/fn_ptr.rs:501-535`); a name-only pointer,
-        // which is all a wrapper can be, cannot. So these are left to Rhai,
-        // and `Program::needs_walker` is what keeps its copy alive for them.
-        if function.takes_this {
-            continue;
-        }
         let Some(name) = program.name(function.name) else {
             continue;
         };
 
         let owner = program.clone();
-        let called: SmartString = name.into();
 
-        // One closure for every arity, rather than the fixed-arity shapes
-        // `Module::set_native_fn` generates. `Dynamic` parameters throughout
-        // mean the types never have to line up, only the count.
-        let wrapper = move |context: Option<NativeCallContext>, args: &mut [&mut Dynamic]| {
-            invoke(&owner, &called, context.as_ref(), args)
-        };
+        let params = function
+            .params
+            .iter()
+            .map(|&index| program.names().get(index).unwrap_or(""))
+            .map(Into::into)
+            .collect();
 
-        FuncRegistration::new(name)
-            .in_internal_namespace()
-            .set_into_module_raw(
-                &mut module,
-                vec![TypeId::of::<Dynamic>(); arity],
-                RhaiFunc::Pure {
-                    func: Shared::new(wrapper),
-                    has_context: true,
-                    is_pure: true,
-                    is_volatile: false,
-                },
-            );
+        module.set_script_fn(ScriptFuncDef {
+            body: ScriptFuncPayload::GrainVM(owner),
+            name: name.into(),
+            access: FnAccess::Private,
+            this_type: None,
+            params,
+            #[cfg(feature = "metadata")]
+            comments: Default::default(),
+        });
     }
 
     module
-}
-
-/// Run one chunk for a native that called back into us.
-fn invoke(
-    program: &SharedProgram,
-    name: &str,
-    context: Option<&NativeCallContext>,
-    args: &mut [&mut Dynamic],
-) -> VmResult {
-    // Registered with `has_context`, so Rhai always supplies one.
-    let context =
-        context.ok_or_else(|| malformed("a callback wrapper was given no context".into()))?;
-
-    // Taken rather than cloned, as every registered function does: the
-    // arguments are the caller's to give away, and it has already copied
-    // anything it still needs.
-    let values: FnArgsVec<Dynamic> = args.iter_mut().map(|arg| mem::take(*arg)).collect();
-
-    Vm::reentrant(context).call_function(
-        program,
-        name,
-        values,
-        context.call_level(),
-        context.call_position(),
-    )
 }

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -1393,6 +1393,33 @@ impl<'e> Vm<'e> {
                     return Err(malformed("chain method arguments missing".to_string()));
                 }
 
+                #[cfg(not(feature = "no_object"))]
+                {
+                    let fn_ptr = target.as_map_mut().as_deref_mut().ok().and_then(|map| {
+                        map.get(name)
+                            .and_then(|value| value.read_lock::<FnPtr>().map(|ptr| ptr.clone()))
+                    });
+                    if let Some(fn_ptr) = fn_ptr {
+                        let mut args: FnArgsVec<Dynamic> =
+                            operands[first..first + argc].iter().cloned().collect();
+                        let mut out = self
+                            .call_map_fn_ptr_method(program, target, fn_ptr, &mut args, step_pos)?;
+
+                        return if last {
+                            if value.is_some() {
+                                Err(malformed("assignment to a method call".to_string()))
+                            } else {
+                                Ok((out, true))
+                            }
+                        } else {
+                            let result = self
+                                .walk_chain(program, chain, rest, &mut out, operands, value, pos)?
+                                .0;
+                            Ok((result, true))
+                        };
+                    }
+                }
+
                 // A method call is where Rhai tries the receiver's type before
                 // the plain name (`func/call.rs:614-629`), and the only place it
                 // does. `argc` already excludes the receiver, which is the arity
@@ -2183,12 +2210,7 @@ impl<'e> Vm<'e> {
             let context = (self.engine, pointer.fn_name(), None, &self.global, pos).into();
             pointer
                 .call_raw(&context, bound.as_mut(), &mut args)
-                .map_err(|mut err| {
-                    if err.position().is_none() {
-                        err.set_position(pos);
-                    }
-                    err
-                })
+                .map_err(|err| positioned(err, pos))
         };
 
         // Before `?`, as everywhere else: Rhai binds the receiver by reference,
@@ -2204,6 +2226,65 @@ impl<'e> Vm<'e> {
         let value = outcome?;
         self.stack.truncate(base);
         Ok(value)
+    }
+
+    /// Call a `FnPtr` found in a map by method name:
+    /// `obj.foo(..)` where `foo` is a function pointer.
+    #[cfg(not(feature = "no_object"))]
+    fn call_map_fn_ptr_method(
+        &mut self,
+        program: &Program,
+        target: &mut Dynamic,
+        fn_ptr: FnPtr,
+        args: &mut [Dynamic],
+        pos: Position,
+    ) -> VmResult {
+        let name = fn_ptr.fn_name();
+        let argc = args.len() + fn_ptr.curry().len();
+        let function = program.function_named(name, argc);
+
+        let (this, restore) = bind_this(target);
+        let mut this = Some(this);
+
+        let result = if let Some(f) = function {
+            let at = self.stack.len();
+            self.stack.extend(fn_ptr.curry().iter().cloned());
+            self.stack.extend(args.iter_mut().map(|v| v.take()));
+            let new_scope = &mut Scope::new();
+            let (result, new_this_value) = self.call_compiled_with_this(
+                program, name, &f.params, f.chunk, at, new_scope, true, pos, this,
+            );
+            self.stack.truncate(at);
+            this = new_this_value;
+            result
+        } else {
+            let mut call_args: FnArgsVec<Dynamic> = fn_ptr
+                .curry()
+                .iter()
+                .cloned()
+                .chain(args.iter().cloned())
+                .collect();
+            let mut args: FnArgsVec<&mut Dynamic> =
+                std::iter::once(this.as_mut().expect("bound above"))
+                    .chain(call_args.iter_mut())
+                    .collect();
+
+            call_engine(
+                self.engine,
+                &mut self.global,
+                &mut self.caches,
+                &mut Scope::new(),
+                name,
+                &mut args,
+                true,
+                true,
+                pos,
+            )
+        };
+
+        unbind_this(target, this, restore);
+
+        result
     }
 
     /// Carry a write through `obj.call(f)`'s `this` back to `obj` itself.
@@ -4334,7 +4415,7 @@ mod tests {
     use crate::grain::bytecode::{assemble, Chain, Chunk, Op, Positions, Step, Strings, Tail};
     use crate::grain::format::Abi;
     use crate::grain::program::{Function, Parts};
-    use crate::{CallFnOptions, Engine, Scope, INT};
+    use crate::{CallFnOptions, Engine, Map, Scope, INT};
 
     /// A program of phantom functions, named `f` upwards in the order given.
     ///
@@ -4587,6 +4668,75 @@ mod tests {
 
         let mut this = Dynamic::from(7 as INT);
         assert_eq!(call(&program, Some(&mut this)).unwrap().as_int(), Ok(7));
+    }
+
+    #[test]
+    #[cfg(not(feature = "no_object"))]
+    fn a_map_method_step_calls_a_fnptr_property_in_oop_style() {
+        let mut map = Map::new();
+        map.insert("g".into(), FnPtr::new("g").expect("valid name").into());
+
+        let program = program_with_chains(
+            // `f` is `#{ g: Fn("g") }.g()`; `g` is `this`.
+            &[
+                &[Op::Const(0), Op::Chain(0), Op::Return],
+                &[Op::LoadThis, Op::Return],
+            ],
+            vec![Dynamic::from_map(map)],
+            vec![Chain {
+                root: Root::Temporary,
+                steps: vec![Step::Method {
+                    name: 1, // `g`
+                    argc: 0,
+                    operand: 0,
+                    flags: Default::default(),
+                    pos: Position::NONE,
+                }],
+                tail: Tail::Read,
+                operands: 0,
+            }],
+        );
+
+        let out = call(&program, None).expect("map fnptr method call should succeed");
+        let map = out.as_map_ref().expect("fnptr body returns `this` map");
+        assert!(
+            map.contains_key("g"),
+            "expected the map returned through `this`"
+        );
+    }
+
+    #[test]
+    #[cfg(not(feature = "no_object"))]
+    fn a_map_fnptr_method_in_oop_style_beats_a_registered_method_with_the_same_name() {
+        let mut map = Map::new();
+        map.insert("len".into(), FnPtr::new("g").expect("valid name").into());
+
+        let program = program_with_chains(
+            // `f` is `#{ len: Fn("g") }.len()`; `g` is `this`.
+            &[
+                &[Op::Const(0), Op::Chain(0), Op::Return],
+                &[Op::LoadThis, Op::Return],
+            ],
+            vec![Dynamic::from_map(map)],
+            vec![Chain {
+                root: Root::Temporary,
+                steps: vec![Step::Method {
+                    name: 3, // `len`
+                    argc: 0,
+                    operand: 0,
+                    flags: Default::default(),
+                    pos: Position::NONE,
+                }],
+                tail: Tail::Read,
+                operands: 0,
+            }],
+        );
+
+        let out = call(&program, None).expect("map fnptr method call should succeed");
+        assert!(
+            out.is_map(),
+            "expected map fnptr dispatch to win over built-in map `len()`"
+        );
     }
 
     /// And a write inside that callee travels back out through both frames: the

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -33,7 +33,9 @@ use crate::{
 mod callback;
 
 use crate::grain::bytecode::{code, AssignOp, Chain, Chunk, Receiver, Root, Step, StepFlags, Tail};
-use crate::grain::program::{Program, SharedModule, SharedProgram};
+#[cfg(not(feature = "no_function"))]
+use crate::grain::program::SharedProgram;
+use crate::grain::program::{Program, SharedModule};
 
 /// Rhai's own `RhaiResult`, which it does not re-export.
 pub type VmResult = Result<Dynamic, Box<EvalAltResult>>;

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -386,7 +386,7 @@ pub struct Vm<'e> {
     /// `this` never inherited: a plain nested call passes `None` and gets the
     /// caller's back on the way out, reproducing `func/call.rs:669` without a
     /// conditional anywhere.
-    this_ptr: Option<Dynamic>,
+    this: Option<Dynamic>,
     /// Whether this `Vm` started the run, and so may clear its trace.
     ///
     /// False for a [`Vm::reentrant`]: a callback clearing the trace would
@@ -485,7 +485,7 @@ impl<'e> Vm<'e> {
             handlers: Vec::new(),
             sizes: Vec::new(),
             unwind_floor: 0,
-            this_ptr: None,
+            this: None,
             owns_trace: true,
             chain_step: 0,
             pending_slot: None,
@@ -528,7 +528,7 @@ impl<'e> Vm<'e> {
             unwind_floor: 0,
             // A crossing carries no receiver: Rhai binds one only where it
             // dispatches a method, and this arrives through `call_fn_raw`.
-            this_ptr: None,
+            this: None,
             // `global` is a clone, so the trace is shared with the run that
             // called in and is not this call's to clear.
             owns_trace: false,
@@ -663,7 +663,7 @@ impl<'e> Vm<'e> {
         scope: &mut Scope,
         rewind_scope: bool,
         pos: Position,
-        this_ptr: Option<Dynamic>,
+        this: Option<Dynamic>,
     ) -> (VmResult, Option<Dynamic>) {
         // An entry point in its own right so the trace starts here rather than at `run_main`.
         self.clear_faults();
@@ -686,7 +686,7 @@ impl<'e> Vm<'e> {
             scope,
             rewind_scope,
             pos,
-            this_ptr,
+            this,
         );
         self.global.level = restore;
 
@@ -1180,7 +1180,7 @@ impl<'e> Vm<'e> {
         // storage, so a body that mutated and then raised has already written;
         // restoring only on success would discard exactly that.
         if let RootValue::This(value) = root {
-            self.this_ptr = Some(value);
+            self.this = Some(value);
         }
 
         let (out, _) = result?;
@@ -1226,7 +1226,7 @@ impl<'e> Vm<'e> {
             // rather than the `.` after it (`eval/chaining.rs:519-527`).
             Root::This { pos: this_pos } => {
                 let value = self
-                    .this_ptr
+                    .this
                     .take()
                     .ok_or_else(|| Box::new(EvalAltResult::ErrorUnboundThis(this_pos)))?;
                 Ok(ChainRoot {
@@ -2246,7 +2246,7 @@ impl<'e> Vm<'e> {
                 }
             }
             Some(Receiver::This) => {
-                if let Some(entry) = self.this_ptr.as_mut() {
+                if let Some(entry) = self.this.as_mut() {
                     *entry = value;
                 }
             }
@@ -2732,10 +2732,7 @@ impl<'e> Vm<'e> {
         // A function this compiler lowered copies its first argument whatever it
         // is handed, exactly as Rhai copies one before running a script function
         // (`func/call.rs:661`), so a compiled callee rules a reference out too.
-        let by_reference = self
-            .this_ptr
-            .as_ref()
-            .map_or(false, |value| !is_shared!(value))
+        let by_reference = self.this.as_ref().map_or(false, |value| !is_shared!(value))
             && program.function(name_index, argc).is_none();
 
         if !by_reference {
@@ -2748,7 +2745,7 @@ impl<'e> Vm<'e> {
 
         let value = {
             let entry = self
-                .this_ptr
+                .this
                 .as_mut()
                 .ok_or_else(|| malformed("`this` stopped being bound".to_string()))?;
             // Argument zero is the snapshot, dead now that there is a register
@@ -2812,9 +2809,9 @@ impl<'e> Vm<'e> {
         scope: &mut Scope,
         rewind_scope: bool,
         pos: Position,
-        this_ptr: Option<Dynamic>,
+        this: Option<Dynamic>,
     ) -> (VmResult, Option<Dynamic>) {
-        let saved = mem::replace(&mut self.this_ptr, this_ptr);
+        let saved = mem::replace(&mut self.this, this);
 
         let result = match self.engine.track_operation(&mut self.global, pos) {
             Ok(()) => {
@@ -2835,7 +2832,7 @@ impl<'e> Vm<'e> {
             Err(err) => Err(err),
         };
 
-        (result, mem::replace(&mut self.this_ptr, saved))
+        (result, mem::replace(&mut self.this, saved))
     }
 
     fn call_compiled_body(
@@ -2987,7 +2984,7 @@ impl<'e> Vm<'e> {
                 &mut self.global,
                 &mut self.caches,
                 scope,
-                self.this_ptr.as_mut(),
+                self.this.as_mut(),
                 (&node).into(),
                 event,
             );
@@ -3044,7 +3041,7 @@ impl<'e> Vm<'e> {
             &mut self.global,
             &mut self.caches,
             scope,
-            self.this_ptr.as_mut(),
+            self.this.as_mut(),
             &node,
         );
         rewind_after_stop(scope, before);
@@ -3674,7 +3671,7 @@ impl<'e> Vm<'e> {
 
                 code::tag::LOAD_THIS | code::tag::LOAD_THIS_SHARED => {
                     let value = self
-                        .this_ptr
+                        .this
                         .as_ref()
                         .ok_or_else(|| Box::new(EvalAltResult::ErrorUnboundThis(pos())))?;
                     // Rhai's read is `this_ptr.cloned()` and does not flatten
@@ -3688,7 +3685,7 @@ impl<'e> Vm<'e> {
                 }
 
                 code::tag::REQUIRE_THIS => {
-                    if self.this_ptr.is_none() {
+                    if self.this.is_none() {
                         return Err(Box::new(EvalAltResult::ErrorUnboundThis(pos())));
                     }
                 }
@@ -3715,7 +3712,7 @@ impl<'e> Vm<'e> {
                     // that lost its receiver would answer `ErrorUnboundThis` to
                     // every read after this one.
                     let mut this = self
-                        .this_ptr
+                        .this
                         .take()
                         .ok_or_else(|| Box::new(EvalAltResult::ErrorUnboundThis(pos())))?;
 
@@ -3735,7 +3732,7 @@ impl<'e> Vm<'e> {
                         }
                     };
 
-                    self.this_ptr = Some(this);
+                    self.this = Some(this);
                     outcome?;
                 }
 
@@ -3768,7 +3765,7 @@ impl<'e> Vm<'e> {
                             &mut self.global,
                             &mut self.caches,
                             scope,
-                            self.this_ptr.as_mut(),
+                            self.this.as_mut(),
                             block.statements(),
                             rewind_scope,
                         ),
@@ -3776,7 +3773,7 @@ impl<'e> Vm<'e> {
                             &mut self.global,
                             &mut self.caches,
                             scope,
-                            self.this_ptr.as_mut(),
+                            self.this.as_mut(),
                             expr,
                         ),
                     }?;
@@ -4425,13 +4422,10 @@ mod tests {
         program_of(&[ops], consts)
     }
 
-    fn call(
-        program: &Program,
-        this_ptr: Option<&mut Dynamic>,
-    ) -> Result<Dynamic, Box<EvalAltResult>> {
+    fn call(program: &Program, this: Option<&mut Dynamic>) -> Result<Dynamic, Box<EvalAltResult>> {
         let engine = Engine::new();
         let mut options = CallFnOptions::new().eval_ast(false);
-        options.this_ptr = this_ptr;
+        options.this_ptr = this;
         Vm::new(&engine).call_fn_with_options(options, &mut Scope::new(), program, "f", ())
     }
 

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -4421,7 +4421,7 @@ mod tests {
     use crate::grain::bytecode::{assemble, Chain, Chunk, Op, Positions, Step, Strings, Tail};
     use crate::grain::format::Abi;
     use crate::grain::program::{Function, Parts};
-    use crate::{CallFnOptions, Engine, Map, Scope, INT};
+    use crate::{CallFnOptions, Engine, Scope, INT};
 
     /// A program of phantom functions, named `f` upwards in the order given.
     ///
@@ -4679,7 +4679,7 @@ mod tests {
     #[test]
     #[cfg(not(feature = "no_object"))]
     fn a_map_method_step_calls_a_fnptr_property_in_oop_style() {
-        let mut map = Map::new();
+        let mut map = crate::Map::new();
         map.insert("g".into(), FnPtr::new("g").expect("valid name").into());
 
         let program = program_with_chains(
@@ -4714,7 +4714,7 @@ mod tests {
     #[test]
     #[cfg(not(feature = "no_object"))]
     fn a_map_fnptr_method_in_oop_style_beats_a_registered_method_with_the_same_name() {
-        let mut map = Map::new();
+        let mut map = crate::Map::new();
         map.insert("len".into(), FnPtr::new("g").expect("valid name").into());
 
         let program = program_with_chains(

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -631,9 +631,21 @@ impl<'e> Vm<'e> {
         level: usize,
         pos: Position,
     ) -> VmResult {
+        let Some(function) = program.function_named(name, args.len()) else {
+            return Err(Box::new(EvalAltResult::ErrorFunctionNotFound(
+                format!("{name} ({} args)", args.len()),
+                pos,
+            )));
+        };
+
+        let (params, chunk) = (&function.params, function.chunk);
+
         let scope = &mut Scope::new();
-        self.call_function_with_this(program, name, args, level, scope, true, pos, None)
-            .0
+
+        self.call_function_with_this(
+            program, name, params, chunk, args, level, scope, true, pos, None,
+        )
+        .0
     }
 
     /// The same, against a receiver the callee owns for the duration.
@@ -644,6 +656,8 @@ impl<'e> Vm<'e> {
         &mut self,
         program: &Program,
         name: &str,
+        params: &[u32],
+        chunk: Chunk,
         args: FnArgsVec<Dynamic>,
         level: usize,
         scope: &mut Scope,
@@ -657,17 +671,6 @@ impl<'e> Vm<'e> {
         #[cfg(feature = "debugging")]
         self.pending_steps.clear();
 
-        let Some(function) = program.function_named(name, args.len()) else {
-            return (
-                Err(Box::new(EvalAltResult::ErrorFunctionNotFound(
-                    format!("{name} ({} args)", args.len()),
-                    pos,
-                ))),
-                this_ptr,
-            );
-        };
-        let (params, chunk) = (function.params.clone(), function.chunk);
-
         // `call_compiled` takes its arguments off the operand stack, where a
         // compiled call site would already have put them.
         let first = self.stack.len();
@@ -677,7 +680,7 @@ impl<'e> Vm<'e> {
         let (result, this) = self.call_compiled_with_this(
             program,
             name,
-            &params,
+            params,
             chunk,
             first,
             scope,
@@ -777,28 +780,40 @@ impl<'e> Vm<'e> {
                 evaluated = unwind_exit(vm.run_main(program, scope)).map(|_| ());
             }
 
-            let (result, returned) = if evaluated.is_ok() {
-                vm.call_function_with_this(
-                    program,
-                    name,
-                    arg_values,
-                    0,
-                    scope,
-                    options.rewind_scope,
-                    Position::NONE,
+            if let Some(function) = program.function_named(name, arg_values.len()) {
+                let (result, returned) = if evaluated.is_ok() {
+                    vm.call_function_with_this(
+                        program,
+                        name,
+                        &function.params,
+                        function.chunk,
+                        arg_values,
+                        0,
+                        scope,
+                        options.rewind_scope,
+                        Position::NONE,
+                        this,
+                    )
+                } else {
+                    (Ok(Dynamic::UNIT), this)
+                };
+
+                // However it went, and whether the call happened at all: Rhai
+                // reports the end of a `call_fn` unconditionally
+                // (`api/call_fn.rs:302-308`).
+                #[cfg(feature = "debugging")]
+                let result = vm.at_end(scope).and(result);
+
+                (result, returned)
+            } else {
+                (
+                    Err(Box::new(EvalAltResult::ErrorFunctionNotFound(
+                        format!("{name} ({} args)", arg_values.len()),
+                        Position::NONE,
+                    ))),
                     this,
                 )
-            } else {
-                (Ok(Dynamic::UNIT), this)
-            };
-
-            // However it went, and whether the call happened at all: Rhai
-            // reports the end of a `call_fn` unconditionally
-            // (`api/call_fn.rs:302-308`).
-            #[cfg(feature = "debugging")]
-            let result = vm.at_end(scope).and(result);
-
-            (result, returned)
+            }
         });
 
         // Before the errors below, both of them: Rhai's mutation through `this`
@@ -2486,6 +2501,7 @@ impl<'e> Vm<'e> {
     ) -> VmResult {
         // Run compiled function if available.
         if let Some(function) = program.function(name_index, argc) {
+            let name = program.name(function.name).unwrap_or("<unknown>");
             return self.call_compiled(
                 program,
                 name,

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -33,9 +33,7 @@ use crate::{
 mod callback;
 
 use crate::grain::bytecode::{code, AssignOp, Chain, Chunk, Receiver, Root, Step, StepFlags, Tail};
-#[cfg(not(feature = "no_function"))]
-use crate::grain::program::SharedProgram;
-use crate::grain::program::{Program, SharedModule};
+use crate::grain::program::{Program, SharedModule, SharedProgram};
 
 /// Rhai's own `RhaiResult`, which it does not re-export.
 pub type VmResult = Result<Dynamic, Box<EvalAltResult>>;
@@ -896,11 +894,16 @@ impl<'e> Vm<'e> {
     /// # Errors
     ///
     /// As [`eval_with_scope`](Self::eval_with_scope).
-    #[cfg(not(feature = "no_function"))]
     pub fn eval_with_callbacks(&mut self, scope: &mut Scope, program: &SharedProgram) -> VmResult {
-        let wrappers =
-            (!program.functions().is_empty()).then(|| callback::wrappers(program).into());
-        self.run_with(program, scope, wrappers)
+        #[cfg(not(feature = "no_function"))]
+        return if program.functions().is_empty() {
+            self.run_with(program, scope, None)
+        } else {
+            let wrappers = callback::wrappers(program).into();
+            self.run_with(program, scope, Some(wrappers))
+        };
+        #[cfg(feature = "no_function")]
+        return self.run_with(program, scope, None);
     }
 
     fn run_with(

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -3665,6 +3665,12 @@ impl<'e> Vm<'e> {
                     let name = program
                         .name(index)
                         .ok_or_else(|| malformed(format!("no name {index}")))?;
+                    // If shadowing is not allowed, return error.
+                    if !self.engine.allow_shadowing() && scope.contains(name) {
+                        return Err(
+                            EvalAltResult::ErrorVariableExists(name.to_string(), pos()).into()
+                        );
+                    }
                     // Flattened, as Rhai flattens a declaration's initializer
                     // (`eval/stmt.rs:438`). A native can hand back a cell that is
                     // already shared, and sharing must stop at the `let` rather

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -2935,7 +2935,7 @@ impl<'e> Vm<'e> {
             if self.global.level > self.engine.max_call_levels() {
                 return Err(Box::new(EvalAltResult::ErrorStackOverflow(pos)));
             }
-            if params.len() > self.engine.max_variables() {
+            if scope.len() + params.len() > self.engine.max_variables() {
                 return Err(Box::new(EvalAltResult::ErrorTooManyVariables(pos)));
             }
         }
@@ -3676,6 +3676,13 @@ impl<'e> Vm<'e> {
                     // already shared, and sharing must stop at the `let` rather
                     // than becoming a property of the new local.
                     let value = self.pop()?.flatten();
+
+                    // Guard against too many variables
+                    #[cfg(not(feature = "unchecked"))]
+                    if scope.len() >= self.engine.max_variables() {
+                        return Err(EvalAltResult::ErrorTooManyVariables(pos()).into());
+                    }
+
                     if tag == code::tag::DECLARE_CONST {
                         scope.push_constant_dynamic(name, value);
                     } else {

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -386,7 +386,7 @@ pub struct Vm<'e> {
     /// `this` never inherited: a plain nested call passes `None` and gets the
     /// caller's back on the way out, reproducing `func/call.rs:669` without a
     /// conditional anywhere.
-    this: Option<Dynamic>,
+    this_ptr: Option<Dynamic>,
     /// Whether this `Vm` started the run, and so may clear its trace.
     ///
     /// False for a [`Vm::reentrant`]: a callback clearing the trace would
@@ -479,13 +479,13 @@ impl<'e> Vm<'e> {
             engine,
             global,
             caches: Caches::new(),
-            strings_interner: StringsInterner::new(256),
+            strings_interner: StringsInterner::new(64),
             stack: Vec::new(),
             iterators: Vec::new(),
             handlers: Vec::new(),
             sizes: Vec::new(),
             unwind_floor: 0,
-            this: None,
+            this_ptr: None,
             owns_trace: true,
             chain_step: 0,
             pending_slot: None,
@@ -520,7 +520,7 @@ impl<'e> Vm<'e> {
             engine: context.engine(),
             global: context.global_runtime_state().clone(),
             caches: Caches::new(),
-            strings_interner: StringsInterner::new(256),
+            strings_interner: StringsInterner::new(64),
             stack: Vec::new(),
             iterators: Vec::new(),
             handlers: Vec::new(),
@@ -528,7 +528,7 @@ impl<'e> Vm<'e> {
             unwind_floor: 0,
             // A crossing carries no receiver: Rhai binds one only where it
             // dispatches a method, and this arrives through `call_fn_raw`.
-            this: None,
+            this_ptr: None,
             // `global` is a clone, so the trace is shared with the run that
             // called in and is not this call's to clear.
             owns_trace: false,
@@ -640,7 +640,7 @@ impl<'e> Vm<'e> {
     ///
     /// The receiver comes back however the call ended, for the caller to put
     /// where it took it from — see [`bind_this`] and [`unbind_this`].
-    fn call_function_with_this(
+    pub(crate) fn call_function_with_this(
         &mut self,
         program: &Program,
         name: &str,
@@ -649,7 +649,7 @@ impl<'e> Vm<'e> {
         scope: &mut Scope,
         rewind_scope: bool,
         pos: Position,
-        this: Option<Dynamic>,
+        this_ptr: Option<Dynamic>,
     ) -> (VmResult, Option<Dynamic>) {
         // An entry point in its own right so the trace starts here rather than at `run_main`.
         self.clear_faults();
@@ -663,7 +663,7 @@ impl<'e> Vm<'e> {
                     format!("{name} ({} args)", args.len()),
                     pos,
                 ))),
-                this,
+                this_ptr,
             );
         };
         let (params, chunk) = (function.params.clone(), function.chunk);
@@ -683,7 +683,7 @@ impl<'e> Vm<'e> {
             scope,
             rewind_scope,
             pos,
-            this,
+            this_ptr,
         );
         self.global.level = restore;
 
@@ -894,6 +894,7 @@ impl<'e> Vm<'e> {
     /// # Errors
     ///
     /// As [`eval_with_scope`](Self::eval_with_scope).
+    #[cfg(not(feature = "no_function"))]
     pub fn eval_with_callbacks(&mut self, scope: &mut Scope, program: &SharedProgram) -> VmResult {
         let wrappers =
             (!program.functions().is_empty()).then(|| callback::wrappers(program).into());
@@ -1159,7 +1160,7 @@ impl<'e> Vm<'e> {
         // storage, so a body that mutated and then raised has already written;
         // restoring only on success would discard exactly that.
         if let RootValue::This(value) = root {
-            self.this = Some(value);
+            self.this_ptr = Some(value);
         }
 
         let (out, _) = result?;
@@ -1205,7 +1206,7 @@ impl<'e> Vm<'e> {
             // rather than the `.` after it (`eval/chaining.rs:519-527`).
             Root::This { pos: this_pos } => {
                 let value = self
-                    .this
+                    .this_ptr
                     .take()
                     .ok_or_else(|| Box::new(EvalAltResult::ErrorUnboundThis(this_pos)))?;
                 Ok(ChainRoot {
@@ -2225,7 +2226,7 @@ impl<'e> Vm<'e> {
                 }
             }
             Some(Receiver::This) => {
-                if let Some(entry) = self.this.as_mut() {
+                if let Some(entry) = self.this_ptr.as_mut() {
                     *entry = value;
                 }
             }
@@ -2710,7 +2711,10 @@ impl<'e> Vm<'e> {
         // A function this compiler lowered copies its first argument whatever it
         // is handed, exactly as Rhai copies one before running a script function
         // (`func/call.rs:661`), so a compiled callee rules a reference out too.
-        let by_reference = self.this.as_ref().map_or(false, |value| !is_shared!(value))
+        let by_reference = self
+            .this_ptr
+            .as_ref()
+            .map_or(false, |value| !is_shared!(value))
             && program.function(name_index, argc).is_none();
 
         if !by_reference {
@@ -2723,7 +2727,7 @@ impl<'e> Vm<'e> {
 
         let value = {
             let entry = self
-                .this
+                .this_ptr
                 .as_mut()
                 .ok_or_else(|| malformed("`this` stopped being bound".to_string()))?;
             // Argument zero is the snapshot, dead now that there is a register
@@ -2787,9 +2791,9 @@ impl<'e> Vm<'e> {
         scope: &mut Scope,
         rewind_scope: bool,
         pos: Position,
-        this: Option<Dynamic>,
+        this_ptr: Option<Dynamic>,
     ) -> (VmResult, Option<Dynamic>) {
-        let saved = mem::replace(&mut self.this, this);
+        let saved = mem::replace(&mut self.this_ptr, this_ptr);
 
         let result = match self.engine.track_operation(&mut self.global, pos) {
             Ok(()) => {
@@ -2810,7 +2814,7 @@ impl<'e> Vm<'e> {
             Err(err) => Err(err),
         };
 
-        (result, mem::replace(&mut self.this, saved))
+        (result, mem::replace(&mut self.this_ptr, saved))
     }
 
     fn call_compiled_body(
@@ -2962,7 +2966,7 @@ impl<'e> Vm<'e> {
                 &mut self.global,
                 &mut self.caches,
                 scope,
-                self.this.as_mut(),
+                self.this_ptr.as_mut(),
                 (&node).into(),
                 event,
             );
@@ -3019,7 +3023,7 @@ impl<'e> Vm<'e> {
             &mut self.global,
             &mut self.caches,
             scope,
-            self.this.as_mut(),
+            self.this_ptr.as_mut(),
             &node,
         );
         rewind_after_stop(scope, before);
@@ -3649,7 +3653,7 @@ impl<'e> Vm<'e> {
 
                 code::tag::LOAD_THIS | code::tag::LOAD_THIS_SHARED => {
                     let value = self
-                        .this
+                        .this_ptr
                         .as_ref()
                         .ok_or_else(|| Box::new(EvalAltResult::ErrorUnboundThis(pos())))?;
                     // Rhai's read is `this_ptr.cloned()` and does not flatten
@@ -3663,7 +3667,7 @@ impl<'e> Vm<'e> {
                 }
 
                 code::tag::REQUIRE_THIS => {
-                    if self.this.is_none() {
+                    if self.this_ptr.is_none() {
                         return Err(Box::new(EvalAltResult::ErrorUnboundThis(pos())));
                     }
                 }
@@ -3690,7 +3694,7 @@ impl<'e> Vm<'e> {
                     // that lost its receiver would answer `ErrorUnboundThis` to
                     // every read after this one.
                     let mut this = self
-                        .this
+                        .this_ptr
                         .take()
                         .ok_or_else(|| Box::new(EvalAltResult::ErrorUnboundThis(pos())))?;
 
@@ -3710,7 +3714,7 @@ impl<'e> Vm<'e> {
                         }
                     };
 
-                    self.this = Some(this);
+                    self.this_ptr = Some(this);
                     outcome?;
                 }
 
@@ -3743,7 +3747,7 @@ impl<'e> Vm<'e> {
                             &mut self.global,
                             &mut self.caches,
                             scope,
-                            self.this.as_mut(),
+                            self.this_ptr.as_mut(),
                             block.statements(),
                             rewind_scope,
                         ),
@@ -3751,7 +3755,7 @@ impl<'e> Vm<'e> {
                             &mut self.global,
                             &mut self.caches,
                             scope,
-                            self.this.as_mut(),
+                            self.this_ptr.as_mut(),
                             expr,
                         ),
                     }?;
@@ -4368,7 +4372,6 @@ mod tests {
                 name: index as u32,
                 params: Vec::new(),
                 this_type: None,
-                takes_this: false,
                 chunk: Chunk::new(end_of(span.start), end_of(span.end), 8),
             })
             .collect();
@@ -4401,10 +4404,13 @@ mod tests {
         program_of(&[ops], consts)
     }
 
-    fn call(program: &Program, this: Option<&mut Dynamic>) -> Result<Dynamic, Box<EvalAltResult>> {
+    fn call(
+        program: &Program,
+        this_ptr: Option<&mut Dynamic>,
+    ) -> Result<Dynamic, Box<EvalAltResult>> {
         let engine = Engine::new();
         let mut options = CallFnOptions::new().eval_ast(false);
-        options.this_ptr = this;
+        options.this_ptr = this_ptr;
         Vm::new(&engine).call_fn_with_options(options, &mut Scope::new(), program, "f", ())
     }
 

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -1517,10 +1517,10 @@ impl Engine {
                     // Payload is a statements block
                     crate::ast::script_fn::ScriptFuncPayload::Statements(..) => {
                         let mut fn_def = crate::func::shared_take_or_clone(fn_def);
-                        let crate::ast::script_fn::ScriptFuncPayload::Statements(mut body) =
-                            fn_def.body
-                        else {
-                            unreachable!()
+                        let mut body = match fn_def.body {
+                            crate::ast::script_fn::ScriptFuncPayload::Statements(body) => body,
+                            #[cfg(feature = "grain")]
+                            crate::ast::script_fn::ScriptFuncPayload::GrainVM(..) => unreachable!(),
                         };
                         let statements = body.take_statements();
                         *body.statements_mut() =
@@ -1528,8 +1528,9 @@ impl Engine {
                         fn_def.body = crate::ast::script_fn::ScriptFuncPayload::Statements(body);
                         fn_def.into()
                     }
-                    // Can't optimize anything else
-                    _ => fn_def,
+                    // Payload is a Grain VM function chunk -- cannot optimize
+                    #[cfg(feature = "grain")]
+                    crate::ast::script_fn::ScriptFuncPayload::GrainVM(..) => fn_def,
                 }
             }))
             .into()

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -1516,7 +1516,12 @@ impl Engine {
                 match fn_def.body {
                     // Payload is a statements block
                     crate::ast::script_fn::ScriptFuncPayload::Statements(..) => {
+                        // We cannot just bind to the body here because the `fn_def`
+                        // is wrapped within an `Rc` (or `Arc`).
+                        // It is impossible to take ownership of the body inside
+                        // `fn_def` unless we consume or clone it first.
                         let mut fn_def = crate::func::shared_take_or_clone(fn_def);
+                        // Use a `match` instead of `let ... else` to shut up clippy.
                         let mut body = match fn_def.body {
                             crate::ast::script_fn::ScriptFuncPayload::Statements(body) => body,
                             #[cfg(feature = "grain")]
@@ -1524,13 +1529,16 @@ impl Engine {
                                 unreachable!()
                             }
                         };
+                        // Consume the statements block body and optimize it
                         let statements = body.take_statements();
                         *body.statements_mut() =
                             self.optimize_top_level(statements, scope, lib2, optimization_level);
+                        // Write back the optimized body
                         fn_def.body = crate::ast::script_fn::ScriptFuncPayload::Statements(body);
+                        // Return it as a new `ScriptFuncDef`
                         fn_def.into()
                     }
-                    // Payload is a Grain VM function chunk -- cannot optimize
+                    // Payload is a Grain VM function chunk -- cannot be optimized
                     #[cfg(feature = "grain")]
                     crate::ast::script_fn::ScriptFuncPayload::GrainVM { .. } => fn_def,
                 }

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -1512,12 +1512,23 @@ impl Engine {
             let lib2 = &[lib2.into()];
 
             crate::Module::from(functions.into_iter().map(|fn_def| {
+                use crate::ast::ScriptFuncPayload;
+
                 // Optimize the function body
-                let mut fn_def = crate::func::shared_take_or_clone(fn_def);
-                let statements = fn_def.body.take_statements();
-                *fn_def.body.statements_mut() =
-                    self.optimize_top_level(statements, scope, lib2, optimization_level);
-                fn_def.into()
+                match fn_def.body {
+                    // Payload is a statements block
+                    ScriptFuncPayload::Statements(..) => {
+                        let mut fn_def = crate::func::shared_take_or_clone(fn_def);
+                        let mut body = match fn_def.body {
+                            ScriptFuncPayload::Statements(body) => body,
+                        };
+                        let statements = body.take_statements();
+                        *body.statements_mut() =
+                            self.optimize_top_level(statements, scope, lib2, optimization_level);
+                        fn_def.body = ScriptFuncPayload::Statements(body);
+                        fn_def.into()
+                    }
+                }
             }))
             .into()
         };

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -1520,7 +1520,9 @@ impl Engine {
                         let mut body = match fn_def.body {
                             crate::ast::script_fn::ScriptFuncPayload::Statements(body) => body,
                             #[cfg(feature = "grain")]
-                            crate::ast::script_fn::ScriptFuncPayload::GrainVM(..) => unreachable!(),
+                            crate::ast::script_fn::ScriptFuncPayload::GrainVM { .. } => {
+                                unreachable!()
+                            }
                         };
                         let statements = body.take_statements();
                         *body.statements_mut() =
@@ -1530,7 +1532,7 @@ impl Engine {
                     }
                     // Payload is a Grain VM function chunk -- cannot optimize
                     #[cfg(feature = "grain")]
-                    crate::ast::script_fn::ScriptFuncPayload::GrainVM(..) => fn_def,
+                    crate::ast::script_fn::ScriptFuncPayload::GrainVM { .. } => fn_def,
                 }
             }))
             .into()

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -1512,22 +1512,24 @@ impl Engine {
             let lib2 = &[lib2.into()];
 
             crate::Module::from(functions.into_iter().map(|fn_def| {
-                use crate::ast::ScriptFuncPayload;
-
                 // Optimize the function body
                 match fn_def.body {
                     // Payload is a statements block
-                    ScriptFuncPayload::Statements(..) => {
+                    crate::ast::script_fn::ScriptFuncPayload::Statements(..) => {
                         let mut fn_def = crate::func::shared_take_or_clone(fn_def);
-                        let mut body = match fn_def.body {
-                            ScriptFuncPayload::Statements(body) => body,
+                        let crate::ast::script_fn::ScriptFuncPayload::Statements(mut body) =
+                            fn_def.body
+                        else {
+                            unreachable!()
                         };
                         let statements = body.take_statements();
                         *body.statements_mut() =
                             self.optimize_top_level(statements, scope, lib2, optimization_level);
-                        fn_def.body = ScriptFuncPayload::Statements(body);
+                        fn_def.body = crate::ast::script_fn::ScriptFuncPayload::Statements(body);
                         fn_def.into()
                     }
+                    // Can't optimize anything else
+                    _ => fn_def,
                 }
             }))
             .into()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,10 +1,11 @@
 //! Main module defining the lexer and parser.
 
 use crate::api::options::LangOptions;
+#[cfg(not(feature = "no_function"))]
+use crate::ast::script_fn::{ScriptFuncDef, ScriptFuncPayload};
 use crate::ast::{
     ASTFlags, BinaryExpr, CaseBlocksList, Expr, FlowControl, FnCallExpr, FnCallHashes, Ident,
-    OpAssignment, RangeCase, ScriptFuncDef, Stmt, StmtBlock, StmtBlockContainer,
-    SwitchCasesCollection,
+    OpAssignment, RangeCase, Stmt, StmtBlock, StmtBlockContainer, SwitchCasesCollection,
 };
 use crate::engine::{Precedence, OP_CONTAINS, OP_NOT};
 use crate::eval::{Caches, GlobalRuntimeState};
@@ -3698,7 +3699,7 @@ impl Engine {
             #[cfg(not(feature = "no_object"))]
             this_type,
             params,
-            body,
+            body: ScriptFuncPayload::Statements(body),
             #[cfg(feature = "metadata")]
             comments: comments.into_iter().collect(),
         })
@@ -3913,7 +3914,7 @@ impl Engine {
             #[cfg(not(feature = "no_object"))]
             this_type: None,
             params,
-            body: body.into(),
+            body: ScriptFuncPayload::Statements(body.into()),
             #[cfg(not(feature = "no_function"))]
             #[cfg(feature = "metadata")]
             comments: <_>::default(),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,10 +2,11 @@
 
 use crate::api::options::LangOptions;
 #[cfg(not(feature = "no_function"))]
-use crate::ast::script_fn::{ScriptFuncDef, ScriptFuncPayload};
+use crate::ast::script_fn::ScriptFuncPayload;
 use crate::ast::{
     ASTFlags, BinaryExpr, CaseBlocksList, Expr, FlowControl, FnCallExpr, FnCallHashes, Ident,
-    OpAssignment, RangeCase, Stmt, StmtBlock, StmtBlockContainer, SwitchCasesCollection,
+    OpAssignment, RangeCase, ScriptFuncDef, Stmt, StmtBlock, StmtBlockContainer,
+    SwitchCasesCollection,
 };
 use crate::engine::{Precedence, OP_CONTAINS, OP_NOT};
 use crate::eval::{Caches, GlobalRuntimeState};

--- a/src/types/fn_ptr.rs
+++ b/src/types/fn_ptr.rs
@@ -582,11 +582,24 @@ impl FnPtr {
         extras: [Dynamic; E],
         move_this_ptr_to_args: usize,
     ) -> RhaiResult {
+        // Wrap the error in an `ErrorInFunctionCall`
+        fn wrap_err(result: RhaiResult, ctx: &NativeCallContext, caller_fn: &str) -> RhaiResult {
+            result.map_err(|err| {
+                Box::new(ERR::ErrorInFunctionCall(
+                    caller_fn.to_string(),
+                    ctx.call_source().unwrap_or("").to_string(),
+                    err,
+                    Position::NONE,
+                ))
+            })
+        }
+
         match self.typ {
             #[cfg(not(feature = "no_function"))]
             FnPtrType::Script { num_params, .. } => {
                 if num_params == N + self.curry().len() {
-                    return self.call_raw(ctx, this_ptr, args);
+                    let result = self.call_raw(ctx, this_ptr, args);
+                    return wrap_err(result, ctx, caller_fn);
                 }
                 if MOVE_PTR {
                     if let Some(this_ptr) = this_ptr.as_deref() {
@@ -599,7 +612,8 @@ impl FnPtr {
                                 args2.extend(args);
                                 args2.insert(move_this_ptr_to_args, this_ptr.clone());
                             }
-                            return self.call_raw(ctx, None, args2);
+                            let result = self.call_raw(ctx, None, args2);
+                            return wrap_err(result, ctx, caller_fn);
                         }
                         if num_params == N + E + 1 + self.curry().len() {
                             let mut args2 = FnArgsVec::with_capacity(args.len() + extras.len() + 1);
@@ -612,7 +626,8 @@ impl FnPtr {
                                 args2.extend(extras);
                                 args2.insert(move_this_ptr_to_args, this_ptr.clone());
                             }
-                            return self.call_raw(ctx, None, args2);
+                            let result = self.call_raw(ctx, None, args2);
+                            return wrap_err(result, ctx, caller_fn);
                         }
                     }
                 }
@@ -620,7 +635,8 @@ impl FnPtr {
                     let mut args2 = FnArgsVec::with_capacity(args.len() + extras.len());
                     args2.extend(args);
                     args2.extend(extras);
-                    return self.call_raw(ctx, this_ptr, args2);
+                    let result = self.call_raw(ctx, this_ptr, args2);
+                    return wrap_err(result, ctx, caller_fn);
                 }
             }
             _ => (),
@@ -669,14 +685,7 @@ impl FnPtr {
                 }
                 _ => Err(err),
             })
-            .map_err(|err| {
-                Box::new(ERR::ErrorInFunctionCall(
-                    caller_fn.to_string(),
-                    ctx.call_source().unwrap_or("").to_string(),
-                    err,
-                    Position::NONE,
-                ))
-            })
+            .or_else(|err| wrap_err(Err(err), ctx, caller_fn))
     }
 }
 

--- a/src/types/scope.rs
+++ b/src/types/scope.rs
@@ -801,6 +801,7 @@ impl Scope<'_> {
     ///
     /// If the entry is read-only, [`Some`]`(`[`None`]`))` is returned.
     #[inline]
+    #[cfg(feature = "grain")]
     #[must_use]
     pub(crate) fn get_mut_raw(&mut self, name: &str) -> Option<Option<&mut Dynamic>> {
         self.search(name)

--- a/tests/grain/callback.rs
+++ b/tests/grain/callback.rs
@@ -166,14 +166,29 @@ fn a_callback_costs_more_call_levels() {
 
 #[test]
 fn without_the_wrappers_the_pointer_does_not_resolve() {
-    // The whole reason `eval_with_callbacks` exists. A plain eval leaves Rhai
-    // nowhere to look, and the failure is a lookup failure rather than
-    // anything worse.
     let engine = corpus::engine();
-    let source = "let a = [1, 2, 3]; a.map(|x| x * 2)";
-    let ast = engine.compile(source).unwrap();
-    let program = Compiler::new().compile(&ast);
 
-    let err = Vm::new(&engine).eval_with_scope(&mut Scope::new(), &program).unwrap_err();
-    assert!(format!("{err:?}").contains("ErrorFunctionNotFound"), "{err}");
+    const SCRIPTS: &[&str] = &[
+        "let a = [1, 2, 3]; a.map(|x| x * 2)",
+        "let a = [1, 2, 3]; a.map(|| this * 2)",
+        "let a = [1, 2, 3]; a.filter(|x| x % 2 == 0).map(|| this * 2)",
+        "let a = [1, 2, 3]; a.reduce(|a, v| if a == () { v } else { a + v })",
+        "let a = [1, 2, 3]; a.reduce(|a| if a == () { this } else { a + this })",
+        "let s = 0; let a = [10, 20, 30]; a.for_each(|i| s += i); s",
+        "let s = 0; let a = [10, 20, 30]; a.for_each(|| s += this); s",
+    ];
+
+    for source in SCRIPTS {
+        // The AST walker and VM must agree.
+        agree(source);
+
+        // Now check that the program is a callback that requires wrappers.
+        let ast = engine.compile(source).unwrap();
+        let program = Compiler::new().compile(&ast);
+
+        assert!(program.makes_fn_pointers(), "{source} must be a program a host is told to run with callbacks",);
+
+        let err = Vm::new(&engine).eval_with_scope(&mut Scope::new(), &program).unwrap_err();
+        assert!(format!("{err:?}").contains("ErrorFunctionNotFound"), "{source}: {err}");
+    }
 }

--- a/tests/grain/corpus/mod.rs
+++ b/tests/grain/corpus/mod.rs
@@ -198,6 +198,7 @@ pub fn applies_to_this_build(name: &str) -> bool {
                 | "is_def_fn"
                 | "map_computed_order"
                 | "map_read_of_absent_key_is_not_visible_to_a_closure"
+                | "oop_style_calling"
                 | "switch_on_a_shared_subject_matches"
                 | "switch_range_on_a_shared_subject_matches"
                 | "temp_root_call"

--- a/tests/grain/corpus/mod.rs
+++ b/tests/grain/corpus/mod.rs
@@ -353,6 +353,7 @@ pub fn applies_to_this_build(name: &str) -> bool {
                 | "index_expression_reads_the_root"
                 | "interpolation_of_containers"
                 | "nested_containers"
+                | "oop_style_calling"
                 | "property_assign_deep"
                 | "string_ops"
                 | "temp_root_array_method"
@@ -854,6 +855,8 @@ pub const CASES: &[Case] = &[
     case("closure_for_each_binds_this", "let t = 0; [1, 2, 3].for_each(|| t += this); t"),
     // And the argument form, which takes the element as a parameter instead.
     case("closure_map_takes_an_argument", "[1, 2, 3].map(|x| x * 2)"),
+    // OOP-style calling.
+    case("oop_style_calling", "let map = #{ value: 42, foo: |x| { this.value += x; }}; map.foo(8);"),
     // `type_of` has no registered implementation anywhere — Rhai answers it by
     // name — so it is reached through the same door every other call is.
     // A constant argument is folded by the optimizer and proves nothing.

--- a/tests/grain/differential.rs
+++ b/tests/grain/differential.rs
@@ -27,7 +27,10 @@ struct Outcome {
 }
 
 fn snapshot_scope(scope: &Scope) -> Vec<(String, String)> {
-    scope.iter_raw().map(|(name, _, value)| (name.to_string(), format!("{value:?}"))).collect()
+    scope
+        .iter_raw()
+        .map(|(name, _, value)| (name.to_string(), format!("{value:?}").replace("Fn*", "Fn").replace("Fn+", "Fn")))
+        .collect()
 }
 
 fn run_stock(engine: &Engine, source: &str) -> Outcome {

--- a/tests/grain/format.rs
+++ b/tests/grain/format.rs
@@ -24,8 +24,11 @@ struct Outcome {
 /// A finished run, reduced to what two of them can be compared on.
 fn snapshot(scope: &Scope, result: Result<Dynamic, Box<rhai::EvalAltResult>>) -> Outcome {
     Outcome {
-        result: result.map(|value| format!("{value:?}")).map_err(|err| format!("{err:?}")),
-        scope: scope.iter_raw().map(|(name, _, value)| (name.to_string(), format!("{value:?}"))).collect(),
+        result: result.map(|value| format!("{value:?}")).map_err(|err| format!("{err:?}").replace("Fn*", "Fn").replace("Fn+", "Fn")),
+        scope: scope
+            .iter_raw()
+            .map(|(name, _, value)| (name.to_string(), format!("{value:?}").replace("Fn*", "Fn").replace("Fn+", "Fn")))
+            .collect(),
     }
 }
 

--- a/tests/grain/fuzz.rs
+++ b/tests/grain/fuzz.rs
@@ -180,8 +180,11 @@ impl std::fmt::Debug for Outcome {
 
 fn snapshot(scope: &Scope, result: Result<Dynamic, Box<rhai::EvalAltResult>>) -> Outcome {
     Outcome {
-        result: result.map(|value| format!("{value:?}")).map_err(|err| format!("{err:?}")),
-        scope: scope.iter_raw().map(|(name, _, value)| (name.to_string(), format!("{value:?}"))).collect(),
+        result: result.map(|value| format!("{value:?}")).map_err(|err| format!("{err:?}").replace("Fn*", "Fn").replace("Fn+", "Fn")),
+        scope: scope
+            .iter_raw()
+            .map(|(name, _, value)| (name.to_string(), format!("{value:?}").replace("Fn*", "Fn").replace("Fn+", "Fn")))
+            .collect(),
     }
 }
 


### PR DESCRIPTION
This is a re-architect of the attempt to make Grain function chunks callable from native functions registered in Rhai in a seamless manner that all existing code would work.

This approach starts from a different direction -- instead of fitting Grain into an unaccommodating Rhai, Rhai is taught that different types of scripted functions exist.

Therefore, it replaces a scripted function's body (normally a `StmtBlock`) with an enum specifying the type of the payload.

* A `Statements` payload works the same as before.

* A `GrainVM` payload is given a shared `Program` to run.

Thus nothing changes in Rhai, nor in Grain.  You can observe that none of the files touched by previous attempts (e.g. `fn_ptr.rs`) is modified.

Rhai now knows that a Grain wrapper is a scripted function (not disguised as a native) and calls it directly.

A side benefit is that `takes_this` is no longer necessary. There is no difference in call shapes as Rhai knows the function is a script.

@ImTheSquid   I'm quite sure this is missing the `vm.adopt(program)` and `release` etc. that has to do with multiple levels of reentrency...
