### PR TITLE
VM: Make sure constants are checked for capabilities.

### DIFF
--- a/src/grain/bytecode/verify.rs
+++ b/src/grain/bytecode/verify.rs
@@ -2,6 +2,7 @@ use crate::grain::bytecode::code::{self, tag};
 use crate::grain::bytecode::{Chain, Chunk, Op, Receiver, Root, Step, Switch, Tail};
 use crate::grain::format::Caps;
 use crate::grain::program::Function;
+use crate::Dynamic;
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
 
@@ -162,11 +163,39 @@ pub enum VerifyError {
 /// declare.
 pub fn verify(
     caps: Caps,
+    consts: &[Dynamic],
     code: &[u8],
     functions: &[Function],
     chunks: &[Chunk],
     pools: &Pools,
 ) -> Result<Vec<u16>, VerifyError> {
+    // Before we start, check whether we need caps to handle constants.
+    for v in consts {
+        fn check_caps(do_check: bool, host: Caps, required: Caps) -> Result<(), VerifyError> {
+            if do_check && !host.contains(required) {
+                Err(VerifyError::MissingCaps {
+                    at: 0,
+                    artifact: host.to_string(),
+                    missing: required.to_string(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+
+        #[cfg(not(feature = "no_float"))]
+        check_caps(v.is_float(), caps, Caps::FLOAT)?;
+        #[cfg(feature = "decimal")]
+        check_caps(v.is_decimal(), caps, Caps::DECIMAL)?;
+        #[cfg(not(feature = "no_index"))]
+        check_caps(v.is_array(), caps, Caps::ARRAY)?;
+        #[cfg(not(feature = "no_index"))]
+        check_caps(v.is_blob(), caps, Caps::BLOB)?;
+        #[cfg(not(feature = "no_object"))]
+        check_caps(v.is_map(), caps, Caps::MAP)?;
+        check_caps(v.is_fnptr(), caps, Caps::FN_PTR)?;
+    }
+
     // Pass one: where do instructions start?
     //
     // Over the whole buffer at once, because every chunk shares it and an
@@ -762,14 +791,14 @@ mod tests {
     fn check(ops: Vec<Op>) -> Result<Vec<u16>, VerifyError> {
         let (code, _) = assemble(&ops).expect("the test ops must assemble");
         let chunk = Chunk::new(0, code.len() as u32, 8);
-        verify(Abi::host().caps, &code, &[], &[chunk], &pools())
+        verify(Abi::host().caps, &[], &code, &[], &[chunk], &pools())
     }
 
     /// The same, for bytes `assemble` would refuse to produce — which is what
     /// a corrupt artifact hands the loader.
     fn check_bytes(code: Vec<u8>, max_stack: u16) -> Result<Vec<u16>, VerifyError> {
         let chunk = Chunk::new(0, code.len() as u32, max_stack);
-        verify(Abi::host().caps, &code, &[], &[chunk], &pools())
+        verify(Abi::host().caps, &[], &code, &[], &[chunk], &pools())
     }
 
     #[test]
@@ -879,7 +908,7 @@ mod tests {
             };
             assert!(
                 matches!(
-                    verify(Abi::host().caps, &code, &[], &[chunk], &pools),
+                    verify(Abi::host().caps, &[], &code, &[], &[chunk], &pools),
                     Err(VerifyError::BadIndex {
                         what: "name",
                         index: 3,
@@ -901,6 +930,7 @@ mod tests {
         assert!(matches!(
             verify(
                 Abi::host().caps,
+                &[],
                 &code,
                 &[],
                 &[chunk],
@@ -934,7 +964,7 @@ mod tests {
             Chunk::new(boundary, code.len() as u32, 8),
         ];
         assert!(matches!(
-            verify(Abi::host().caps, &code, &[], &chunks, &pools()),
+            verify(Abi::host().caps, &[], &code, &[], &chunks, &pools()),
             Err(VerifyError::JumpOutOfRange { .. }),
         ));
     }
@@ -1034,6 +1064,7 @@ mod tests {
         assert_eq!(
             verify(
                 Abi::host().caps,
+                &[],
                 &code,
                 &[],
                 &[chunk],
@@ -1051,6 +1082,7 @@ mod tests {
             matches!(
                 verify(
                     Abi::host().caps,
+                    &[],
                     &code,
                     &[],
                     &[chunk],
@@ -1070,6 +1102,7 @@ mod tests {
             matches!(
                 verify(
                     Abi::host().caps,
+                    &[],
                     &code,
                     &[],
                     &[chunk],
@@ -1130,6 +1163,7 @@ mod tests {
         assert!(matches!(
             verify(
                 Abi::host().caps,
+                &[],
                 &code,
                 &[],
                 &[chunk],
@@ -1180,6 +1214,7 @@ mod tests {
         assert!(matches!(
             verify(
                 Abi::host().caps,
+                &[],
                 &code,
                 &[],
                 &[Chunk::new(0, 9999, 8)],

--- a/src/grain/program.rs
+++ b/src/grain/program.rs
@@ -333,8 +333,9 @@ impl<'a> Program<'a> {
     pub fn verify(&self) -> Result<Vec<u16>, crate::grain::bytecode::VerifyError> {
         crate::grain::bytecode::verify(
             self.caps,
+            self.consts(),
             &self.code,
-            &self.functions(),
+            self.functions(),
             &self.chunks(),
             &self.pools(),
         )


### PR DESCRIPTION
Constants in an artifact are not checked for required caps (e.g. float, array).

This PR corrects it.
