### PR TITLE
VM: Support bare function name as variable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Bug fixes
 ---------
 
 * Fixed bug in using bare function name as a variable (identified by Grain VM).
+* Support bare function names as variables in Rhai Grain ([`#1158`](https://github.com/rhaiscript/rhai/pull/1158)).
 
 
 Version 1.26.0

--- a/src/grain/compile/mod.rs
+++ b/src/grain/compile/mod.rs
@@ -81,23 +81,7 @@ impl Compiler {
     /// Lower an `AST` into a [`Program`].
     #[must_use]
     pub fn compile(&self, ast: &AST) -> Program<'static> {
-        // A bare script-function name used as a value is not a variable read
-        // at all — Rhai turns it into a function pointer with the calling
-        // environment attached (`eval/expr.rs:71-99`) — so those names must
-        // not become `LoadNamed`. Carried across every restart below, because
-        // function bodies are lowered after one. Under `no_function` an `AST`
-        // declares none, so there is nothing to hold back.
-        #[cfg(not(feature = "no_function"))]
-        let script_fns: Vec<ImmutableString> = ast
-            .shared_lib()
-            .iter_script_fn_info()
-            .map(|(.., def)| def.name.clone())
-            .collect();
-        #[cfg(feature = "no_function")]
-        let script_fns: Vec<ImmutableString> = Vec::new();
-
         let fresh = |caps| Lowering {
-            script_fns: script_fns.clone(),
             caps,
             ..Lowering::default()
         };
@@ -323,8 +307,6 @@ struct Lowering {
     /// The same for `try` regions: a `break` out of one has to disarm it, or
     /// the next unrelated error is caught into a block already left.
     handlers: usize,
-    /// Names that are script functions rather than variables.
-    script_fns: Vec<ImmutableString>,
     /// How many statements enclose the one being lowered, for the marker
     /// [`Lowering::statement`] emits. Restored on the way out, so it is the
     /// nesting rather than a running count.
@@ -423,7 +405,7 @@ impl Lowering {
                 // function pointer rather than a variable, and turning one
                 // into a name lookup would report it missing where Rhai hands
                 // back a pointer.
-                None if self.is_variable_name(&v.1, false) => Root::Named {
+                None if self.is_variable_name(false) => Root::Named {
                     name: self.push_name(v.1.clone()),
                     pos: root.position(),
                 },
@@ -1097,7 +1079,7 @@ impl Lowering {
             // lives differs.
             Stmt::Assignment(payload)
                 if matches!(&payload.1.lhs, Expr::Variable(v, ..)
-                    if self.is_variable_name(&v.1, has_namespace!(v))) =>
+                    if self.is_variable_name(has_namespace!(v))) =>
             {
                 let (op_info, binary) = &**payload;
                 let Expr::Variable(v, ..) = &binary.lhs else {
@@ -1612,13 +1594,12 @@ impl Lowering {
                     // Not a local this compiler declared, so no slot can name
                     // it: it is the caller's, a module's, or nothing. Looked
                     // up by name at run time, at the cost of a scope scan.
-                    _ if self.is_variable_name(&payload.1, is_qualified) => {
+                    _ if self.is_variable_name(is_qualified) => {
                         let name = self.push_name(payload.1.clone());
                         self.emit_at(Op::LoadNamed(name), expr.position());
                     }
-                    // A qualified name resolves against imported modules, and
-                    // a bare function name is a function pointer. Neither is a
-                    // variable read, and both stay Rhai's job.
+                    // A qualified name resolves against imported modules, so it
+                    // stays Rhai's job.
                     _ => self.residual_expr(expr),
                 }
             }
@@ -1854,7 +1835,7 @@ impl Lowering {
             Expr::Variable(payload, ..) if !has_namespace!(payload) => {
                 match self.slots.resolve(&payload.1) {
                     Some(slot) => Some(Receiver::Local(slot)),
-                    None if self.is_variable_name(&payload.1, false) => {
+                    None if self.is_variable_name(false) => {
                         Some(Receiver::Named(self.push_name(payload.1.clone())))
                     }
                     None => None,
@@ -1893,7 +1874,7 @@ impl Lowering {
 
         match self.slots.resolve(&payload.1) {
             Some(slot) if !qualified => Some(Receiver::Local(slot)),
-            _ if self.is_variable_name(&payload.1, qualified) => {
+            _ if self.is_variable_name(qualified) => {
                 Some(Receiver::Named(self.push_name(payload.1.clone())))
             }
             _ => None,
@@ -1970,11 +1951,13 @@ impl Lowering {
     /// Whether a name read is a variable read at all.
     ///
     /// A qualified name resolves against imported modules rather than the
-    /// scope, and a bare script-function name is a function pointer with the
-    /// calling environment attached (`eval/expr.rs:71-99`). Neither is
-    /// something to look up by name, and both stay fragments.
-    fn is_variable_name(&self, name: &ImmutableString, qualified: bool) -> bool {
-        !qualified && !self.script_fns.contains(name)
+    /// scope, so it stays a fragment.
+    ///
+    /// Currently everything else is considered a valid variable name.
+    /// Keeping this a separate function for future expansion purposes.
+    #[inline(always)]
+    const fn is_variable_name(&self, qualified: bool) -> bool {
+        !qualified
     }
 
     /// Pool what `x op= y` needs, if there is an operator at all.
@@ -2011,7 +1994,7 @@ impl Lowering {
                     Some(slot) => self.emit(Op::LoadShared(slot)),
                     // The caller's. A closure can capture one of those too, and
                     // reading it flat would bind a copy.
-                    None if self.is_variable_name(&payload.1, false) => {
+                    None if self.is_variable_name(false) => {
                         let name = self.push_name(payload.1.clone());
                         self.emit_at(Op::LoadSharedNamed(name), expr.position());
                     }
@@ -2672,6 +2655,34 @@ mod tests {
             order,
             [("alpha", 1), ("alpha", 2), ("mike", 0), ("zulu", 1)],
             "functions must be lowered by name and arity, not by hash",
+        );
+    }
+
+    #[test]
+    fn a_bare_script_function_name_lowers_as_a_named_read() {
+        let engine = crate::Engine::new();
+        let ast = engine
+            .compile("fn answer() { 42 } answer")
+            .expect("must compile");
+        let program = Compiler::new().compile(&ast);
+
+        let named_reads: Vec<_> = crate::grain::bytecode::disassemble(program.code())
+            .filter_map(|(.., op)| match op {
+                Op::LoadNamed(name) => Some(name),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            named_reads
+                .iter()
+                .any(|name| program.name(*name) == Some("answer")),
+            "a bare script-function name should lower into `LoadNamed`, got {named_reads:?}",
+        );
+        assert_eq!(
+            program.residual_count(),
+            0,
+            "lowering a bare script-function name should not leave a residual AST fragment",
         );
     }
 

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -1972,10 +1972,11 @@ impl<'e> Vm<'e> {
     /// Read a variable no slot names, the way Rhai's `search_scope_only` does
     /// (`eval/expr.rs:107-155`).
     ///
-    /// Three places in a fixed order, and the order is observable: a resolver
-    /// registered with `Engine::on_var` sees the name before the scope does,
-    /// and a name in no scope is looked for among the global modules before it
-    /// is reported missing.
+    /// Fixed order:
+    /// 1) a var resolver registered with `Engine::on_var`
+    /// 2) a var in the scope
+    /// 3) a var among global modules
+    /// 4) this program's compiled function table
     ///
     /// `flatten` is what the two reads differ by, and only for a scope entry:
     /// a value position wants what a shared cell contains, and a capture wants
@@ -1984,6 +1985,7 @@ impl<'e> Vm<'e> {
     /// Kept out of the dispatch loop for the reason [`Vm::call_compiled`] is.
     fn load_named(
         &mut self,
+        program: &Program,
         name: &str,
         scope: &mut Scope,
         flatten: bool,
@@ -1995,6 +1997,7 @@ impl<'e> Vm<'e> {
             return Ok(value);
         }
 
+        // Search in scope.
         if let Some(value) = scope.get(name) {
             return Ok(if flatten {
                 value.flatten_clone()
@@ -2011,6 +2014,17 @@ impl<'e> Vm<'e> {
             .find_map(|module| module.get_var(name))
         {
             return Ok(value);
+        }
+
+        // A compiled function.
+        if let Some(value) = program
+            .functions()
+            .iter()
+            .any(|f| program.name(f.name) == Some(name))
+            .then(|| FnPtr::new(name).ok())
+            .flatten()
+        {
+            return Ok(value.into());
         }
 
         Err(missing(name, pos))
@@ -3627,7 +3641,7 @@ impl<'e> Vm<'e> {
                         .name(index)
                         .ok_or_else(|| malformed(format!("no name {index}")))?;
                     let flatten = tag == code::tag::LOAD_NAMED;
-                    let value = self.load_named(name, scope, flatten, pos())?;
+                    let value = self.load_named(program, name, scope, flatten, pos())?;
                     self.stack.push(value);
                 }
 
@@ -4515,6 +4529,40 @@ mod tests {
         let mut options = CallFnOptions::new().eval_ast(false);
         options.this_ptr = this;
         Vm::new(&engine).call_fn_with_options(options, &mut Scope::new(), program, "f", ())
+    }
+
+    #[test]
+    fn a_named_read_falls_back_to_a_script_function_pointer_from_global_lib() {
+        let engine = Engine::new();
+        let ast = engine.compile("fn f(x) { x + 1 } f").expect("must compile");
+        let program = crate::grain::compile::Compiler::new().compile(&ast);
+
+        let value = Vm::new(&engine)
+            .eval_with_scope(&mut Scope::new(), &program)
+            .expect("reading a bare script-function name should produce a function pointer");
+        let pointer = value
+            .try_cast::<FnPtr>()
+            .expect("reading `f` should return an `FnPtr`");
+
+        assert_eq!(pointer.fn_name(), "f");
+    }
+
+    #[test]
+    fn a_scope_variable_beats_script_function_pointer_fallback() {
+        let engine = Engine::new();
+        let ast = engine.compile("fn f(x) { x + 1 } f").expect("must compile");
+        let program = crate::grain::compile::Compiler::new().compile(&ast);
+        let mut scope = Scope::new();
+        scope.push("f", 123 as INT);
+
+        let value = Vm::new(&engine)
+            .eval_with_scope(&mut scope, &program)
+            .expect("scope variable read should succeed");
+        assert_eq!(
+            value.as_int(),
+            Ok(123),
+            "scope lookup should win before script function-pointer fallback",
+        );
     }
 
     #[test]

--- a/tests/grain/scope.rs
+++ b/tests/grain/scope.rs
@@ -367,16 +367,8 @@ fn a_name_that_is_nowhere_is_reported_the_same_way() {
     agree("nope += 1", |_| {}, true);
 }
 
-/// A bare script-function name is a function pointer with the calling
-/// environment attached (`eval/expr.rs:71-99`), not a variable read, so it
-/// must stay a fragment rather than becoming a name lookup that fails.
-///
-/// Checked on the compiled program rather than by running it, because running
-/// it currently disagrees with the walker for an unrelated reason: `execute`
-/// forces `always_search_scope` whenever a program has any fragment, and that
-/// flag makes Rhai skip the function-pointer branch entirely
-/// (`eval/expr.rs:62`). Reported separately — it predates named variables, and
-/// the fix is about residuals rather than about this.
+/// A bare script-function name lowers to a named read and resolves to a
+/// function pointer at run time.
 #[test]
 #[cfg(not(any(feature = "no_function", feature = "no_object")))]
 fn a_script_function_name_is_not_a_variable() {
@@ -384,12 +376,12 @@ fn a_script_function_name_is_not_a_variable() {
     let ast = engine.compile("fn helper() { 1 } let f = helper; f.call()").expect("must compile");
     let program = Compiler::new().compile(&ast);
 
-    assert!(program.residual_count() > 0, "a function name must not become a name lookup",);
-    assert!(
-        !rhai::grain::bytecode::disassemble(program.code()).any(|(.., op)| matches!(op, rhai::grain::bytecode::Op::LoadNamed(..))),
-        "nothing in {:?} may load `helper` by name",
-        program,
-    );
+    assert_eq!(program.residual_count(), 0, "a script-function name should lower without residual AST fragments",);
+    assert!(rhai::grain::bytecode::disassemble(program.code()).any(|(.., op)| matches!(op, rhai::grain::bytecode::Op::LoadNamed(..))), "the lowered program should read `helper` by name",);
+    let out = Vm::new(&engine)
+        .eval_with_scope(&mut Scope::new(), &program)
+        .expect("a script-function name should resolve as a function pointer");
+    assert_eq!(out.as_int().unwrap(), 1);
 }
 
 /// The last of the three places Rhai looks: a constant a host published on a


### PR DESCRIPTION
The VM previously did not handle using a function's name as a variable, returning it as a residual fragment, such as:

```rust
fn increment(x) { x + 1 }

[1, 2, 3].map(increment);       // 'increment' is a FnPtr
```

As the base `FnPtr` function pointer data type has been patched upstream (https://github.com/rhaiscript/rhai/commit/648c684861ad143067b67c4e444b389ddb9f1015) such that it no longer carries an embedded environment (something the VM cannot handle), this restriction can be removed.

The bug was early discovered by Grain but I didn't get to it until now.

This PR adds back the support.
