### PR TITLE
VM: Improve callback performance 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Version 1.27.0
 Bug fixes
 ---------
 
-* Fixed bug in using bare function names as a variable (identified by Grain VM, [`#1158`](https://github.com/rhaiscript/rhai/pull/1158)).
+* Fixed bug in using bare function name as a variable (identified by Grain VM).
 
 
 Version 1.26.0

--- a/fuzz/fuzz_targets/grain_roundtrip.rs
+++ b/fuzz/fuzz_targets/grain_roundtrip.rs
@@ -33,21 +33,8 @@ fn engine() -> Engine {
     engine
 }
 
-/// A value, with the one difference between the two sides that is intended.
-///
-/// Rhai renders a closure pointer `Fn*+("anon$..")` — a script function with a
-/// captured environment attached — and ours `Fn("anon$..")`, because ours is
-/// name-only and resolved at call time. That is the whole point: a `Script`
-/// pointer carries an AST, and an AST is what an artifact must not contain.
-/// The difference is deliberate, pinned by `a_closure_pointer_is_late_bound` in
-/// `tests/scope.rs`, and left in the rendering rather than papered over there.
-///
-/// Here it has to be papered over, or the first script whose value is a bare
-/// closure ends the run — which is within a few thousand executions.
 fn rendered(value: &Dynamic) -> String {
-    format!("{value:?}")
-        .replace("Fn*+(", "Fn(")
-        .replace("Fn*(", "Fn(")
+    format!("{value:?}").replace("Fn*(", "Fn(")
 }
 
 /// A run reduced to something two of them can be compared on, scope included:

--- a/src/grain/bytecode/op.rs
+++ b/src/grain/bytecode/op.rs
@@ -213,8 +213,8 @@ pub enum Op {
     ///
     /// `op` indexes the operator pool when the call is an operator, and names
     /// the token the built-in lookup keys on. The walker short-circuits these
-    /// to a function pointer rather than dispatching, and a VM that did not
-    /// would be slower than the tree it replaced.
+    /// rather than dispatching, and a VM that did not would be slower than the
+    /// tree it replaced.
     Call {
         /// The name of the function
         name: u32,

--- a/src/grain/bytecode/switch.rs
+++ b/src/grain/bytecode/switch.rs
@@ -277,9 +277,6 @@ mod tests {
     fn a_non_hashable_subject_falls_through_rather_than_panicking() {
         let one = int(1);
         let table = table(&[(&one, 10)], Vec::new(), 99);
-
-        // A bare function pointer *is* hashable; only one carrying an
-        // environment is not. A host type is the reliable case.
         let non_hashable = Dynamic::from(Opaque);
         assert!(
             !non_hashable.is_hashable(),

--- a/src/grain/compile/mod.rs
+++ b/src/grain/compile/mod.rs
@@ -1578,43 +1578,6 @@ impl Lowering {
                 self.caps.insert(Caps::FLOAT);
                 self.constant(Dynamic::from(**value))
             }
-            // Folded by the optimizer, so it can hold anything a constant call
-            // returned — including a function pointer, which must not be
-            // copied out of a pool. See `poolable`.
-            // A function pointer the optimizer folded — `Fn("f")` with a
-            // constant name, or a closure literal. It cannot go in the pool:
-            // a closure's carries a `ScriptFuncDef`, which is an AST body and
-            // exactly what an artifact must not contain. Rebuilt by name
-            // instead, which reaches the chunk we compiled from that same
-            // body.
-            //
-            // A constant function pointer: a closure literal, or what the
-            // optimizer folds `Fn("f")` into. Either way it embeds a
-            // `ScriptFuncDef` — an AST body, `Fn*` in Rhai's own rendering —
-            // so it cannot go in the pool. Rebuilt by name instead, reaching
-            // the chunk compiled from that same body.
-            //
-            // There is no version of this that keeps the rendering: the thing
-            // that differs *is* the tree, and carrying it is what an artifact
-            // must not do. `a_closure_pointer_is_late_bound` pins the
-            // difference for both spellings.
-            //
-            // Curried values are arbitrary `Dynamic`s with the same problem one
-            // level down, and are left to the walker.
-            Expr::DynamicConstant(value, ..)
-                if value
-                    .read_lock::<rhai::FnPtr>()
-                    .map_or(false, |f| f.curry().is_empty()) =>
-            {
-                let name = value
-                    .read_lock::<rhai::FnPtr>()
-                    .expect("checked by the guard")
-                    .fn_name()
-                    .to_string();
-                let name = self.push_name(name.into());
-                self.emit_at(Op::MakeClosure(name), expr.position());
-                self.caps.insert(Caps::FN_PTR);
-            }
 
             Expr::DynamicConstant(value, ..) if is_poolable(value) => {
                 #[cfg(not(feature = "no_index"))]
@@ -1632,6 +1595,9 @@ impl Lowering {
                 #[cfg(feature = "decimal")]
                 if value.is_decimal() {
                     self.caps.insert(Caps::DECIMAL);
+                }
+                if value.is_fnptr() {
+                    self.caps.insert(Caps::FN_PTR);
                 }
                 self.constant((**value).clone());
             }

--- a/src/grain/compile/poolable.rs
+++ b/src/grain/compile/poolable.rs
@@ -15,13 +15,6 @@ use rust_decimal::Decimal;
 /// The artifact must be loadable in another process, which rules out anything
 /// carrying a host `TypeId`, a live `Rc`, or a clock reading: `Variant`,
 /// `Shared`, `TimeStamp`.
-///
-/// And `FnPtr` is not a value the VM may simply clone into place, even in the
-/// same process. Rhai attaches the calling environment when it reads a
-/// function pointer out of a constant (`ast/expr.rs:471-482`), so a pointer
-/// copied straight from the pool would be missing the module library it was
-/// created against. Keeping it out of the pool leaves it as a fragment, which
-/// evaluates through the path that does the attaching.
 pub(crate) fn is_poolable(value: &Dynamic) -> bool {
     // A shared cell first, because every question below sees through one:
     // `is_array` and friends unwrap `Union::Shared`, so a shared array of ints
@@ -73,8 +66,6 @@ pub(crate) fn is_poolable(value: &Dynamic) -> bool {
         return value.read_lock::<Decimal>().is_some();
     }
 
-    // Disregard the embedded environment in the FnPtr because it most likely
-    // will simply be the collection of all functions in the program.
     if value.is_fnptr() {
         return value.read_lock::<rhai::FnPtr>().is_some();
     }

--- a/src/grain/format/mod.rs
+++ b/src/grain/format/mod.rs
@@ -109,6 +109,11 @@ mod constant {
     pub const RANGE: u8 = 0x0a;
     pub const RANGE_INCLUSIVE: u8 = 0x0b;
     pub const DECIMAL: u8 = 0x0c;
+    pub const FN_PTR: u8 = 0x0d;
+
+    pub const FN_PTR_TYPE_NORMAL: u8 = 0x81;
+    #[cfg(not(feature = "no_function"))]
+    pub const FN_PTR_TYPE_SCRIPT: u8 = 0x82;
 }
 
 /// Everything a stripped artifact left behind.

--- a/src/grain/format/read.rs
+++ b/src/grain/format/read.rs
@@ -1,4 +1,5 @@
-use crate::{tokenizer::Token, types::StringsInterner, Dynamic};
+use crate::types::fn_ptr::FnPtrType;
+use crate::{tokenizer::Token, types::StringsInterner, Dynamic, FnPtr, ThinVec};
 use core::convert::{TryFrom, TryInto};
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
@@ -523,6 +524,33 @@ fn get_constant(
         constant::RANGE_INCLUSIVE => {
             let start = bounded_int(cursor.ivarint()?)?;
             Dynamic::from(start..=bounded_int(cursor.ivarint()?)?)
+        }
+
+        constant::FN_PTR => {
+            let name = strings_interner.get(cursor.str()?);
+            let count = cursor.uvarint()?;
+            let mut curry = ThinVec::new();
+            for _ in 0..count {
+                curry.push(get_constant(cursor, strings_interner, depth + 1)?);
+            }
+            let typ = match cursor.byte()? {
+                constant::FN_PTR_TYPE_NORMAL => FnPtrType::Normal,
+                #[cfg(not(feature = "no_function"))]
+                constant::FN_PTR_TYPE_SCRIPT => {
+                    let num_params = cursor.uvarint()? as usize;
+                    FnPtrType::Script {
+                        num_params,
+                        hash: crate::calc_fn_hash(None, &name, num_params),
+                    }
+                }
+                tag => {
+                    return Err(ReadError::UnknownTag {
+                        section: "constant",
+                        tag,
+                    })
+                }
+            };
+            Dynamic::from(FnPtr { name, curry, typ })
         }
 
         #[cfg(not(feature = "no_index"))]

--- a/src/grain/format/write.rs
+++ b/src/grain/format/write.rs
@@ -2,11 +2,12 @@ use core::ops::{Range, RangeInclusive};
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
 
+use crate::types::fn_ptr::FnPtrType;
 #[cfg(not(feature = "no_object"))]
-use rhai::Map;
-use rhai::{tokenizer::Token, Dynamic, INT};
+use crate::Map;
+use crate::{tokenizer::Token, Dynamic, FnPtr, INT};
 #[cfg(not(feature = "no_index"))]
-use rhai::{Array, Blob};
+use crate::{Array, Blob};
 
 use crate::grain::bytecode::{AssignOp, Chain, Root, Step, Tail};
 use crate::grain::format::abi::Abi;
@@ -467,6 +468,24 @@ fn put_constant(out: &mut Vec<u8>, value: &Dynamic) -> Result<(), String> {
     if let Some(range) = value.read_lock::<RangeInclusive<INT>>() {
         out.push(constant::RANGE_INCLUSIVE);
         put_range(out, *range.start(), *range.end());
+        return Ok(());
+    }
+    if let Some(fn_ptr) = value.read_lock::<FnPtr>() {
+        out.push(constant::FN_PTR);
+        put_str(out, fn_ptr.fn_name());
+        put_uvarint(out, fn_ptr.curry().len() as u64);
+        for item in fn_ptr.iter_curry() {
+            put_constant(out, item)?;
+        }
+        match fn_ptr.typ {
+            FnPtrType::Normal => out.push(constant::FN_PTR_TYPE_NORMAL),
+            FnPtrType::Native(..) => return Err("embedded native function pointer".to_string()),
+            #[cfg(not(feature = "no_function"))]
+            FnPtrType::Script { num_params, .. } => {
+                out.push(constant::FN_PTR_TYPE_SCRIPT);
+                put_uvarint(out, num_params as u64);
+            }
+        }
         return Ok(());
     }
 

--- a/src/grain/program.rs
+++ b/src/grain/program.rs
@@ -445,11 +445,10 @@ impl<'a> Program<'a> {
             .find(|f| matching(f) && f.this_type.is_none())
     }
 
-    /// The compiled function a *pointer* resolves to.
+    /// The compiled function with a particular name and arity.
     ///
-    /// By name rather than by pool index, because a `FnPtr` carries a string —
-    /// it may have been built from one at run time. A linear scan, which at
-    /// these sizes beats a map and keeps the common indexed lookup untouched.
+    /// A linear scan, which at these sizes beats a map and
+    /// keeps the common indexed lookup untouched.
     pub(crate) fn function_named(&self, name: &str, argc: usize) -> Option<&Function> {
         self.functions.iter().find(|f| {
             f.params.len() == argc && f.this_type.is_none() && self.name(f.name) == Some(name)

--- a/src/grain/vm/callback.rs
+++ b/src/grain/vm/callback.rs
@@ -9,21 +9,6 @@
 //! So a program that hands a pointer out registers one native wrapper per
 //! compiled function for the length of the run. Direct dispatch is untouched —
 //! this is somewhere for Rhai to look, not somewhere we look.
-//!
-//! # What being a native costs
-//!
-//! Rhai reaches its own closures through a `Fn*` pointer carrying the body, and
-//! that shortcut is what these wrappers cannot have. One consequence:
-//!
-//! * **Speed, and call budget.** Rhai resolves a wrapper by name and type on
-//!   every element, from a cache it builds fresh per crossing, where its own
-//!   pointer skips resolution entirely. `native callbacks` in
-//!   `examples/bench.rs` measures 0.34x — the one case the VM loses — and the
-//!   two extra dispatch layers cost 5 call levels per crossing against the
-//!   walker's 2.
-//!
-//! Neither touches a pointer called directly from compiled code, which is
-//! `Op::CallFnPtr` and never comes through here.
 
 #[cfg(feature = "no_std")]
 use std::prelude::v1::*;
@@ -36,17 +21,6 @@ use crate::{
     types::Span,
     FnAccess, Module,
 };
-
-/// The most parameters a wrapper is registered for.
-///
-/// A wrapper takes `Dynamic` throughout, and Rhai only reaches a `Dynamic`
-/// parameter by permuting the call's own argument types towards it — a search
-/// it caps at `MAX_DYNAMIC_PARAMETERS`, 16 (`func/call.rs:235`). A wider
-/// wrapper would be registered and never found, so it is left out rather than
-/// silently dead. Direct dispatch has no such bound; this limits only what a
-/// native can call back into.
-#[cfg(not(feature = "no_function"))]
-const MAX_PARAMS: usize = 16;
 
 /// A wrapper per compiled function, for Rhai to resolve a pointer against.
 ///
@@ -64,10 +38,6 @@ pub(super) fn wrappers(vm: &mut Vm, program: &SharedProgram) -> Module {
     }
 
     for function in program.functions() {
-        let arity = function.params.len();
-        if arity > MAX_PARAMS {
-            continue;
-        }
         let Some(name) = program.name(function.name) else {
             continue;
         };

--- a/src/grain/vm/mod.rs
+++ b/src/grain/vm/mod.rs
@@ -507,9 +507,9 @@ impl<'e> Vm<'e> {
     /// The empty `Caches` is the cost, and it is the one thing a `Vm` normally
     /// exists to avoid. It cannot be helped: the outer `Vm` is borrowed by the
     /// frame still running beneath this one. Rhai pays the same on its own
-    /// callbacks — but it also skips resolution entirely for a pointer that
-    /// carries its body, which is why a crossing measures 0.34x. See the
-    /// `callback` module.
+    /// callbacks — but, similar to `Vm`, it also skips resolution entirely
+    /// for a pointer that is known to be a scripted function and carries its
+    /// own hash.
     ///
     /// Operation counting has the same shape and the same reason: increments
     /// inside the callback land on the clone and are lost when it drops, as
@@ -897,10 +897,6 @@ impl<'e> Vm<'e> {
     /// otherwise identical and copies nothing. A program that needs this and
     /// does not get it still runs — the pointer simply fails to resolve, as
     /// `ErrorFunctionNotFound`, at the point the native tries to call it.
-    ///
-    /// Read the `callback` module before relying on it: a crossing is slower than the
-    /// walker, and a *capturing* closure handed to a native that binds `this`
-    /// arrives with its arguments rotated.
     ///
     /// Named `eval_` rather than `run_` because it yields the program's value;
     /// Rhai has no `Engine` method to mirror here, so the crate's own rule is

--- a/tests/grain/corpus/mod.rs
+++ b/tests/grain/corpus/mod.rs
@@ -535,10 +535,7 @@ pub const CASES: &[Case] = &[
     // Neither of these can be handed out by reference, so both are passed by
     // value and the mutation is discarded (`func/call.rs:1449-1454`).
     case("call_style_constant_receiver", "const a = [1]; push(a, 2); a"),
-    // The closure is made in a block so the scope the two sides are compared on
-    // does not end up holding a pointer, which they render differently on
-    // purpose — see `a_closure_pointer_is_late_bound` in `tests/scope.rs`.
-    case("call_style_shared_receiver", "let a = [1]; { let f = || a.len(); } push(a, 2); a"),
+    case("call_style_shared_receiver", "let a = [1]; let f = || a.len(); push(a, 2); a"),
     // A script function copies its first argument whichever way it arrives, so
     // the rewrite is invisible here — which is the thing to pin.
     case("call_style_script_fn", "fn bump_it(x) { x += 1; x } let n = 3; bump_it(n); n"),
@@ -556,12 +553,6 @@ pub const CASES: &[Case] = &[
     // --- closures ---------------------------------------------------------
     // Function pointers are invoked via `.call()`; `f(5)` would look for a
     // function literally named `f`.
-    // The closure is kept inside a block in all of these. Not incidental: the
-    // pointer we build is late-bound where Rhai's is early-bound, so Rhai
-    // renders it `Fn*+("anon$..")` and we render it `Fn("anon$..")`. That
-    // difference is the price of not shipping an AST body, it is script-
-    // visible, and `a_closure_pointer_is_late_bound` is where it is pinned —
-    // so these cases test the capture rather than re-testing the rendering.
     case("closure_capture_read", "let n = 10; let r = 0; { let f = |x| x + n; r = f.call(5); } r"),
     // Capture is by shared cell, so the mutation must be visible outside.
     case("closure_capture_mutate", "let n = 0; { let f = || n += 1; f.call(); f.call(); } n"),
@@ -833,11 +824,6 @@ pub const CASES: &[Case] = &[
     // `obj.call(f)` binds `obj` as the closure's `this` by reference, so a
     // write inside the closure reaches `obj`. The operand stack only ever holds
     // a copy of it, which is why the instruction carries where it came from.
-    //
-    // The pointer is scoped to a block throughout, as the other closure cases
-    // are: a compiled closure's `FnPtr` carries a name where Rhai's carries the
-    // body and its environment, so one left in the scope compares unequal for a
-    // reason that has nothing to do with the call.
     case("closure_call_on_a_local_writes_back", "let v = 21; { let f = || { this *= 2; }; v.call(f); } v"),
     case("closure_call_on_a_local_inline", "let v = 21; v.call(|| { this *= 2; }); v"),
     case("closure_call_on_a_local_reads", "let v = 21; let r = 0; { let f = || this * 2; r = v.call(f); } r"),

--- a/tests/grain/fixtures/golden.rhai
+++ b/tests/grain/fixtures/golden.rhai
@@ -44,10 +44,7 @@ supplied.push(counts.len());
 push(counts, ratio.to_int());
 push(supplied, STRIDE);
 
-// A closure, which shares what it captures and curries it onto a pointer. Made
-// and spent inside a block, so the scope this is compared on does not end up
-// holding a pointer — the two sides render one differently on purpose, which
-// `a_closure_pointer_is_late_bound` in `tests/scope.rs` pins.
+// A closure, which shares what it captures and curries it onto a pointer.
 let captured = 0;
 {
     let capture = || supplied.len() + counts.len();

--- a/tests/grain/scope.rs
+++ b/tests/grain/scope.rs
@@ -611,19 +611,9 @@ fn a_resolved_receiver_is_not_the_scope_entry_it_shadows() {
     assert_eq!(format!("{:?}", run.get_value::<Dynamic>("shadowed").unwrap()), "[1]", "the entry the resolver shadowed must come back untouched",);
 }
 
-/// The one place a compiled closure is not the walker's closure.
-///
-/// Rhai's parser builds a pointer that embeds the closure's `ScriptFuncDef` —
-/// the AST body — and tags it with the environment it was written in. That is
-/// exactly what an artifact must not carry, so the compiler emits a
-/// name-only pointer to the chunk it compiled from that same body.
-///
-/// Everything the closure *does* is identical; what differs is that ours is
-/// late-bound, which Rhai renders. Pinned here rather than left to be
-/// discovered, because it is visible to a script that prints one.
 #[test]
 #[cfg(not(feature = "no_function"))]
-fn a_closure_pointer_is_late_bound() {
+fn a_closure_pointer_is_the_same_from_the_vm() {
     let engine = corpus::engine();
     let source = "let n = 1; let f = |x| x + n; f";
 
@@ -635,12 +625,7 @@ fn a_closure_pointer_is_late_bound() {
     let walker = engine.eval_ast_with_scope::<Dynamic>(&mut Scope::new(), &ast).expect("must run under Rhai too");
 
     let (ours, walker) = (format!("{ours:?}"), format!("{walker:?}"));
-    assert!(ours.starts_with("Fn(\"anon$"), "ours is a plain named pointer: {ours}",);
-    assert!(walker.starts_with("Fn*(\"anon$"), "rhai's carries a script body and an environment: {walker}",);
-
-    // And the difference is only in the binding: calling either gives the
-    // same answer, which is what the corpus covers.
-    assert_ne!(ours, walker, "if these ever match, delete this test");
+    assert_eq!(ours, walker);
 }
 
 /// Calling a compiled function from outside, which is what a native wrapper


### PR DESCRIPTION
This is it.

### Simplified Rhai `FnPtr` data structure

Due to [this commit](https://github.com/rhaiscript/rhai/commit/648c684861ad143067b67c4e444b389ddb9f1015), Rhai's `FnPtr` type no longer contains any _embedded environment_, nor does it contain any pointers to internal data structures.

In hindsight, it was a poor design decision anyway. I was too eager to make something work.

In other words, the `FnPtr` type is now completely serializable and can be considered a normal type with native support by the VM.

### What this PR does

Add support for loading `FnPtr` directly from a `Expr::DynamicConstant`.

Previous this was farmed out into the `MakeClosure` op.  The reader/writer now considers it a known type serialized/deserialized natively.

### Impacts

1) The `MakeClosure` op is no longer used (but kept for now).

2) There is no longer _any_ distinction between a `FnPtr` created by the walker and a `FnPtr` created by the VM.

3) There is no more speed penalty in closure callbacks into the VM.  Benchmarks now show callbacks to be at least at par with the walker.

4) Large sections of code in Rhai (and some in the VM) became unnecessary and removed, simplifying the codebase significantly.

5) All the special tests for differences between `FnPtr` now return them as identical. All tests related to `FnPtr` that used to fail now pass and patched accordingly. Docs related to this difference are also patched.

